### PR TITLE
feat: add batch tool for parallel tool execution

### DIFF
--- a/src/tool/tools/__tests__/batch.test.ts
+++ b/src/tool/tools/__tests__/batch.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { batchTool, MAX_BATCH_SIZE } from '../batch.js';
+import { registerTool, type Tool, type ToolContext } from '../../index.js';
+import { z } from 'zod';
+
+// Mock tools for testing
+const mockReadTool = {
+  name: 'read',
+  description: 'Mock read tool',
+  parameters: z.object({
+    filePath: z.string(),
+  }),
+  toFunctionSchema: () => ({
+    name: 'read',
+    description: 'Mock read tool',
+    parameters: { type: 'object', properties: { filePath: { type: 'string' } } },
+  }),
+  execute: vi.fn(async (params: { filePath: string }) => ({
+    success: true,
+    data: { content: `Content of ${params.filePath}` },
+  })),
+  executeUnsafe: vi.fn(async (params: { filePath: string }) => ({
+    success: true,
+    data: { content: `Content of ${params.filePath}` },
+  })),
+} as unknown as Tool<z.ZodTypeAny, unknown>;
+
+const mockGlobTool = {
+  name: 'glob',
+  description: 'Mock glob tool',
+  parameters: z.object({
+    pattern: z.string(),
+  }),
+  toFunctionSchema: () => ({
+    name: 'glob',
+    description: 'Mock glob tool',
+    parameters: { type: 'object', properties: { pattern: { type: 'string' } } },
+  }),
+  execute: vi.fn(async (_params: { pattern: string }) => ({
+    success: true,
+    data: { files: [`file1.ts`, `file2.ts`] },
+  })),
+  executeUnsafe: vi.fn(async (_params: { pattern: string }) => ({
+    success: true,
+    data: { files: [`file1.ts`, `file2.ts`] },
+  })),
+} as unknown as Tool<z.ZodTypeAny, unknown>;
+
+const mockFailingTool = {
+  name: 'failing',
+  description: 'Mock failing tool',
+  parameters: z.object({
+    shouldFail: z.boolean(),
+  }),
+  toFunctionSchema: () => ({
+    name: 'failing',
+    description: 'Mock failing tool',
+    parameters: { type: 'object', properties: { shouldFail: { type: 'boolean' } } },
+  }),
+  execute: vi.fn(async (params: { shouldFail: boolean }) => {
+    if (params.shouldFail) {
+      return { success: false, error: 'Intentional failure' };
+    }
+    return { success: true, data: { message: 'Success' } };
+  }),
+  executeUnsafe: vi.fn(async (params: { shouldFail: boolean }) => {
+    if (params.shouldFail) {
+      return { success: false, error: 'Intentional failure' };
+    }
+    return { success: true, data: { message: 'Success' } };
+  }),
+} as unknown as Tool<z.ZodTypeAny, unknown>;
+
+const mockSlowTool = {
+  name: 'slow',
+  description: 'Mock slow tool',
+  parameters: z.object({
+    delay: z.number(),
+  }),
+  toFunctionSchema: () => ({
+    name: 'slow',
+    description: 'Mock slow tool',
+    parameters: { type: 'object', properties: { delay: { type: 'number' } } },
+  }),
+  execute: vi.fn(async (params: { delay: number }) => {
+    await new Promise((resolve) => setTimeout(resolve, params.delay));
+    return { success: true, data: { elapsed: params.delay } };
+  }),
+  executeUnsafe: vi.fn(async (params: { delay: number }) => {
+    await new Promise((resolve) => setTimeout(resolve, params.delay));
+    return { success: true, data: { elapsed: params.delay } };
+  }),
+} as unknown as Tool<z.ZodTypeAny, unknown>;
+
+describe('batch tool', () => {
+  const context: ToolContext = {
+    workdir: '/tmp',
+  };
+
+  beforeEach(() => {
+    // Clear the registry and re-register mock tools
+    vi.clearAllMocks();
+
+    // Register mock tools
+    registerTool(mockReadTool);
+    registerTool(mockGlobTool);
+    registerTool(mockFailingTool);
+    registerTool(mockSlowTool);
+    registerTool(batchTool as Tool<z.ZodTypeAny, unknown>);
+  });
+
+  describe('basic functionality', () => {
+    it('should execute a single tool invocation', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [{ tool: 'read', params: { filePath: '/test/file.ts' } }],
+        },
+        context
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data?.totalInvocations).toBe(1);
+      expect(result.data?.successful).toBe(1);
+      expect(result.data?.failed).toBe(0);
+      expect(result.data?.results).toHaveLength(1);
+      expect(result.data?.results[0].tool).toBe('read');
+      expect(result.data?.results[0].success).toBe(true);
+    });
+
+    it('should execute multiple tool invocations in parallel', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [
+            { tool: 'read', params: { filePath: '/test/file1.ts' } },
+            { tool: 'read', params: { filePath: '/test/file2.ts' } },
+            { tool: 'glob', params: { pattern: '**/*.ts' } },
+          ],
+        },
+        context
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data?.totalInvocations).toBe(3);
+      expect(result.data?.successful).toBe(3);
+      expect(result.data?.failed).toBe(0);
+      expect(result.data?.results).toHaveLength(3);
+    });
+
+    it('should preserve order of results', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [
+            { tool: 'read', params: { filePath: '/first.ts' } },
+            { tool: 'glob', params: { pattern: '*.ts' } },
+            { tool: 'read', params: { filePath: '/third.ts' } },
+          ],
+        },
+        context
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data?.results[0].index).toBe(0);
+      expect(result.data?.results[0].tool).toBe('read');
+      expect(result.data?.results[1].index).toBe(1);
+      expect(result.data?.results[1].tool).toBe('glob');
+      expect(result.data?.results[2].index).toBe(2);
+      expect(result.data?.results[2].tool).toBe('read');
+    });
+  });
+
+  describe('parallel execution', () => {
+    it('should execute tools in parallel (timing verification)', async () => {
+      const startTime = Date.now();
+
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [
+            { tool: 'slow', params: { delay: 50 } },
+            { tool: 'slow', params: { delay: 50 } },
+            { tool: 'slow', params: { delay: 50 } },
+          ],
+        },
+        context
+      );
+
+      const elapsed = Date.now() - startTime;
+
+      expect(result.success).toBe(true);
+      // If truly parallel, should take ~50ms, not ~150ms
+      // Allow some buffer for execution overhead
+      expect(elapsed).toBeLessThan(120);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle tool not found error', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [{ tool: 'nonexistent', params: {} }],
+        },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.data?.failed).toBe(1);
+      expect(result.data?.results[0].success).toBe(false);
+      expect(result.data?.results[0].error).toContain('Tool not found');
+    });
+
+    it('should handle mixed success and failure', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [
+            { tool: 'read', params: { filePath: '/test.ts' } },
+            { tool: 'failing', params: { shouldFail: true } },
+            { tool: 'glob', params: { pattern: '*.ts' } },
+          ],
+        },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.data?.totalInvocations).toBe(3);
+      expect(result.data?.successful).toBe(2);
+      expect(result.data?.failed).toBe(1);
+      expect(result.hint).toContain('1 of 3 invocations failed');
+    });
+
+    it('should prevent recursive batch calls', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [
+            { tool: 'read', params: { filePath: '/test.ts' } },
+            {
+              tool: 'batch',
+              params: { invocations: [{ tool: 'read', params: { filePath: '/inner.ts' } }] },
+            },
+          ],
+        },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.data?.results[1].success).toBe(false);
+      expect(result.data?.results[1].error).toContain('Recursive batch calls are not allowed');
+    });
+
+    it('should continue other invocations when one fails', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [
+            { tool: 'failing', params: { shouldFail: true } },
+            { tool: 'read', params: { filePath: '/test.ts' } },
+            { tool: 'failing', params: { shouldFail: false } },
+          ],
+        },
+        context
+      );
+
+      expect(result.data?.results[0].success).toBe(false);
+      expect(result.data?.results[1].success).toBe(true);
+      expect(result.data?.results[2].success).toBe(true);
+    });
+  });
+
+  describe('abort signal handling', () => {
+    it('should return error when signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [{ tool: 'read', params: { filePath: '/test.ts' } }],
+        },
+        { ...context, signal: controller.signal }
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('aborted');
+    });
+  });
+
+  describe('batch size limits', () => {
+    it('should export MAX_BATCH_SIZE constant', () => {
+      expect(MAX_BATCH_SIZE).toBe(25);
+    });
+
+    it('should reject empty invocations array', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [],
+        },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid parameters');
+    });
+
+    it('should reject invocations exceeding MAX_BATCH_SIZE', async () => {
+      const invocations = Array(26).fill({ tool: 'read', params: { filePath: '/test.ts' } });
+
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations,
+        },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid parameters');
+    });
+
+    it('should accept exactly MAX_BATCH_SIZE invocations', async () => {
+      const invocations = Array(25).fill({ tool: 'read', params: { filePath: '/test.ts' } });
+
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations,
+        },
+        context
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data?.totalInvocations).toBe(25);
+    });
+  });
+
+  describe('tool schema', () => {
+    it('should have correct name and description', () => {
+      expect(batchTool.name).toBe('batch');
+      expect(batchTool.description).toContain('parallel');
+      expect(batchTool.description).toContain('25');
+    });
+
+    it('should generate valid function schema', () => {
+      const schema = batchTool.toFunctionSchema();
+
+      expect(schema.name).toBe('batch');
+      expect(schema.parameters).toHaveProperty('properties');
+      expect((schema.parameters as Record<string, unknown>).properties).toHaveProperty(
+        'invocations'
+      );
+    });
+  });
+
+  describe('result structure', () => {
+    it('should include result data from each tool', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [{ tool: 'read', params: { filePath: '/test.ts' } }],
+        },
+        context
+      );
+
+      expect(result.data?.results[0].result).toBeDefined();
+      expect(result.data?.results[0].result?.data).toBeDefined();
+    });
+
+    it('should not include result for failed tools with error', async () => {
+      const result = await batchTool.executeUnsafe(
+        {
+          invocations: [{ tool: 'nonexistent', params: {} }],
+        },
+        context
+      );
+
+      expect(result.data?.results[0].result).toBeUndefined();
+      expect(result.data?.results[0].error).toBeDefined();
+    });
+  });
+});

