### PR TITLE
ci: switch homebrew update to daily schedule instead of per-PR

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,19 +1,16 @@
 name: Update Homebrew Formula
 
 on:
-  pull_request_target:
-    types: [closed]
-    branches: [master]
+  schedule:
+    # Run once a day at 02:00 UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   update-homebrew:
-    # Run on every merged PR except release/* (those are handled by on-release-merge.yml)
-    if: |
-      github.event.pull_request.merged == true &&
-      !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- Changes `update-homebrew.yml` trigger from `pull_request_target: closed` to a daily `schedule` cron (`0 2 * * *`, 02:00 UTC)
- Adds `workflow_dispatch` for manual runs
- Removes the per-PR `if:` condition — the job now always runs on schedule against current `master` HEAD
- The idempotency guard (`git diff --quiet`) ensures no commit is made if the formula is already up to date