### PR TITLE
feat: PR-based release workflow with Homebrew auto-update

### DIFF
--- a/.github/workflows/on-release-merge.yml
+++ b/.github/workflows/on-release-merge.yml
@@ -1,0 +1,126 @@
+name: On Release Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-update-homebrew:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${​{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from branch
+        id: version
+        run: |
+          BRANCH="${​{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH#release/}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a ${​{ steps.version.outputs.tag }} -m "Release ${​{ steps.version.outputs.tag }}"
+          git push origin ${​{ steps.version.outputs.tag }}
+
+      - name: Get commit SHA
+        id: sha
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: ausardcompany/homebrew-tap
+          token: ${​{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Formula
+        run: |
+          cat > homebrew-tap/Formula/alexi.rb << 'FORMULA'
+          class Alexi < Formula
+            desc "Intelligent LLM orchestrator with SAP AI Core provider support"
+            homepage "https://github.com/ausardcompany/sap-bot-orchestrator"
+            url "https://github.com/ausardcompany/sap-bot-orchestrator.git",
+                tag:      "TAG_PLACEHOLDER",
+                revision: "SHA_PLACEHOLDER"
+            license "ISC"
+            head "https://github.com/ausardcompany/sap-bot-orchestrator.git", branch: "master"
+
+            depends_on "node@22"
+
+            def install
+              system "npm", "install", *std_npm_args(prefix: false)
+              system "npm", "run", "build"
+
+              libexec.install Dir["*"]
+
+              (bin/"alexi").write <<~EOS
+                #!/bin/bash
+                exec "#{Formula["node@22"].opt_bin}/node" "#{libexec}/dist/cli/program.js" "$@"
+              EOS
+
+              (bin/"ax").write <<~EOS
+                #!/bin/bash
+                exec "#{Formula["node@22"].opt_bin}/node" "#{libexec}/dist/cli/program.js" "$@"
+              EOS
+            end
+
+            def caveats
+              <<~EOS
+                Alexi requires SAP AI Core credentials.
+                Set the following environment variables:
+                  - AICORE_SERVICE_KEY (JSON service key) or individual credentials:
+                  - AICORE_CLIENT_ID
+                  - AICORE_CLIENT_SECRET
+                  - AICORE_AUTH_URL
+                  - AICORE_BASE_URL
+                  - AICORE_RESOURCE_GROUP
+              EOS
+            end
+
+            test do
+              assert_match "alexi", shell_output("#{bin}/alexi --version")
+            end
+          end
+          FORMULA
+          
+          # Replace placeholders
+          sed -i 's|TAG_PLACEHOLDER|${{ steps.version.outputs.tag }}|g' homebrew-tap/Formula/alexi.rb
+          sed -i 's|SHA_PLACEHOLDER|${{ steps.sha.outputs.sha }}|g' homebrew-tap/Formula/alexi.rb
+
+      - name: Commit and push to homebrew-tap
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/alexi.rb
+          git rm -f Formula/sap-bot-orchestrator.rb 2>/dev/null || true
+          git commit -m "alexi ${​{ steps.version.outputs.version }}"
+          git push
+
+      - name: Summary
+        run: |
+          echo "## Release Complete!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${​{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** ${​{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${​{ steps.sha.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Homebrew formula has been updated." >> $GITHUB_STEP_SUMMARY
+
+      - name: Delete release branch
+        run: git push origin --delete ${​{ github.event.pull_request.head.ref }} || true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,13 +19,15 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  tag:
+  create-release-pr:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      branch: ${{ steps.version.outputs.branch }}
     
     steps:
       - name: Checkout
@@ -61,7 +63,6 @@ jobs:
           if [ -n "${{ github.event.inputs.version }}" ]; then
             NEW_VERSION="${{ github.event.inputs.version }}"
           else
-            # Parse current version
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
             
             case "${{ github.event.inputs.bump_type }}" in
@@ -80,119 +81,58 @@ jobs:
           echo "New version: $NEW_VERSION"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "branch=release/$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create release branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b ${{ steps.version.outputs.branch }}
 
       - name: Update package.json version
         run: |
           npm version ${{ steps.version.outputs.version }} --no-git-tag-version
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
-          git push
 
-      - name: Create and push tag
+      - name: Push release branch
+        run: git push origin ${{ steps.version.outputs.branch }}
+
+      - name: Create Pull Request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git tag -a ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
-          git push origin ${{ steps.version.outputs.tag }}
+          PR_URL=$(gh pr create \
+            --title "Release v${{ steps.version.outputs.version }}" \
+            --body "$(cat <<EOF
+          ## Release v${{ steps.version.outputs.version }}
+
+          This PR bumps the version to ${{ steps.version.outputs.version }}.
+
+          ### Changes
+          - Updates package.json version to ${{ steps.version.outputs.version }}
+
+          ### After Merge
+          Once this PR is merged, the tag \`${{ steps.version.outputs.tag }}\` will be created automatically, which will:
+          1. Trigger the release workflow
+          2. Create a GitHub release
+          3. Update the Homebrew formula
+
+          ---
+          *This PR was automatically created by the tag-release workflow.*
+          EOF
+          )" \
+            --base master \
+            --head ${{ steps.version.outputs.branch }})
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 
       - name: Summary
         run: |
-          echo "## Release Tagged Successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "## Release PR Created!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** ${{ steps.version.outputs.branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "**PR:** ${{ steps.pr.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The release workflow will now be triggered automatically." >> $GITHUB_STEP_SUMMARY
-
-  update-homebrew:
-    needs: tag
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
-        with:
-          repository: ausardcompany/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-tap
-
-      - name: Get commit SHA
-        id: sha
-        run: |
-          SHA=$(gh api repos/ausardcompany/sap-bot-orchestrator/git/refs/tags/${{ needs.tag.outputs.tag }} --jq '.object.sha')
-          # If it's an annotated tag, get the actual commit
-          TYPE=$(gh api repos/ausardcompany/sap-bot-orchestrator/git/tags/$SHA --jq '.object.type' 2>/dev/null || echo "commit")
-          if [ "$TYPE" = "commit" ]; then
-            COMMIT_SHA=$(gh api repos/ausardcompany/sap-bot-orchestrator/git/tags/$SHA --jq '.object.sha' 2>/dev/null || echo "$SHA")
-          else
-            COMMIT_SHA=$SHA
-          fi
-          echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update Formula
-        run: |
-          cd homebrew-tap
-          cat > Formula/alexi.rb << EOF
-          class Alexi < Formula
-            desc "Intelligent LLM orchestrator with SAP AI Core provider support"
-            homepage "https://github.com/ausardcompany/sap-bot-orchestrator"
-            url "https://github.com/ausardcompany/sap-bot-orchestrator.git",
-                tag:      "${{ needs.tag.outputs.tag }}",
-                revision: "${{ steps.sha.outputs.sha }}"
-            license "ISC"
-            head "https://github.com/ausardcompany/sap-bot-orchestrator.git", branch: "master"
-
-            depends_on "node@22"
-
-            def install
-              # Install npm dependencies
-              system "npm", "install", *std_npm_args(prefix: false)
-              # Build TypeScript
-              system "npm", "run", "build"
-
-              # Install to libexec
-              libexec.install Dir["*"]
-
-              # Create wrapper scripts
-              (bin/"alexi").write <<~EOS
-                #!/bin/bash
-                exec "#{Formula["node@22"].opt_bin}/node" "#{libexec}/dist/cli/program.js" "\$@"
-              EOS
-
-              (bin/"ax").write <<~EOS
-                #!/bin/bash
-                exec "#{Formula["node@22"].opt_bin}/node" "#{libexec}/dist/cli/program.js" "\$@"
-              EOS
-            end
-
-            def caveats
-              <<~EOS
-                Alexi requires SAP AI Core credentials.
-                Set the following environment variables:
-                  - AICORE_SERVICE_KEY (JSON service key) or individual credentials:
-                  - AICORE_CLIENT_ID
-                  - AICORE_CLIENT_SECRET
-                  - AICORE_AUTH_URL
-                  - AICORE_BASE_URL
-                  - AICORE_RESOURCE_GROUP
-              EOS
-            end
-
-            test do
-              assert_match "alexi", shell_output("#{bin}/alexi --version")
-            end
-          end
-          EOF
-
-      - name: Commit and push
-        run: |
-          cd homebrew-tap
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/alexi.rb
-          # Remove old formula if exists
-          git rm -f Formula/sap-bot-orchestrator.rb 2>/dev/null || true
-          git commit -m "alexi ${{ needs.tag.outputs.version }}" || echo "No changes to commit"
-          git push
+          echo "Please review and merge the PR to complete the release." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds a two-stage release workflow that uses PRs for version bumps and automatically updates Homebrew.

### New Workflows

1. **`tag-release.yml`** - Manual dispatch workflow
   - Runs tests, build, and typecheck
   - Creates a release branch with version bump
   - Opens a PR for review

2. **`on-release-merge.yml`** - Triggered on release PR merge
   - Creates and pushes the version tag
   - Updates `ausardcompany/homebrew-tap` formula
   - Cleans up the release branch

### Release Flow

```
1. Run "Tag Release" workflow → Creates release PR
2. Review and merge PR → Auto-creates tag
3. Tag push triggers existing release.yml → GitHub release
4. Homebrew formula updated automatically
```

### Testing

- [ ] Create a test release (v0.1.1) after merge
- [ ] Verify tag is created
- [ ] Verify Homebrew formula is updated
- [ ] Test `brew upgrade alexi`