--- a/src/tool/tools/batch.ts
+++ b/src/tool/tools/batch.ts
@@ -1,0 +1,161 @@
+/**
+ * Batch Tool - Execute multiple tool calls in parallel
+ *
+ * Allows executing up to 25 tool calls in parallel, improving efficiency
+ * when multiple independent operations are needed.
+ */
+
+import { z } from 'zod';
+import { defineTool, getTool, type ToolResult, type ToolContext } from '../index.js';
+
+const MAX_BATCH_SIZE = 25;
+
+const ToolInvocationSchema = z.object({
+  tool: z.string().describe('The name of the tool to invoke'),
+  params: z.record(z.string(), z.unknown()).describe('Parameters to pass to the tool'),
+});
+
+const BatchParamsSchema = z.object({
+  invocations: z
+    .array(ToolInvocationSchema)
+    .min(1)
+    .max(MAX_BATCH_SIZE)
+    .describe(`Array of tool invocations to execute in parallel (max ${MAX_BATCH_SIZE})`),
+});
+
+interface InvocationResult {
+  tool: string;
+  index: number;
+  success: boolean;
+  result?: ToolResult<unknown>;
+  error?: string;
+}
+
+interface BatchResult {
+  totalInvocations: number;
+  successful: number;
+  failed: number;
+  results: InvocationResult[];
+}
+
+/**
+ * Execute a single tool invocation
+ */
+async function executeInvocation(
+  invocation: z.infer<typeof ToolInvocationSchema>,
+  index: number,
+  context: ToolContext
+): Promise<InvocationResult> {
+  const { tool: toolName, params } = invocation;
+
+  // Get the tool from registry
+  const tool = getTool(toolName);
+  if (!tool) {
+    return {
+      tool: toolName,
+      index,
+      success: false,
+      error: `Tool not found: ${toolName}`,
+    };
+  }
+
+  // Don't allow recursive batch calls
+  if (toolName === 'batch') {
+    return {
+      tool: toolName,
+      index,
+      success: false,
+      error: 'Recursive batch calls are not allowed',
+    };
+  }
+
+  try {
+    // Execute the tool
+    const result = await tool.execute(params, context);
+
+    return {
+      tool: toolName,
+      index,
+      success: result.success,
+      result,
+    };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    return {
+      tool: toolName,
+      index,
+      success: false,
+      error: errorMessage,
+    };
+  }
+}
+
+export const batchTool = defineTool<typeof BatchParamsSchema, BatchResult>({
+  name: 'batch',
+  description: `Execute multiple tool calls in parallel for improved efficiency.
+
+Usage:
+- Use when you need to perform multiple independent operations simultaneously.
+- Maximum ${MAX_BATCH_SIZE} tool invocations per batch.
+- Each invocation specifies a tool name and its parameters.
+- All invocations run in parallel; results are collected and returned together.
+- Recursive batch calls (batch within batch) are not allowed.
+- Results preserve the original order of invocations.
+
+Example invocations:
+[
+  { "tool": "read", "params": { "filePath": "/path/to/file1.ts" } },
+  { "tool": "read", "params": { "filePath": "/path/to/file2.ts" } },
+  { "tool": "glob", "params": { "pattern": "**/*.test.ts" } }
+]
+
+Best practices:
+- Use for independent operations that don't depend on each other's results.
+- Group related reads, searches, or file operations together.
+- Consider using for parallel file exploration or bulk operations.`,
+
+  parameters: BatchParamsSchema,
+
+  // No permission needed for batch itself - individual tools handle their own permissions
+  permission: undefined,
+
+  async execute(params, context): Promise<ToolResult<BatchResult>> {
+    const { invocations } = params;
+
+    // Check for abort before starting
+    if (context.signal?.aborted) {
+      return {
+        success: false,
+        error: 'Operation aborted',
+      };
+    }
+
+    // Execute all invocations in parallel
+    const promises = invocations.map((invocation, index) =>
+      executeInvocation(invocation, index, context)
+    );
+
+    const results = await Promise.all(promises);
+
+    // Count successes and failures
+    const successful = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success).length;
+
+    return {
+      success: failed === 0,
+      data: {
+        totalInvocations: invocations.length,
+        successful,
+        failed,
+        results,
+      },
+      hint:
+        failed > 0
+          ? `${failed} of ${invocations.length} invocations failed. Check individual results for details.`
+          : undefined,
+    };
+  },
+});
+
+// Export constants for testing
+export { MAX_BATCH_SIZE };

