### PR TITLE
fix: add continue-on-error for npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
   publish-npm:
     needs: release
     runs-on: ubuntu-latest
+    # Only run on tag push, skip on workflow_dispatch
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
@@ -90,3 +91,4 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to npm publish step so releases succeed even without NPM_TOKEN configured
- Add clarifying comment about the condition for npm publish job

This allows GitHub releases to complete successfully while npm publishing remains optional until NPM_TOKEN secret is configured.