--- a/src/tool/tools/index.ts
+++ b/src/tool/tools/index.ts
@@ -25,6 +25,7 @@ import { notebookReadTool, notebookEditTool } from './notebook.js';
 import { browserTool } from './browser.js';
 import { diagnosticsTool } from './diagnostics.js';
 import { codesearchTool } from './codesearch.js';
+import { batchTool } from './batch.js';
 
 // All built-in tools
 export const builtInTools = [
@@ -49,6 +50,7 @@ export const builtInTools = [
   browserTool,
   diagnosticsTool,
   codesearchTool,
+  batchTool,
 ] as const;
 
 /**
@@ -84,6 +86,7 @@ export {
   browserTool,
   diagnosticsTool,
   codesearchTool,
+  batchTool,
 };
 
 // Re-export UI utilities from specific tools


### PR DESCRIPTION
## Summary

- Implement batch tool that executes up to 25 tool calls in parallel
- This is the final high-priority feature from kilocode analysis

## Changes

- Added `src/tool/tools/batch.ts` - New batch tool implementation
- Added `src/tool/tools/__tests__/batch.test.ts` - 17 comprehensive tests
- Updated `src/tool/tools/index.ts` - Register batch tool

## Features

- Execute multiple independent tool operations simultaneously
- Preserve result order matching invocation order  
- Prevent recursive batch calls for safety
- Individual tool permission handling
- Proper abort signal support

## Testing

All 688 tests passing (671 existing + 17 new batch tests).

## Kilocode Feature Status

With this PR, all high-priority kilocode features are now complete:

| Feature | Status |
|---------|--------|
| Event Bus | ✅ Already implemented |
| Plan Mode | ✅ Already implemented |
| Undo/Snapshot System | ✅ Already implemented |
| Multi-Edit Tool | ✅ Already implemented |
| **Batch Tool** | ✅ **This PR** |