### PR TITLE
feat: add git auto-commits with attribution and repository map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "nanoid": "^5.1.6",
         "react": "^19.2.4",
         "simple-git": "^3.32.3",
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-javascript": "^0.21.4",
+        "tree-sitter-typescript": "^0.23.2",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -5669,6 +5672,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
+      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-cache": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
@@ -5688,6 +5700,17 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -7097,6 +7120,75 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.21.4.tgz",
+      "integrity": "sha512-Lrk8yahebwrwc1sWJE9xPcz1OnnqiEV7Dh5fbN6EN3wNAdu9r06HpTqLqDwUUbnG4EB46Sfk+FJFAOldfoKLOw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript/node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/triple-beam": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "nanoid": "^5.1.6",
     "react": "^19.2.4",
     "simple-git": "^3.32.3",
+    "tree-sitter": "^0.21.1",
+    "tree-sitter-javascript": "^0.21.4",
+    "tree-sitter-typescript": "^0.23.2",
     "zod": "^4.3.6"
   },
   "optionalDependencies": {

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -12,6 +12,10 @@ import { readFileSync } from 'node:fs';
 import type { Command } from 'commander';
 import { agenticChat, type AgenticProgressEvent } from '../../core/agenticChat.js';
 import { SessionManager } from '../../core/sessionManager.js';
+import { createAutoCommitManager } from '../../git/autoCommit.js';
+import { loadGitConfig } from '../../git/config.js';
+import { commitDirtyFiles } from '../../git/dirtyFiles.js';
+import { RepoMapManager } from '../../context/repoMap.js';
 
 interface AgentOptions {
   message?: string;
@@ -26,6 +30,14 @@ interface AgentOptions {
   tools?: string;
   verbose?: boolean;
   quiet?: boolean;
+  // Git flags
+  noAutoCommits?: boolean;
+  noDirtyCommits?: boolean;
+  gitCommitVerify?: boolean;
+  attributeCoAuthoredBy?: boolean;
+  attributeAuthor?: boolean;
+  // Repo map flags
+  mapTokens?: string;
 }
 
 export function registerAgentCommand(program: Command): void {
@@ -44,6 +56,17 @@ export function registerAgentCommand(program: Command): void {
     .option('--tools <list>', 'Comma-separated list of tool names to enable (default: all)')
     .option('-v, --verbose', 'Show progress updates')
     .option('-q, --quiet', 'Only output the final response')
+    // Git auto-commit flags
+    .option('--no-auto-commits', 'Disable git auto-commits after AI file changes')
+    .option('--no-dirty-commits', 'Skip committing pre-existing dirty files before AI edits')
+    .option('--git-commit-verify', 'Run pre-commit hooks when auto-committing (default: skip)')
+    .option('--attribute-co-authored-by', 'Add Co-authored-by trailer to AI commits (default)')
+    .option('--attribute-author', 'Override git author for AI commits')
+    // Repo map flags
+    .option(
+      '--map-tokens <n>',
+      'Include a repo map in the system prompt with token budget N (default: 1000; 0 = disabled)'
+    )
     .action(async (opts: AgentOptions) => {
       try {
         // Get message from either --message or --message-file
@@ -57,6 +80,7 @@ export function registerAgentCommand(program: Command): void {
           process.exit(1);
         }
 
+        const workdir = opts.workdir ?? process.cwd();
         const sessionManager = new SessionManager();
 
         // Load or create session
@@ -73,6 +97,42 @@ export function registerAgentCommand(program: Command): void {
 
         // Parse enabled tools
         const enabledTools = opts.tools ? opts.tools.split(',').map((t) => t.trim()) : undefined;
+
+        // Set up git auto-commits
+        let gitManager: ReturnType<typeof createAutoCommitManager> | undefined;
+        if (!opts.noAutoCommits) {
+          const gitConfig = await loadGitConfig(workdir);
+
+          // Apply CLI flag overrides
+          if (opts.noDirtyCommits) gitConfig.dirtyCommits = false;
+          if (opts.gitCommitVerify) gitConfig.commitVerify = true;
+          if (opts.attributeAuthor) gitConfig.attribution.style = 'author';
+          else if (opts.attributeCoAuthoredBy) gitConfig.attribution.style = 'co-authored-by';
+
+          gitManager = createAutoCommitManager(workdir, gitConfig);
+
+          // Commit pre-existing dirty files before AI starts editing
+          if (gitConfig.dirtyCommits) {
+            const dirtyResult = await commitDirtyFiles(workdir, gitConfig);
+            if (dirtyResult.committed && !opts.quiet) {
+              console.error(
+                `[Git] Committed ${dirtyResult.filesCommitted.length} pre-existing dirty file(s): ${dirtyResult.hash}`
+              );
+            }
+          }
+        }
+
+        // Set up repo map manager
+        let repoMapManager: RepoMapManager | undefined;
+        if (opts.mapTokens !== undefined) {
+          const mapTokensBudget = parseInt(opts.mapTokens, 10);
+          if (!isNaN(mapTokensBudget) && mapTokensBudget > 0) {
+            repoMapManager = new RepoMapManager(workdir, { maxTokens: mapTokensBudget });
+            if (!opts.quiet) {
+              console.error(`[RepoMap] Building repo map (token budget: ${mapTokensBudget})…`);
+            }
+          }
+        }
 
         // Progress callback
         const onProgress =
@@ -112,10 +172,27 @@ export function registerAgentCommand(program: Command): void {
           sessionManager,
           systemPrompt: opts.system,
           maxIterations: parseInt(String(opts.maxIterations ?? '50'), 10),
-          workdir: opts.workdir ?? process.cwd(),
+          workdir,
           enabledTools,
           onProgress,
+          gitManager,
+          repoMapManager,
         });
+
+        // Flush any pending auto-commits
+        if (gitManager) {
+          try {
+            const finalCommit = await gitManager.commitPendingChanges();
+            if (finalCommit && !opts.quiet) {
+              console.error(`[Git] Auto-committed: ${finalCommit.hash} — ${finalCommit.message}`);
+            }
+          } catch (commitErr) {
+            console.error(
+              `[Git] Warning: auto-commit failed: ${commitErr instanceof Error ? commitErr.message : String(commitErr)}`
+            );
+          }
+          gitManager.destroy();
+        }
 
         // Output result
         console.log(res.text);

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -4,6 +4,10 @@
 
 import type { Command } from 'commander';
 import { startInteractive } from '../interactive.js';
+import { createAutoCommitManager } from '../../git/autoCommit.js';
+import { loadGitConfig } from '../../git/config.js';
+import { commitDirtyFiles } from '../../git/dirtyFiles.js';
+import { RepoMapManager } from '../../context/repoMap.js';
 
 interface InteractiveOptions {
   model?: string;
@@ -11,6 +15,14 @@ interface InteractiveOptions {
   preferCheap?: boolean;
   session?: string;
   system?: string;
+  // Git flags
+  noAutoCommits?: boolean;
+  noDirtyCommits?: boolean;
+  gitCommitVerify?: boolean;
+  attributeCoAuthoredBy?: boolean;
+  attributeAuthor?: boolean;
+  // Repo map flags
+  mapTokens?: string;
 }
 
 export function registerInteractiveCommand(program: Command): void {
@@ -23,14 +35,60 @@ export function registerInteractiveCommand(program: Command): void {
     .option('--prefer-cheap', 'Prefer cheaper models when auto-routing')
     .option('--session <id>', 'Continue existing session')
     .option('--system <prompt>', 'System prompt for the conversation')
+    // Git auto-commit flags
+    .option('--no-auto-commits', 'Disable git auto-commits')
+    .option('--no-dirty-commits', 'Skip committing pre-existing dirty files')
+    .option('--git-commit-verify', 'Run pre-commit hooks when auto-committing')
+    .option('--attribute-co-authored-by', 'Add Co-authored-by trailer to AI commits (default)')
+    .option('--attribute-author', 'Override git author for AI commits')
+    // Repo map flags
+    .option(
+      '--map-tokens <n>',
+      'Enable repo map in system prompt with token budget N (default: 1000; 0 = disabled)'
+    )
     .action(async (opts: InteractiveOptions) => {
       try {
+        const workdir = process.cwd();
+        let gitManager: ReturnType<typeof createAutoCommitManager> | undefined;
+
+        if (!opts.noAutoCommits) {
+          const gitConfig = await loadGitConfig(workdir);
+
+          if (opts.noDirtyCommits) gitConfig.dirtyCommits = false;
+          if (opts.gitCommitVerify) gitConfig.commitVerify = true;
+          if (opts.attributeAuthor) gitConfig.attribution.style = 'author';
+          else if (opts.attributeCoAuthoredBy) gitConfig.attribution.style = 'co-authored-by';
+
+          gitManager = createAutoCommitManager(workdir, gitConfig);
+
+          if (gitConfig.dirtyCommits) {
+            const dirtyResult = await commitDirtyFiles(workdir, gitConfig);
+            if (dirtyResult.committed) {
+              console.log(
+                `[Git] Committed ${dirtyResult.filesCommitted.length} pre-existing dirty file(s): ${dirtyResult.hash}`
+              );
+            }
+          }
+        }
+
+        // Set up repo map manager
+        let repoMapManager: RepoMapManager | undefined;
+        if (opts.mapTokens !== undefined) {
+          const mapTokensBudget = parseInt(opts.mapTokens, 10);
+          if (!isNaN(mapTokensBudget) && mapTokensBudget > 0) {
+            repoMapManager = new RepoMapManager(workdir, { maxTokens: mapTokensBudget });
+            console.log(`[RepoMap] Building repo map (token budget: ${mapTokensBudget})…`);
+          }
+        }
+
         await startInteractive({
           model: opts.model,
           autoRoute: opts.autoRoute,
           preferCheap: opts.preferCheap,
           session: opts.session,
           systemPrompt: opts.system,
+          gitManager,
+          repoMapManager,
         });
       } catch (e) {
         console.error(String(e));

--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -11,6 +11,8 @@ import { streamChat, resolveModelId, isAbortError } from '../core/streamingOrche
 import { SessionManager } from '../core/sessionManager.js';
 import { env } from '../config/env.js';
 import { colors, c } from './utils/colors.js';
+import type { AutoCommitManager } from '../git/autoCommit.js';
+import type { RepoMapManager } from '../context/repoMap.js';
 import { getCheckpointManager } from '../core/checkpoints.js';
 import { compactConversation, estimateTokens } from '../core/compaction.js';
 import { DoDChecker } from '../core/dodChecker.js';
@@ -32,6 +34,10 @@ export interface InteractiveOptions {
   preferCheap?: boolean;
   session?: string;
   systemPrompt?: string;
+  /** Optional git auto-commit manager for /commit, /git, /git-log, /git-config commands */
+  gitManager?: AutoCommitManager;
+  /** Optional repo map manager for /map, /map-refresh, /map-tokens commands */
+  repoMapManager?: RepoMapManager;
 }
 
 interface ReplState {
@@ -45,6 +51,8 @@ interface ReplState {
   agent?: string;
   stage?: ConversationStage;
   thinkingMode?: boolean;
+  gitManager?: AutoCommitManager;
+  repoMapManager?: RepoMapManager;
 }
 
 // Spinner animation frames
@@ -115,6 +123,24 @@ function printHelp(): void {
     c('yellow', '  /diff') + c('gray', '              - Show files changed in current session')
   );
   console.log(c('yellow', '  /undo') + c('gray', '              - Undo last file change'));
+  console.log();
+  console.log(c('cyan', '  Repo Map:'));
+  console.log();
+  console.log(c('yellow', '  /map') + c('gray', '                - Show current repo map'));
+  console.log(c('yellow', '  /map-refresh') + c('gray', '        - Force rebuild of the repo map'));
+  console.log(
+    c('yellow', '  /map-tokens <n>') + c('gray', '     - Set repo map token budget (default: 1000)')
+  );
+  console.log();
+  console.log(c('cyan', '  Git:'));
+  console.log();
+  console.log(
+    c('yellow', '  /commit [msg]') +
+      c('gray', '      - Force commit pending changes (optional message)')
+  );
+  console.log(c('yellow', '  /git <cmd>') + c('gray', '         - Run a raw git command'));
+  console.log(c('yellow', '  /git-log') + c('gray', '           - Show recent AI commits'));
+  console.log(c('yellow', '  /git-config') + c('gray', '        - Show current git config'));
   console.log(c('yellow', '  /redo') + c('gray', '              - Redo last undone change'));
   console.log(
     c('yellow', '  /fork [name]') + c('gray', '       - Fork current session with optional name')
@@ -1362,6 +1388,174 @@ async function handleCommand(input: string, state: ReplState): Promise<boolean> 
       return true;
     }
 
+    case 'commit': {
+      const gitManager = state.gitManager;
+      if (!gitManager) {
+        console.log(
+          c(
+            'yellow',
+            '\n  Git auto-commits not enabled (start with --attribute-co-authored-by or similar)\n'
+          )
+        );
+        return true;
+      }
+      const msgOverride = args.length > 0 ? args.join(' ') : undefined;
+      try {
+        const commitResult = await gitManager.commitPendingChanges(msgOverride);
+        if (!commitResult) {
+          console.log(c('yellow', '\n  No pending changes to commit\n'));
+        } else {
+          console.log(c('green', `\n  Committed: ${commitResult.hash}`));
+          console.log(c('dim', `  ${commitResult.message}`));
+          console.log(c('gray', `  ${commitResult.filesCommitted.length} file(s)\n`));
+        }
+      } catch (err) {
+        console.log(
+          c('red', `\n  Commit failed: ${err instanceof Error ? err.message : String(err)}\n`)
+        );
+      }
+      return true;
+    }
+
+    case 'git': {
+      const gitManager = state.gitManager;
+      if (!gitManager) {
+        console.log(c('yellow', '\n  Git manager not available\n'));
+        return true;
+      }
+      if (args.length === 0) {
+        console.log(c('red', '\n  Usage: /git <command> [args...]\n'));
+        return true;
+      }
+      try {
+        const output = await gitManager.runRaw(args);
+        console.log(c('cyan', '\n  Git output:'));
+        console.log(output || c('dim', '  (no output)'));
+        console.log();
+      } catch (err) {
+        console.log(
+          c('red', `\n  Git error: ${err instanceof Error ? err.message : String(err)}\n`)
+        );
+      }
+      return true;
+    }
+
+    case 'git-log': {
+      const gitManager = state.gitManager;
+      if (!gitManager) {
+        console.log(c('yellow', '\n  Git manager not available\n'));
+        return true;
+      }
+      try {
+        const commits = await gitManager.getRecentCommits(10);
+        if (commits.length === 0) {
+          console.log(c('yellow', '\n  No commits found\n'));
+        } else {
+          console.log(c('cyan', '\n  Recent commits:\n'));
+          for (const commit of commits) {
+            console.log(`  ${c('yellow', commit.hash)} ${commit.message}`);
+            console.log(c('dim', `           ${commit.date}`));
+          }
+          console.log();
+        }
+      } catch (err) {
+        console.log(c('red', `\n  Error: ${err instanceof Error ? err.message : String(err)}\n`));
+      }
+      return true;
+    }
+
+    case 'git-config': {
+      const gitManager = state.gitManager;
+      if (!gitManager) {
+        console.log(c('yellow', '\n  Git manager not available\n'));
+        return true;
+      }
+      // Access private config via a getter or cast — expose via method
+      try {
+        const output = await gitManager.runRaw(['config', '--list', '--local']);
+        console.log(c('cyan', '\n  Git local config:\n'));
+        console.log(output || c('dim', '  (no local config)'));
+        console.log();
+      } catch {
+        console.log(c('yellow', '\n  No local git config found (not a repo?)\n'));
+      }
+      return true;
+    }
+
+    case 'map': {
+      const mapManager = state.repoMapManager;
+      if (!mapManager) {
+        console.log(c('yellow', '\n  Repo map not enabled (start with --map-tokens to enable)\n'));
+        return true;
+      }
+      try {
+        const mapText = await mapManager.getMap();
+        if (!mapText.trim()) {
+          console.log(c('yellow', '\n  No source files found for repo map\n'));
+        } else {
+          console.log(c('cyan', '\n  Repo Map:\n'));
+          console.log(mapText);
+          console.log();
+        }
+      } catch (err) {
+        console.log(
+          c('red', `\n  Repo map error: ${err instanceof Error ? err.message : String(err)}\n`)
+        );
+      }
+      return true;
+    }
+
+    case 'map-refresh': {
+      const mapManager = state.repoMapManager;
+      if (!mapManager) {
+        console.log(c('yellow', '\n  Repo map not enabled\n'));
+        return true;
+      }
+      try {
+        console.log(c('dim', '\n  Rebuilding repo map…'));
+        const mapText = await mapManager.refresh();
+        const lines = mapText.split('\n').length;
+        console.log(
+          c('green', `  Repo map rebuilt (${lines} lines, ~${mapManager.maxTokens} token budget)\n`)
+        );
+      } catch (err) {
+        console.log(
+          c(
+            'red',
+            `\n  Repo map refresh error: ${err instanceof Error ? err.message : String(err)}\n`
+          )
+        );
+      }
+      return true;
+    }
+
+    case 'map-tokens': {
+      const mapManager = state.repoMapManager;
+      if (!mapManager) {
+        console.log(c('yellow', '\n  Repo map not enabled\n'));
+        return true;
+      }
+      if (args.length === 0) {
+        console.log(
+          c(
+            'gray',
+            `\n  Current repo map token budget: ${c('green', String(mapManager.maxTokens))}\n`
+          )
+        );
+        return true;
+      }
+      const n = parseInt(args[0], 10);
+      if (isNaN(n) || n < 0) {
+        console.log(c('red', '\n  Usage: /map-tokens <positive integer>\n'));
+        return true;
+      }
+      mapManager.setMaxTokens(n);
+      console.log(
+        c('green', `\n  Repo map token budget set to ${n}. Run /map-refresh to apply.\n`)
+      );
+      return true;
+    }
+
     default:
       console.log(c('red', `\n  Unknown command: /${cmd}`));
       console.log(c('gray', '  Type /help for available commands\n'));
@@ -1380,6 +1574,8 @@ export async function startInteractive(options: InteractiveOptions = {}): Promis
     preferCheap: options.preferCheap || false,
     systemPrompt: options.systemPrompt,
     isStreaming: false,
+    gitManager: options.gitManager,
+    repoMapManager: options.repoMapManager,
   };
 
   // Load existing session if specified

--- a/src/context/ranking.ts
+++ b/src/context/ranking.ts
@@ -1,0 +1,199 @@
+/**
+ * Graph-based importance ranking via import analysis
+ *
+ * Builds a directed import graph across all files in the repo map, then
+ * uses a simplified PageRank-style algorithm to assign each file an
+ * importance score.  Files that are imported by many others rank higher.
+ *
+ * Import extraction is done with a lightweight regex pass (no full AST
+ * needed here) to keep things fast on large repos.
+ */
+
+import * as path from 'path';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Map from resolved absolute path → set of absolute paths it imports */
+export type ImportGraph = Map<string, Set<string>>;
+
+/** Map from absolute path → importance score [0, 1] */
+export type RankMap = Map<string, number>;
+
+// ─── Import extraction ────────────────────────────────────────────────────────
+
+const IMPORT_RE = /(?:^|\n)\s*(?:import|export)\s+(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]/g;
+const REQUIRE_RE = /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+/**
+ * Extract all module specifiers from source code (static imports/exports and
+ * require() calls).  Only relative paths (starting with `.`) are returned;
+ * bare package names are skipped.
+ */
+export function extractImports(source: string): string[] {
+  const specifiers: string[] = [];
+
+  for (const re of [IMPORT_RE, REQUIRE_RE]) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(source)) !== null) {
+      const spec = m[1];
+      if (spec.startsWith('.')) specifiers.push(spec);
+    }
+  }
+
+  return specifiers;
+}
+
+// ─── Graph construction ───────────────────────────────────────────────────────
+
+/**
+ * The extensions we try when resolving a bare relative import like `./foo`
+ * (mirrors the TypeScript module resolution order).
+ */
+const RESOLVE_EXTENSIONS = [
+  '', // exact match (e.g. already has extension)
+  '.ts',
+  '.tsx',
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.jsx',
+];
+
+/**
+ * Attempt to resolve a relative import specifier to one of the known file paths.
+ *
+ * @param spec      The import specifier (e.g. `"./utils"` or `"../config"`)
+ * @param fromFile  Absolute path of the importing file
+ * @param fileSet   Set of all known absolute paths in the repo
+ */
+function resolveSpecifier(spec: string, fromFile: string, fileSet: Set<string>): string | null {
+  const dir = path.dirname(fromFile);
+  const base = path.resolve(dir, spec);
+
+  for (const ext of RESOLVE_EXTENSIONS) {
+    const candidate = base + ext;
+    if (fileSet.has(candidate)) return candidate;
+  }
+
+  // Also try `/index.ts` etc. for directory imports
+  for (const ext of RESOLVE_EXTENSIONS.slice(1)) {
+    const candidate = path.join(base, `index${ext}`);
+    if (fileSet.has(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+/**
+ * Build an import graph from a map of filePath → source content.
+ * Only edges between known files are included.
+ */
+export function buildImportGraph(files: Map<string, string>): ImportGraph {
+  const fileSet = new Set(files.keys());
+  const graph: ImportGraph = new Map();
+
+  for (const [filePath, source] of files) {
+    const imports = new Set<string>();
+    for (const spec of extractImports(source)) {
+      const resolved = resolveSpecifier(spec, filePath, fileSet);
+      if (resolved) imports.add(resolved);
+    }
+    graph.set(filePath, imports);
+  }
+
+  return graph;
+}
+
+// ─── PageRank ─────────────────────────────────────────────────────────────────
+
+const DAMPING = 0.85;
+const ITERATIONS = 20;
+const CONVERGENCE_THRESHOLD = 1e-6;
+
+/**
+ * Run a simplified PageRank on the import graph.
+ *
+ * In the import graph an edge A → B means "A imports B".  We want files that
+ * are *imported by many others* to rank high, so we treat each edge as a vote
+ * from A *for* B (i.e. the "in-link" model).
+ *
+ * Returns a map of filePath → score in (0, 1].
+ */
+export function rankFiles(graph: ImportGraph): RankMap {
+  const nodes = [...graph.keys()];
+  const N = nodes.length;
+  if (N === 0) return new Map();
+
+  const initialScore = 1 / N;
+  const scores = new Map<string, number>(nodes.map((n) => [n, initialScore]));
+
+  // Pre-compute the in-link lists (who imports me?)
+  const inLinks = new Map<string, string[]>(nodes.map((n) => [n, []]));
+  const outDegree = new Map<string, number>();
+
+  for (const [from, targets] of graph) {
+    outDegree.set(from, targets.size);
+    for (const to of targets) {
+      inLinks.get(to)?.push(from);
+    }
+  }
+
+  // Iterative PageRank
+  for (let iter = 0; iter < ITERATIONS; iter++) {
+    let delta = 0;
+
+    for (const node of nodes) {
+      let rank = (1 - DAMPING) / N;
+
+      for (const from of inLinks.get(node) ?? []) {
+        const deg = outDegree.get(from) ?? 1;
+        rank += (DAMPING * (scores.get(from) ?? 0)) / deg;
+      }
+
+      delta += Math.abs(rank - (scores.get(node) ?? 0));
+      scores.set(node, rank);
+    }
+
+    if (delta < CONVERGENCE_THRESHOLD) break;
+  }
+
+  // Normalise to [0, 1] relative to the maximum score
+  const max = Math.max(...scores.values());
+  if (max > 0) {
+    for (const [k, v] of scores) {
+      scores.set(k, v / max);
+    }
+  }
+
+  return scores;
+}
+
+// ─── Reference counting ───────────────────────────────────────────────────────
+
+/**
+ * Count how many times each symbol name appears in files *other than* the one
+ * that defines the symbol.  This gives a rough "cross-file usage" count.
+ *
+ * For performance this is a simple substring search, not a full AST analysis.
+ */
+export function countSymbolReferences(
+  symbolName: string,
+  definingFile: string,
+  files: Map<string, string>
+): number {
+  let count = 0;
+  const re = new RegExp(`\\b${escapeRegex(symbolName)}\\b`, 'g');
+
+  for (const [filePath, source] of files) {
+    if (filePath === definingFile) continue;
+    const matches = source.match(re);
+    if (matches) count += matches.length;
+  }
+
+  return count;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+}

--- a/src/context/repoMap.ts
+++ b/src/context/repoMap.ts
@@ -1,0 +1,377 @@
+/**
+ * Repository Map — main module
+ *
+ * Scans the working directory for TypeScript/JavaScript source files,
+ * extracts symbols via tree-sitter, ranks files by import importance,
+ * and serialises the result into a compact text block suitable for
+ * inclusion in an LLM system prompt.
+ *
+ * Public API:
+ *   generateRepoMap(workdir, options)  — build and format a repo map
+ *   RepoMapManager                     — stateful class with caching
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { isSupportedFile } from './treeSitter.js';
+import { extractSymbols, type CodeSymbol } from './symbols.js';
+import { buildImportGraph, rankFiles, countSymbolReferences } from './ranking.js';
+
+// ─── Public interfaces ────────────────────────────────────────────────────────
+
+export interface RepoMap {
+  /** filePath → symbols in that file */
+  files: Map<string, CodeSymbol[]>;
+  /** Approximate token count of the rendered map */
+  totalTokens: number;
+  /** Unix timestamp (ms) of when the map was generated */
+  lastUpdated: number;
+}
+
+export interface RepoMapOptions {
+  /** Maximum token budget for the rendered map (default: 1000) */
+  maxTokens?: number;
+  /** Additional glob-style patterns to ignore (on top of defaults + .alexiignore) */
+  extraIgnore?: string[];
+}
+
+// ─── Defaults ─────────────────────────────────────────────────────────────────
+
+/** Always-ignored directory / file patterns */
+const DEFAULT_IGNORE_PATTERNS = [
+  'node_modules',
+  'dist',
+  'build',
+  '.git',
+  'coverage',
+  '.next',
+  '.nuxt',
+  '.turbo',
+  '__pycache__',
+  '.DS_Store',
+];
+
+const DEFAULT_MAX_TOKENS = 1000;
+
+// ─── .alexiignore support ────────────────────────────────────────────────────
+
+/**
+ * Load patterns from `.alexiignore` in `workdir`.
+ * Lines starting with `#` and blank lines are skipped.
+ */
+function loadAlexiIgnore(workdir: string): string[] {
+  const ignoreFile = path.join(workdir, '.alexiignore');
+  try {
+    const content = fs.readFileSync(ignoreFile, 'utf-8');
+    return content
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'));
+  } catch {
+    return [];
+  }
+}
+
+// ─── File discovery ───────────────────────────────────────────────────────────
+
+/**
+ * Returns true if any segment of `relativePath` matches an ignored pattern.
+ * Patterns are matched as simple substring checks or exact segment matches.
+ */
+function isIgnored(relativePath: string, ignorePatterns: string[]): boolean {
+  const segments = relativePath.split(path.sep);
+  for (const pattern of ignorePatterns) {
+    // Exact segment match (e.g. "node_modules")
+    if (segments.includes(pattern)) return true;
+    // Substring match (e.g. ".test." to skip test files)
+    if (relativePath.includes(pattern)) return true;
+  }
+  return false;
+}
+
+/**
+ * Recursively walk `dir`, collecting all supported source files.
+ * Skips directories/files matching `ignorePatterns`.
+ */
+function collectFiles(
+  dir: string,
+  workdir: string,
+  ignorePatterns: string[],
+  results: string[] = []
+): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    const relPath = path.relative(workdir, fullPath);
+
+    if (isIgnored(relPath, ignorePatterns)) continue;
+
+    if (entry.isDirectory()) {
+      collectFiles(fullPath, workdir, ignorePatterns, results);
+    } else if (entry.isFile() && isSupportedFile(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+// ─── Token estimation ────────────────────────────────────────────────────────
+
+/**
+ * Rough token count: ~4 characters per token (GPT-style approximation).
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+
+/**
+ * Format a single file's symbols as a compact text block.
+ *
+ * Example:
+ *   src/core/router.ts
+ *     function routePrompt(…)
+ *     interface RouterOptions
+ */
+function formatFile(relPath: string, symbols: CodeSymbol[]): string {
+  if (symbols.length === 0) return `${relPath}\n`;
+
+  const lines = [`${relPath}`];
+  for (const sym of symbols) {
+    const sigLine = sym.signature ? `  ${sym.signature}` : `  ${sym.kind} ${sym.name}`;
+    lines.push(sigLine);
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Build the full repo map text, respecting the token budget.
+ *
+ * Files are ordered by importance score (descending).  Within each file,
+ * symbols are ordered by line number.  If the full map would exceed the
+ * token budget we progressively drop lower-ranked files.
+ */
+function renderRepoMap(
+  fileSymbols: Map<string, CodeSymbol[]>,
+  rankScores: Map<string, number>,
+  maxTokens: number
+): { text: string; tokensUsed: number } {
+  // Sort files by rank score descending
+  const sorted = [...fileSymbols.entries()].sort(([a], [b]) => {
+    const ra = rankScores.get(a) ?? 0;
+    const rb = rankScores.get(b) ?? 0;
+    return rb - ra;
+  });
+
+  const chunks: string[] = [];
+  let tokensUsed = 0;
+
+  for (const [filePath, symbols] of sorted) {
+    const chunk = formatFile(filePath, symbols);
+    const chunkTokens = estimateTokens(chunk);
+
+    if (tokensUsed + chunkTokens > maxTokens && chunks.length > 0) {
+      // Stop adding files once we'd exceed the budget
+      break;
+    }
+
+    chunks.push(chunk);
+    tokensUsed += chunkTokens;
+  }
+
+  return { text: chunks.join('\n'), tokensUsed };
+}
+
+// ─── Core generation ─────────────────────────────────────────────────────────
+
+/**
+ * Scan `workdir`, extract symbols, rank files, and return a `RepoMap`.
+ */
+export async function buildRepoMap(
+  workdir: string,
+  options: RepoMapOptions = {}
+): Promise<RepoMap> {
+  const maxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const alexiIgnore = loadAlexiIgnore(workdir);
+  const allIgnore = [...DEFAULT_IGNORE_PATTERNS, ...alexiIgnore, ...(options.extraIgnore ?? [])];
+
+  // Discover files
+  const absolutePaths = collectFiles(workdir, workdir, allIgnore);
+
+  // Read sources
+  const sources = new Map<string, string>();
+  for (const filePath of absolutePaths) {
+    try {
+      sources.set(filePath, fs.readFileSync(filePath, 'utf-8'));
+    } catch {
+      // unreadable file — skip
+    }
+  }
+
+  // Build import graph and rank
+  const graph = buildImportGraph(sources);
+  const rankScores = rankFiles(graph);
+
+  // Extract symbols for each file
+  const fileSymbols = new Map<string, CodeSymbol[]>();
+  for (const [filePath, source] of sources) {
+    const relPath = path.relative(workdir, filePath);
+    const symbols = extractSymbols(source, relPath);
+    fileSymbols.set(filePath, symbols);
+  }
+
+  // Enrich symbols with cross-file reference counts
+  for (const symbols of fileSymbols.values()) {
+    for (const sym of symbols) {
+      sym.references = countSymbolReferences(sym.name, sym.filePath, sources);
+    }
+  }
+
+  // Render respecting token budget
+  const { tokensUsed } = renderRepoMap(fileSymbols, rankScores, maxTokens);
+
+  return {
+    files: fileSymbols,
+    totalTokens: tokensUsed,
+    lastUpdated: Date.now(),
+  };
+}
+
+/**
+ * Generate a formatted repo map string ready for insertion into a system prompt.
+ *
+ * Returns an empty string if no files were found.
+ */
+export async function generateRepoMap(
+  workdir: string,
+  options: RepoMapOptions = {}
+): Promise<string> {
+  const maxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const alexiIgnore = loadAlexiIgnore(workdir);
+  const allIgnore = [...DEFAULT_IGNORE_PATTERNS, ...alexiIgnore, ...(options.extraIgnore ?? [])];
+
+  const absolutePaths = collectFiles(workdir, workdir, allIgnore);
+  if (absolutePaths.length === 0) return '';
+
+  const sources = new Map<string, string>();
+  for (const filePath of absolutePaths) {
+    try {
+      sources.set(filePath, fs.readFileSync(filePath, 'utf-8'));
+    } catch {
+      /* skip */
+    }
+  }
+
+  const graph = buildImportGraph(sources);
+  const rankScores = rankFiles(graph);
+
+  // Build relative-path keyed map for rendering
+  const relFileSymbols = new Map<string, CodeSymbol[]>();
+  const absToRel = new Map<string, string>();
+  for (const [filePath, source] of sources) {
+    const relPath = path.relative(workdir, filePath);
+    absToRel.set(filePath, relPath);
+    relFileSymbols.set(relPath, extractSymbols(source, relPath));
+  }
+
+  // Re-key rank scores to relative paths
+  const relRankScores = new Map<string, number>();
+  for (const [abs, score] of rankScores) {
+    const rel = absToRel.get(abs);
+    if (rel) relRankScores.set(rel, score);
+  }
+
+  const { text, tokensUsed } = renderRepoMap(relFileSymbols, relRankScores, maxTokens);
+  if (!text.trim()) return '';
+
+  return [
+    `# Repository Map (~${tokensUsed} tokens)`,
+    '# Files are ordered by import importance (most-imported first)',
+    '',
+    text,
+  ].join('\n');
+}
+
+// ─── Stateful manager ────────────────────────────────────────────────────────
+
+export interface RepoMapManagerOptions extends RepoMapOptions {
+  /** Minimum milliseconds between automatic refreshes (default: 30_000) */
+  refreshIntervalMs?: number;
+}
+
+/**
+ * Stateful wrapper around `generateRepoMap` that caches the last result
+ * and can refresh automatically on a timer or on explicit request.
+ */
+export class RepoMapManager {
+  private workdir: string;
+  private opts: Required<RepoMapManagerOptions>;
+  private cachedMap: string | null = null;
+  private lastBuilt = 0;
+  private buildPromise: Promise<string> | null = null;
+
+  constructor(workdir: string, opts: RepoMapManagerOptions = {}) {
+    this.workdir = workdir;
+    this.opts = {
+      maxTokens: opts.maxTokens ?? DEFAULT_MAX_TOKENS,
+      extraIgnore: opts.extraIgnore ?? [],
+      refreshIntervalMs: opts.refreshIntervalMs ?? 30_000,
+    };
+  }
+
+  /** Return the cached map text, rebuilding if stale. */
+  async getMap(): Promise<string> {
+    const now = Date.now();
+    if (this.cachedMap !== null && now - this.lastBuilt < this.opts.refreshIntervalMs) {
+      return this.cachedMap;
+    }
+    return this.refresh();
+  }
+
+  /** Force a rebuild and return the new map text. */
+  async refresh(): Promise<string> {
+    // Deduplicate concurrent calls
+    if (this.buildPromise) return this.buildPromise;
+
+    this.buildPromise = generateRepoMap(this.workdir, {
+      maxTokens: this.opts.maxTokens,
+      extraIgnore: this.opts.extraIgnore,
+    })
+      .then((map) => {
+        this.cachedMap = map;
+        this.lastBuilt = Date.now();
+        this.buildPromise = null;
+        return map;
+      })
+      .catch((err) => {
+        this.buildPromise = null;
+        throw err;
+      });
+
+    return this.buildPromise;
+  }
+
+  /** Update the token budget and invalidate the cache. */
+  setMaxTokens(n: number): void {
+    this.opts.maxTokens = n;
+    this.cachedMap = null;
+  }
+
+  /** Returns the current token budget. */
+  get maxTokens(): number {
+    return this.opts.maxTokens;
+  }
+
+  /** Returns the cached map without triggering a refresh. */
+  get cached(): string | null {
+    return this.cachedMap;
+  }
+}

--- a/src/context/symbols.ts
+++ b/src/context/symbols.ts
@@ -1,0 +1,183 @@
+/**
+ * Symbol extraction from AST nodes
+ *
+ * Extracts top-level symbols (classes, functions, interfaces, types,
+ * variables, methods) from a TypeScript/JavaScript source file using
+ * the tree-sitter AST produced by treeSitter.ts.
+ */
+
+import { parseSource, walkNode, getNameNode } from './treeSitter.js';
+
+// ─── Public interfaces ────────────────────────────────────────────────────────
+
+export interface CodeSymbol {
+  name: string;
+  kind: 'class' | 'function' | 'interface' | 'type' | 'variable' | 'method';
+  filePath: string;
+  line: number;
+  /** Condensed first-line signature (e.g. "function foo(a: string): void") */
+  signature?: string;
+  /** Number of cross-file references discovered during ranking */
+  references: number;
+}
+
+// ─── Node-type → symbol-kind mapping ─────────────────────────────────────────
+
+const TOP_LEVEL_KINDS: Record<string, CodeSymbol['kind']> = {
+  // Classes
+  class_declaration: 'class',
+  abstract_class_declaration: 'class',
+  // Functions
+  function_declaration: 'function',
+  generator_function_declaration: 'function',
+  // Interfaces & types (TypeScript)
+  interface_declaration: 'interface',
+  type_alias_declaration: 'type',
+  // Variables / constants that are exported
+  lexical_declaration: 'variable',
+  variable_declaration: 'variable',
+};
+
+/**
+ * Node types that we descend into to look for the above declarations
+ * (e.g. export statements wrap the real declaration).
+ */
+const TRANSPARENT_WRAPPERS = new Set([
+  'export_statement',
+  'export_default_declaration',
+  'ambient_declaration', // "declare …"
+]);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Extract a condensed single-line signature from a node.
+ * We take only the first non-trivial line of the node's text and truncate.
+ */
+function extractSignature(node: import('tree-sitter').SyntaxNode): string {
+  const raw = node.text ?? '';
+  // Take just the first line and strip the body (everything after '{' or '=>')
+  const firstLine = raw.split('\n')[0].replace(/\{.*/, '').replace(/=>.*/, '').trim();
+  return firstLine.length > 120 ? firstLine.slice(0, 120) + '…' : firstLine;
+}
+
+/**
+ * Extract name + kind from a node, unwrapping export/ambient wrappers.
+ * Returns null if the node is not a recognisable top-level declaration.
+ */
+function extractDeclaration(
+  node: import('tree-sitter').SyntaxNode
+): { name: string; kind: CodeSymbol['kind']; signature: string } | null {
+  let target = node;
+
+  // Unwrap transparent export/ambient wrappers
+  if (TRANSPARENT_WRAPPERS.has(node.type)) {
+    // The actual declaration is usually the last named child
+    for (let i = node.childCount - 1; i >= 0; i--) {
+      const child = node.child(i);
+      if (child && child.type !== 'export' && child.type !== 'default' && child.isNamed) {
+        target = child;
+        break;
+      }
+    }
+  }
+
+  const kind = TOP_LEVEL_KINDS[target.type];
+  if (!kind) return null;
+
+  // For variable declarations, look at the first declarator
+  let nameNode: import('tree-sitter').SyntaxNode | null = null;
+  if (kind === 'variable') {
+    // lexical_declaration → variable_declarator → identifier
+    for (let i = 0; i < target.childCount; i++) {
+      const child = target.child(i);
+      if (child?.type === 'variable_declarator') {
+        nameNode = getNameNode(child);
+        break;
+      }
+    }
+  } else {
+    nameNode = getNameNode(target);
+  }
+
+  if (!nameNode) return null;
+
+  return {
+    name: nameNode.text,
+    kind,
+    signature: extractSignature(node), // use the outermost node for the signature
+  };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Extract top-level code symbols from `source`.
+ *
+ * Only direct children of the root program node (and their export wrappers)
+ * are examined. Method extraction is done one level deeper for class bodies.
+ */
+export function extractSymbols(source: string, filePath: string): CodeSymbol[] {
+  const root = parseSource(source, filePath);
+  if (!root) return [];
+
+  const symbols: CodeSymbol[] = [];
+
+  // Walk only the first level of the program
+  for (let i = 0; i < root.childCount; i++) {
+    const child = root.child(i);
+    if (!child || !child.isNamed) continue;
+
+    const decl = extractDeclaration(child);
+    if (!decl) continue;
+
+    symbols.push({
+      name: decl.name,
+      kind: decl.kind,
+      filePath,
+      line: child.startPosition.row + 1,
+      signature: decl.signature,
+      references: 0,
+    });
+
+    // For classes, also extract public methods
+    if (decl.kind === 'class') {
+      // Find class_body inside the class_declaration (or wrapped node)
+      let classNode = child;
+      if (TRANSPARENT_WRAPPERS.has(child.type)) {
+        for (let j = child.childCount - 1; j >= 0; j--) {
+          const c = child.child(j);
+          if (c && (c.type === 'class_declaration' || c.type === 'abstract_class_declaration')) {
+            classNode = c;
+            break;
+          }
+        }
+      }
+
+      walkNode(classNode, (node) => {
+        if (
+          node.type === 'method_definition' ||
+          node.type === 'public_field_definition' ||
+          node.type === 'method_signature'
+        ) {
+          // Only direct children of the class body (skip deeply nested)
+          if (node.parent?.type === 'class_body' && node.parent?.parent === classNode) {
+            const methodName = getNameNode(node);
+            if (methodName) {
+              symbols.push({
+                name: `${decl.name}.${methodName.text}`,
+                kind: 'method',
+                filePath,
+                line: node.startPosition.row + 1,
+                signature: extractSignature(node),
+                references: 0,
+              });
+            }
+          }
+        }
+      });
+    }
+  }
+
+  return symbols;
+}

--- a/src/context/treeSitter.ts
+++ b/src/context/treeSitter.ts
@@ -1,0 +1,133 @@
+/**
+ * Tree-sitter AST parsing helpers
+ *
+ * Provides lazy-initialised parsers for TypeScript and JavaScript.
+ * The parsers are created on first use to avoid startup overhead.
+ */
+
+import Parser from 'tree-sitter';
+import TypeScript from 'tree-sitter-typescript';
+import JavaScript from 'tree-sitter-javascript';
+
+// Lazily initialised parsers (one per language to avoid setLanguage races)
+let tsParser: Parser | null = null;
+let jsParser: Parser | null = null;
+let tsxParser: Parser | null = null;
+
+/**
+ * Get (or lazily create) the TypeScript parser
+ */
+function getTsParser(): Parser {
+  if (!tsParser) {
+    tsParser = new Parser();
+    tsParser.setLanguage(TypeScript.typescript);
+  }
+  return tsParser;
+}
+
+/**
+ * Get (or lazily create) the TSX parser
+ */
+function getTsxParser(): Parser {
+  if (!tsxParser) {
+    tsxParser = new Parser();
+    tsxParser.setLanguage(TypeScript.tsx);
+  }
+  return tsxParser;
+}
+
+/**
+ * Get (or lazily create) the JavaScript parser
+ */
+function getJsParser(): Parser {
+  if (!jsParser) {
+    jsParser = new Parser();
+    jsParser.setLanguage(JavaScript);
+  }
+  return jsParser;
+}
+
+export type SupportedExtension = 'ts' | 'tsx' | 'js' | 'mjs' | 'cjs' | 'jsx';
+
+/**
+ * Returns true if the file extension is supported by tree-sitter parsers
+ */
+export function isSupportedFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return (
+    ext === 'ts' || ext === 'tsx' || ext === 'js' || ext === 'mjs' || ext === 'cjs' || ext === 'jsx'
+  );
+}
+
+/**
+ * Parse source code using the appropriate parser for the file extension.
+ * Returns the root node of the AST, or null if the file is not supported.
+ */
+export function parseSource(source: string, filePath: string): Parser.SyntaxNode | null {
+  const ext = filePath.split('.').pop()?.toLowerCase() as SupportedExtension | undefined;
+
+  let parser: Parser;
+  switch (ext) {
+    case 'ts':
+      parser = getTsParser();
+      break;
+    case 'tsx':
+    case 'jsx':
+      parser = getTsxParser();
+      break;
+    case 'js':
+    case 'mjs':
+    case 'cjs':
+      parser = getJsParser();
+      break;
+    default:
+      return null;
+  }
+
+  try {
+    const tree = parser.parse(source);
+    return tree.rootNode;
+  } catch {
+    // Parser errors are non-fatal; return null so callers can skip the file
+    return null;
+  }
+}
+
+/**
+ * Walk every descendant of a node, calling `visitor` for each.
+ * Skips nodes whose type is in the `skipTypes` set.
+ */
+export function walkNode(
+  node: Parser.SyntaxNode,
+  visitor: (node: Parser.SyntaxNode) => void,
+  skipTypes?: Set<string>
+): void {
+  if (skipTypes?.has(node.type)) return;
+  visitor(node);
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child) walkNode(child, visitor, skipTypes);
+  }
+}
+
+/**
+ * Find the first child node of `node` with type in `types`, or null.
+ */
+export function findChildOfType(
+  node: Parser.SyntaxNode,
+  ...types: string[]
+): Parser.SyntaxNode | null {
+  const typeSet = new Set(types);
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child && typeSet.has(child.type)) return child;
+  }
+  return null;
+}
+
+/**
+ * Find the `identifier` or `type_identifier` child of a node (for name extraction)
+ */
+export function getNameNode(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+  return findChildOfType(node, 'identifier', 'type_identifier', 'property_identifier');
+}

--- a/src/core/agenticChat.ts
+++ b/src/core/agenticChat.ts
@@ -17,6 +17,8 @@ import { getToolRegistry, type ToolContext, type ToolResult } from '../tool/inde
 import { registerBuiltInTools } from '../tool/tools/index.js';
 import { getPermissionManager } from '../permission/index.js';
 import type { CompletionResult, TokenUsage } from '../providers/sapOrchestration.js';
+import type { AutoCommitManager } from '../git/autoCommit.js';
+import type { RepoMapManager } from '../context/repoMap.js';
 
 // Tool call from LLM response
 interface ToolCall {
@@ -50,6 +52,10 @@ export interface AgenticChatOptions {
   onProgress?: (event: AgenticProgressEvent) => void;
   /** AbortSignal for cancellation */
   signal?: AbortSignal;
+  /** Optional git auto-commit manager */
+  gitManager?: AutoCommitManager;
+  /** Optional repo map manager for codebase indexing context */
+  repoMapManager?: RepoMapManager;
 }
 
 export interface AgenticProgressEvent {
@@ -238,6 +244,25 @@ export async function agenticChat(
 
   const toolSchemas = enabledTools.map((t) => formatToolForApi(t.toFunctionSchema()));
 
+  // Fetch repo map if a manager is provided (non-blocking best-effort)
+  let repoMapText = '';
+  if (options?.repoMapManager) {
+    try {
+      repoMapText = await options.repoMapManager.getMap();
+    } catch {
+      // Non-fatal: proceed without repo map
+    }
+  }
+
+  /**
+   * Build the effective system prompt, optionally prepending the repo map.
+   */
+  function buildSystemPrompt(base?: string): string {
+    if (!repoMapText) return base ?? '';
+    if (!base) return repoMapText;
+    return `${repoMapText}\n\n${base}`;
+  }
+
   // Build initial messages
   const messages: Message[] = [];
 
@@ -249,14 +274,17 @@ export async function agenticChat(
 
     const history = options.sessionManager.getHistory(20);
     if (options.systemPrompt && !history.some((m) => m.role === 'system')) {
-      messages.push({ role: 'system', content: options.systemPrompt });
+      messages.push({ role: 'system', content: buildSystemPrompt(options.systemPrompt) });
+    } else if (repoMapText && !history.some((m) => m.role === 'system')) {
+      messages.push({ role: 'system', content: repoMapText });
     }
     messages.push(
       ...history.map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content }))
     );
   } else {
-    if (options?.systemPrompt) {
-      messages.push({ role: 'system', content: options.systemPrompt });
+    const effectiveSystemPrompt = buildSystemPrompt(options?.systemPrompt);
+    if (effectiveSystemPrompt) {
+      messages.push({ role: 'system', content: effectiveSystemPrompt });
     }
   }
 
@@ -277,6 +305,7 @@ export async function agenticChat(
     workdir,
     signal: options?.signal,
     sessionId: options?.sessionManager?.getCurrentSession()?.metadata.id,
+    gitManager: options?.gitManager,
   };
 
   // Agent loop

--- a/src/git/attribution.ts
+++ b/src/git/attribution.ts
@@ -1,0 +1,67 @@
+/**
+ * Git Attribution
+ * Formats Co-authored-by / author trailers for AI commits
+ */
+
+import type { GitConfig } from './config.js';
+
+/**
+ * Build git commit trailers based on attribution style
+ */
+export function buildAttributionTrailers(config: GitConfig): string[] {
+  const { style, name, email } = config.attribution;
+
+  switch (style) {
+    case 'none':
+      return [];
+
+    case 'co-authored-by':
+      return [`Co-authored-by: ${name} <${email}>`];
+
+    case 'author':
+      // Used to override the git author via env vars (GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL)
+      // The trailer itself just records the AI name
+      return [`Co-authored-by: ${name} <${email}>`];
+
+    case 'committer':
+      return [`Committed-by: ${name} <${email}>`];
+
+    default:
+      return [];
+  }
+}
+
+/**
+ * Append attribution trailers to a commit message body
+ * Trailers are separated from body by a blank line (git convention)
+ */
+export function appendTrailers(message: string, trailers: string[]): string {
+  if (trailers.length === 0) return message;
+
+  const trimmed = message.trimEnd();
+
+  // If the message already has a blank line before trailers section, don't add another
+  const trailersBlock = trailers.join('\n');
+  return `${trimmed}\n\n${trailersBlock}`;
+}
+
+/**
+ * Build git env vars override for author-style attribution
+ * Returns an env object to spread into child_process / simple-git options
+ */
+export function buildAuthorEnv(config: GitConfig): Record<string, string> | undefined {
+  if (config.attribution.style !== 'author') return undefined;
+
+  return {
+    GIT_AUTHOR_NAME: config.attribution.name,
+    GIT_AUTHOR_EMAIL: config.attribution.email,
+  };
+}
+
+/**
+ * Format a complete commit message with attribution
+ */
+export function formatCommitMessage(body: string, config: GitConfig): string {
+  const trailers = buildAttributionTrailers(config);
+  return appendTrailers(body, trailers);
+}

--- a/src/git/autoCommit.ts
+++ b/src/git/autoCommit.ts
@@ -1,0 +1,215 @@
+/**
+ * AutoCommitManager
+ * Core class that collects file changes and commits them automatically
+ * after a debounce window, attributing them to the AI assistant.
+ */
+
+import { simpleGit, type SimpleGit } from 'simple-git';
+import type { GitConfig } from './config.js';
+import { formatCommitMessage, buildAuthorEnv } from './attribution.js';
+import { generateCommitMessage, type ChangedFile } from './commitMessage.js';
+import { isGitRepo } from './dirtyFiles.js';
+
+const DEBOUNCE_MS = 500;
+
+export interface CommitResult {
+  hash: string;
+  message: string;
+  filesCommitted: string[];
+}
+
+export interface AutoCommitManagerOptions {
+  workdir: string;
+  config: GitConfig;
+}
+
+export class AutoCommitManager {
+  private workdir: string;
+  private config: GitConfig;
+  private pendingFiles: Map<string, ChangedFile> = new Map();
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private git: SimpleGit;
+  private repoChecked: boolean | null = null;
+  private lastCommitHash: string | null = null;
+
+  constructor(options: AutoCommitManagerOptions) {
+    this.workdir = options.workdir;
+    this.config = options.config;
+    this.git = simpleGit(this.workdir);
+  }
+
+  /**
+   * Update config (e.g. from CLI flags after construction)
+   */
+  updateConfig(partial: Partial<GitConfig>): void {
+    this.config = { ...this.config, ...partial };
+  }
+
+  /**
+   * Called after a write/edit/delete tool succeeds.
+   * Queues the file and starts (or resets) the debounce timer.
+   */
+  onFileChanged(filePath: string, toolName: string, description?: string): void {
+    if (!this.config.autoCommits) return;
+
+    this.pendingFiles.set(filePath, { filePath, toolName, description });
+
+    // Reset debounce timer
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      void this.commitPendingChanges();
+    }, DEBOUNCE_MS);
+  }
+
+  /**
+   * Force-commit all pending changes immediately (bypasses debounce).
+   * Returns the commit hash, or null if nothing to commit.
+   */
+  async commitPendingChanges(messageOverride?: string): Promise<CommitResult | null> {
+    // Clear any pending debounce timer
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    if (this.pendingFiles.size === 0) return null;
+
+    const inRepo = await this.checkIsGitRepo();
+    if (!inRepo) return null;
+
+    const files = [...this.pendingFiles.values()];
+    this.pendingFiles.clear();
+
+    try {
+      // Stage modified/new files; skip any that no longer exist (deleted)
+      const filePaths = files.map((f) => f.filePath);
+      await this.git.add(filePaths);
+
+      // Check if anything is actually staged
+      const status = await this.git.status();
+      if (status.staged.length === 0) return null;
+
+      // Generate message
+      const rawMessage = messageOverride ?? (await generateCommitMessage(files, this.config));
+      const message = formatCommitMessage(rawMessage, this.config);
+
+      // Apply author env if needed
+      const authorEnv = buildAuthorEnv(this.config);
+      if (authorEnv) {
+        process.env['GIT_AUTHOR_NAME'] = authorEnv['GIT_AUTHOR_NAME'];
+        process.env['GIT_AUTHOR_EMAIL'] = authorEnv['GIT_AUTHOR_EMAIL'];
+      }
+
+      const commitOptions: Record<string, string> = {};
+      if (!this.config.commitVerify) {
+        commitOptions['--no-verify'] = 'true';
+      }
+
+      const result = await this.git.commit(message, undefined, commitOptions);
+
+      if (authorEnv) {
+        delete process.env['GIT_AUTHOR_NAME'];
+        delete process.env['GIT_AUTHOR_EMAIL'];
+      }
+
+      this.lastCommitHash = result.commit;
+
+      return {
+        hash: result.commit,
+        message,
+        filesCommitted: filePaths,
+      };
+    } catch (err) {
+      // Restore pending files so they can be retried
+      for (const f of files) {
+        this.pendingFiles.set(f.filePath, f);
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`AutoCommit failed: ${msg}`, { cause: err });
+    }
+  }
+
+  /**
+   * Undo the last AI commit (soft reset — keeps changes staged)
+   */
+  async undoLastCommit(): Promise<void> {
+    const inRepo = await this.checkIsGitRepo();
+    if (!inRepo) throw new Error('Not a git repository');
+
+    await this.git.reset(['--soft', 'HEAD~1']);
+    this.lastCommitHash = null;
+  }
+
+  /**
+   * Get the hash of the last commit made by this manager
+   */
+  getLastCommitHash(): string | null {
+    return this.lastCommitHash;
+  }
+
+  /**
+   * Run a raw git command and return stdout
+   */
+  async runRaw(args: string[]): Promise<string> {
+    return this.git.raw(args);
+  }
+
+  /**
+   * Get recent commits made in this repo
+   */
+  async getRecentCommits(
+    limit = 10
+  ): Promise<Array<{ hash: string; message: string; date: string }>> {
+    const inRepo = await this.checkIsGitRepo();
+    if (!inRepo) return [];
+
+    const log = await this.git.log({ maxCount: limit });
+    return log.all.map((entry) => ({
+      hash: entry.hash.slice(0, 8),
+      message: entry.message,
+      date: entry.date,
+    }));
+  }
+
+  /**
+   * Get current git diff (unstaged)
+   */
+  async getDiff(): Promise<string> {
+    const inRepo = await this.checkIsGitRepo();
+    if (!inRepo) return '';
+    return this.git.diff();
+  }
+
+  /**
+   * Get count of pending (uncommitted) files queued by this manager
+   */
+  getPendingCount(): number {
+    return this.pendingFiles.size;
+  }
+
+  private async checkIsGitRepo(): Promise<boolean> {
+    if (this.repoChecked !== null) return this.repoChecked;
+    this.repoChecked = await isGitRepo(this.workdir);
+    return this.repoChecked;
+  }
+
+  /**
+   * Flush pending changes synchronously on process exit
+   * (best-effort; async commits may not complete)
+   */
+  destroy(): void {
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+}
+
+/**
+ * Convenience factory
+ */
+export function createAutoCommitManager(workdir: string, config: GitConfig): AutoCommitManager {
+  return new AutoCommitManager({ workdir, config });
+}

--- a/src/git/commitMessage.ts
+++ b/src/git/commitMessage.ts
@@ -1,0 +1,120 @@
+/**
+ * Commit Message Generator
+ * Generates Conventional Commits messages via cheap LLM or heuristics
+ */
+
+import { routePrompt } from '../core/router.js';
+import { getProviderForModel } from '../providers/index.js';
+import type { GitConfig } from './config.js';
+
+export interface ChangedFile {
+  filePath: string;
+  toolName: string;
+  description?: string;
+}
+
+/**
+ * Build a heuristic commit message without LLM
+ */
+export function buildHeuristicMessage(files: ChangedFile[], conventional: boolean): string {
+  const paths = files.map((f) => f.filePath);
+  const toolNames = [...new Set(files.map((f) => f.toolName))];
+
+  // Determine conventional commit type
+  const allPaths = paths.join(' ').toLowerCase();
+
+  const type: string = toolNames.includes('delete')
+    ? 'chore'
+    : allPaths.includes('test') ||
+        allPaths.includes('spec') ||
+        allPaths.includes('.test.') ||
+        allPaths.includes('.spec.')
+      ? 'test'
+      : allPaths.includes('readme') || allPaths.includes('.md') || allPaths.includes('docs/')
+        ? 'docs'
+        : allPaths.includes('fix') || allPaths.includes('bug') || allPaths.includes('patch')
+          ? 'fix'
+          : 'feat';
+
+  // Build a short summary from file names
+  const shortPaths = paths.map((p) => {
+    const parts = p.replace(/\\/g, '/').split('/');
+    return parts[parts.length - 1];
+  });
+
+  const summary =
+    shortPaths.length === 1
+      ? shortPaths[0]
+      : shortPaths.length <= 3
+        ? shortPaths.join(', ')
+        : `${shortPaths.slice(0, 2).join(', ')} and ${shortPaths.length - 2} more`;
+
+  if (conventional) {
+    return `${type}: update ${summary}`;
+  }
+
+  return `Update ${summary}`;
+}
+
+/**
+ * Generate commit message via LLM (cheap model)
+ */
+async function generateWithLLM(files: ChangedFile[], config: GitConfig): Promise<string | null> {
+  try {
+    const modelId = config.commitMessage.model
+      ? config.commitMessage.model
+      : routePrompt('summarize in 10 words', { preferCheap: true }).modelId;
+
+    const provider = getProviderForModel(modelId);
+
+    const fileList = files
+      .map((f) => {
+        const rel = f.filePath.replace(/\\/g, '/');
+        const desc = f.description ? ` (${f.description})` : '';
+        return `- ${rel}${desc} [via ${f.toolName}]`;
+      })
+      .join('\n');
+
+    const prompt = config.commitMessage.conventional
+      ? `Generate a single Conventional Commits message (type(scope): description) for these AI-edited files. Be concise, max 72 chars, no quotes:\n${fileList}`
+      : `Generate a single short git commit message (max 72 chars, no quotes) describing these AI-edited files:\n${fileList}`;
+
+    const result = await provider.complete(
+      [
+        {
+          role: 'system',
+          content:
+            'You are a git commit message generator. Respond with ONLY the commit message, nothing else. No markdown, no quotes, no explanation.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      { maxTokens: 100 }
+    );
+
+    const msg = result.text?.trim();
+    if (!msg) return null;
+
+    // Strip surrounding quotes if LLM added them
+    return msg.replace(/^["'`]|["'`]$/g, '');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Generate a commit message for a set of changed files
+ */
+export async function generateCommitMessage(
+  files: ChangedFile[],
+  config: GitConfig
+): Promise<string> {
+  if (files.length === 0) return 'chore: ai-assisted changes';
+
+  if (config.commitMessage.useAI) {
+    const llmMessage = await generateWithLLM(files, config);
+    if (llmMessage) return llmMessage;
+  }
+
+  // Fallback to heuristics
+  return buildHeuristicMessage(files, config.commitMessage.conventional);
+}

--- a/src/git/config.ts
+++ b/src/git/config.ts
@@ -1,0 +1,86 @@
+/**
+ * Git Configuration
+ * Defines GitConfig interface and load/save helpers
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+export interface GitConfig {
+  autoCommits: boolean;
+  dirtyCommits: boolean;
+  commitVerify: boolean;
+  attribution: {
+    style: 'none' | 'author' | 'co-authored-by' | 'committer';
+    name: string;
+    email: string;
+  };
+  commitMessage: {
+    useAI: boolean;
+    model?: string;
+    conventional: boolean;
+  };
+}
+
+export const DEFAULT_GIT_CONFIG: GitConfig = {
+  autoCommits: true,
+  dirtyCommits: true,
+  commitVerify: false,
+  attribution: {
+    style: 'co-authored-by',
+    name: 'Alexi AI',
+    email: 'alexi@assistant.local',
+  },
+  commitMessage: {
+    useAI: true,
+    conventional: true,
+  },
+};
+
+const CONFIG_FILE_NAME = '.alexi-git.json';
+
+/**
+ * Load git config from workdir, falling back to defaults
+ */
+export async function loadGitConfig(workdir: string): Promise<GitConfig> {
+  const configPath = path.join(workdir, CONFIG_FILE_NAME);
+  try {
+    const raw = await fs.readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<GitConfig>;
+    return mergeConfig(DEFAULT_GIT_CONFIG, parsed);
+  } catch {
+    // File not found or parse error — use defaults
+    return {
+      ...DEFAULT_GIT_CONFIG,
+      attribution: { ...DEFAULT_GIT_CONFIG.attribution },
+      commitMessage: { ...DEFAULT_GIT_CONFIG.commitMessage },
+    };
+  }
+}
+
+/**
+ * Save git config to workdir
+ */
+export async function saveGitConfig(workdir: string, config: GitConfig): Promise<void> {
+  const configPath = path.join(workdir, CONFIG_FILE_NAME);
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Deep-merge partial config over defaults
+ */
+function mergeConfig(defaults: GitConfig, partial: Partial<GitConfig>): GitConfig {
+  return {
+    autoCommits: partial.autoCommits ?? defaults.autoCommits,
+    dirtyCommits: partial.dirtyCommits ?? defaults.dirtyCommits,
+    commitVerify: partial.commitVerify ?? defaults.commitVerify,
+    attribution: {
+      ...defaults.attribution,
+      ...(partial.attribution ?? {}),
+    },
+    commitMessage: {
+      ...defaults.commitMessage,
+      ...(partial.commitMessage ?? {}),
+    },
+  };
+}

--- a/src/git/dirtyFiles.ts
+++ b/src/git/dirtyFiles.ts
@@ -1,0 +1,108 @@
+/**
+ * Dirty Files Handler
+ * Commits pre-existing dirty (modified/untracked) files before AI edits begin
+ * so AI changes are isolated in their own commits.
+ */
+
+import { simpleGit, type SimpleGit } from 'simple-git';
+import type { GitConfig } from './config.js';
+import { formatCommitMessage } from './attribution.js';
+import { buildAuthorEnv } from './attribution.js';
+
+export interface DirtyFilesResult {
+  committed: boolean;
+  hash?: string;
+  filesCommitted: string[];
+  skipped: boolean;
+  reason?: string;
+}
+
+/**
+ * Check if workdir is inside a git repo
+ */
+export async function isGitRepo(workdir: string): Promise<boolean> {
+  try {
+    const git: SimpleGit = simpleGit(workdir);
+    await git.revparse(['--git-dir']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get list of dirty files (modified tracked + untracked non-ignored)
+ */
+export async function getDirtyFiles(workdir: string): Promise<string[]> {
+  const git: SimpleGit = simpleGit(workdir);
+  const status = await git.status();
+
+  const dirty: string[] = [
+    ...status.modified,
+    ...status.not_added, // untracked
+    ...status.deleted,
+    ...status.renamed.map((r) => r.to),
+    ...status.created,
+  ];
+
+  // Deduplicate
+  return [...new Set(dirty)];
+}
+
+/**
+ * Commit pre-existing dirty files before AI work begins.
+ * Returns info about what was committed (or skipped).
+ */
+export async function commitDirtyFiles(
+  workdir: string,
+  config: GitConfig
+): Promise<DirtyFilesResult> {
+  if (!config.dirtyCommits) {
+    return { committed: false, filesCommitted: [], skipped: true, reason: 'dirtyCommits disabled' };
+  }
+
+  const inRepo = await isGitRepo(workdir);
+  if (!inRepo) {
+    return { committed: false, filesCommitted: [], skipped: true, reason: 'not a git repository' };
+  }
+
+  const dirtyFiles = await getDirtyFiles(workdir);
+  if (dirtyFiles.length === 0) {
+    return { committed: false, filesCommitted: [], skipped: true, reason: 'no dirty files' };
+  }
+
+  const git: SimpleGit = simpleGit(workdir);
+
+  // Stage all dirty files
+  await git.add('.');
+
+  const rawMessage = 'chore: save uncommitted changes before ai session';
+  const message = formatCommitMessage(rawMessage, config);
+
+  const commitOptions: Record<string, string> = {};
+  const authorEnv = buildAuthorEnv(config);
+  if (authorEnv) {
+    // simple-git doesn't directly support env overrides per-call;
+    // set them on the git instance options instead via environment
+    process.env['GIT_AUTHOR_NAME'] = authorEnv['GIT_AUTHOR_NAME'];
+    process.env['GIT_AUTHOR_EMAIL'] = authorEnv['GIT_AUTHOR_EMAIL'];
+  }
+
+  if (!config.commitVerify) {
+    commitOptions['--no-verify'] = 'true';
+  }
+
+  const result = await git.commit(message, undefined, commitOptions);
+
+  if (authorEnv) {
+    delete process.env['GIT_AUTHOR_NAME'];
+    delete process.env['GIT_AUTHOR_EMAIL'];
+  }
+
+  return {
+    committed: true,
+    hash: result.commit,
+    filesCommitted: dirtyFiles,
+    skipped: false,
+  };
+}

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Git Module
+ * Auto-commit AI-assisted changes with attribution
+ */
+
+export type { GitConfig } from './config.js';
+export { DEFAULT_GIT_CONFIG, loadGitConfig, saveGitConfig } from './config.js';
+
+export {
+  buildAttributionTrailers,
+  appendTrailers,
+  buildAuthorEnv,
+  formatCommitMessage,
+} from './attribution.js';
+
+export type { ChangedFile } from './commitMessage.js';
+export { generateCommitMessage, buildHeuristicMessage } from './commitMessage.js';
+
+export type { DirtyFilesResult } from './dirtyFiles.js';
+export { isGitRepo, getDirtyFiles, commitDirtyFiles } from './dirtyFiles.js';
+
+export type { CommitResult, AutoCommitManagerOptions } from './autoCommit.js';
+export { AutoCommitManager, createAutoCommitManager } from './autoCommit.js';

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -8,12 +8,15 @@ import { z } from 'zod';
 import { nanoid } from 'nanoid';
 import { ToolExecutionStarted, ToolExecutionCompleted, ToolExecutionFailed } from '../bus/index.js';
 import { getPermissionManager, type PermissionAction } from '../permission/index.js';
+import type { AutoCommitManager } from '../git/autoCommit.js';
 
 // Tool execution context
 export interface ToolContext {
   workdir: string;
   signal?: AbortSignal;
   sessionId?: string;
+  /** Optional git auto-commit manager — injected by agenticChat when enabled */
+  gitManager?: AutoCommitManager;
 }
 
 // Tool result

--- a/src/tool/tools/delete.ts
+++ b/src/tool/tools/delete.ts
@@ -138,6 +138,8 @@ Usage:
           await fs.rm(targetPath, { recursive: true });
         }
 
+        context.gitManager?.onFileChanged(targetPath, 'delete', 'deleted directory');
+
         return {
           success: true,
           data: {
@@ -151,6 +153,8 @@ Usage:
 
       // Delete file
       await fs.unlink(targetPath);
+
+      context.gitManager?.onFileChanged(targetPath, 'delete', 'deleted file');
 
       return {
         success: true,

--- a/src/tool/tools/edit.ts
+++ b/src/tool/tools/edit.ts
@@ -87,7 +87,7 @@ Usage:
         Buffer.byteLength(newContent, 'utf-8') - Buffer.byteLength(content, 'utf-8')
       );
 
-      return {
+      const toolResult = {
         success: true,
         data: {
           path: filePath,
@@ -95,6 +95,10 @@ Usage:
           bytesChanged,
         },
       };
+
+      context.gitManager?.onFileChanged(filePath, 'edit', `${replacements} replacement(s)`);
+
+      return toolResult;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
 

--- a/src/tool/tools/multiedit.ts
+++ b/src/tool/tools/multiedit.ts
@@ -147,6 +147,8 @@ Usage:
         result.hint = 'Warning: File became empty after edits';
       }
 
+      context.gitManager?.onFileChanged(filePath, 'multiedit', `${changes.length} edit(s) applied`);
+
       return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/tool/tools/write.ts
+++ b/src/tool/tools/write.ts
@@ -63,7 +63,7 @@ Usage:
       await fs.writeFile(filePath, params.content, 'utf-8');
       const bytesWritten = Buffer.byteLength(params.content, 'utf-8');
 
-      return {
+      const toolResult = {
         success: true,
         data: {
           path: filePath,
@@ -71,6 +71,14 @@ Usage:
           created: !exists,
         },
       };
+
+      context.gitManager?.onFileChanged(
+        filePath,
+        'write',
+        !exists ? 'created file' : 'overwrote file'
+      );
+
+      return toolResult;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
 

--- a/tests/git/attribution.test.ts
+++ b/tests/git/attribution.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAttributionTrailers,
+  appendTrailers,
+  buildAuthorEnv,
+  formatCommitMessage,
+} from '../../src/git/attribution.js';
+import type { GitConfig } from '../../src/git/config.js';
+
+const baseConfig: GitConfig = {
+  autoCommits: true,
+  dirtyCommits: true,
+  commitVerify: false,
+  attribution: {
+    style: 'co-authored-by',
+    name: 'Alexi AI',
+    email: 'alexi@assistant.local',
+  },
+  commitMessage: {
+    useAI: false,
+    conventional: true,
+  },
+};
+
+describe('buildAttributionTrailers', () => {
+  it('returns empty array for style=none', () => {
+    const config: GitConfig = {
+      ...baseConfig,
+      attribution: { ...baseConfig.attribution, style: 'none' },
+    };
+    expect(buildAttributionTrailers(config)).toEqual([]);
+  });
+
+  it('returns Co-authored-by trailer for style=co-authored-by', () => {
+    const trailers = buildAttributionTrailers(baseConfig);
+    expect(trailers).toEqual(['Co-authored-by: Alexi AI <alexi@assistant.local>']);
+  });
+
+  it('returns Co-authored-by trailer for style=author (for recording purposes)', () => {
+    const config: GitConfig = {
+      ...baseConfig,
+      attribution: { ...baseConfig.attribution, style: 'author' },
+    };
+    const trailers = buildAttributionTrailers(config);
+    expect(trailers).toEqual(['Co-authored-by: Alexi AI <alexi@assistant.local>']);
+  });
+
+  it('returns Committed-by trailer for style=committer', () => {
+    const config: GitConfig = {
+      ...baseConfig,
+      attribution: { ...baseConfig.attribution, style: 'committer' },
+    };
+    const trailers = buildAttributionTrailers(config);
+    expect(trailers).toEqual(['Committed-by: Alexi AI <alexi@assistant.local>']);
+  });
+});
+
+describe('appendTrailers', () => {
+  it('appends trailers separated by blank line', () => {
+    const result = appendTrailers('feat: add thing', ['Co-authored-by: Bot <b@b.com>']);
+    expect(result).toBe('feat: add thing\n\nCo-authored-by: Bot <b@b.com>');
+  });
+
+  it('returns message unchanged when trailers is empty', () => {
+    expect(appendTrailers('feat: add thing', [])).toBe('feat: add thing');
+  });
+
+  it('trims trailing whitespace from message before appending', () => {
+    const result = appendTrailers('feat: add thing   ', ['Co-authored-by: Bot <b@b.com>']);
+    expect(result).toBe('feat: add thing\n\nCo-authored-by: Bot <b@b.com>');
+  });
+});
+
+describe('buildAuthorEnv', () => {
+  it('returns undefined for non-author styles', () => {
+    expect(buildAuthorEnv(baseConfig)).toBeUndefined();
+    const none: GitConfig = {
+      ...baseConfig,
+      attribution: { ...baseConfig.attribution, style: 'none' },
+    };
+    expect(buildAuthorEnv(none)).toBeUndefined();
+  });
+
+  it('returns env vars for style=author', () => {
+    const config: GitConfig = {
+      ...baseConfig,
+      attribution: { ...baseConfig.attribution, style: 'author' },
+    };
+    const env = buildAuthorEnv(config);
+    expect(env).toEqual({
+      GIT_AUTHOR_NAME: 'Alexi AI',
+      GIT_AUTHOR_EMAIL: 'alexi@assistant.local',
+    });
+  });
+});
+
+describe('formatCommitMessage', () => {
+  it('appends Co-authored-by to message with co-authored-by style', () => {
+    const msg = formatCommitMessage('feat: do something', baseConfig);
+    expect(msg).toBe('feat: do something\n\nCo-authored-by: Alexi AI <alexi@assistant.local>');
+  });
+
+  it('returns plain message when attribution style is none', () => {
+    const config: GitConfig = {
+      ...baseConfig,
+      attribution: { ...baseConfig.attribution, style: 'none' },
+    };
+    const msg = formatCommitMessage('feat: do something', config);
+    expect(msg).toBe('feat: do something');
+  });
+});

--- a/tests/git/autoCommit.test.ts
+++ b/tests/git/autoCommit.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AutoCommitManager } from '../../src/git/autoCommit.js';
+import type { GitConfig } from '../../src/git/config.js';
+
+// Mock simple-git
+vi.mock('simple-git', () => {
+  const mockGit = {
+    revparse: vi.fn().mockResolvedValue('.git'),
+    status: vi.fn().mockResolvedValue({
+      staged: [],
+      modified: [],
+      not_added: [],
+      deleted: [],
+      renamed: [],
+      created: [],
+    }),
+    add: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue({ commit: 'abc1234' }),
+    reset: vi.fn().mockResolvedValue(undefined),
+    raw: vi.fn().mockResolvedValue(''),
+    log: vi.fn().mockResolvedValue({ all: [] }),
+    diff: vi.fn().mockResolvedValue(''),
+  };
+  return {
+    simpleGit: vi.fn(() => mockGit),
+    __mockGit: mockGit,
+  };
+});
+
+// Mock commitMessage to avoid LLM calls
+vi.mock('../../src/git/commitMessage.js', () => ({
+  generateCommitMessage: vi.fn().mockResolvedValue('feat: update foo.ts'),
+  buildHeuristicMessage: vi.fn().mockReturnValue('feat: update foo.ts'),
+}));
+
+// Mock isGitRepo from dirtyFiles
+vi.mock('../../src/git/dirtyFiles.js', () => ({
+  isGitRepo: vi.fn().mockResolvedValue(true),
+  getDirtyFiles: vi.fn().mockResolvedValue([]),
+  commitDirtyFiles: vi.fn().mockResolvedValue({
+    committed: false,
+    filesCommitted: [],
+    skipped: true,
+    reason: 'no dirty files',
+  }),
+}));
+
+const baseConfig: GitConfig = {
+  autoCommits: true,
+  dirtyCommits: true,
+  commitVerify: false,
+  attribution: {
+    style: 'co-authored-by',
+    name: 'Alexi AI',
+    email: 'alexi@assistant.local',
+  },
+  commitMessage: {
+    useAI: false,
+    conventional: true,
+  },
+};
+
+describe('AutoCommitManager', () => {
+  let manager: AutoCommitManager;
+
+  beforeEach(() => {
+    manager = new AutoCommitManager({ workdir: '/tmp/test-repo', config: baseConfig });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    manager.destroy();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('does not queue files when autoCommits=false', () => {
+    const config: GitConfig = { ...baseConfig, autoCommits: false };
+    const mgr = new AutoCommitManager({ workdir: '/tmp/test-repo', config });
+    mgr.onFileChanged('/tmp/test-repo/foo.ts', 'write');
+    expect(mgr.getPendingCount()).toBe(0);
+    mgr.destroy();
+  });
+
+  it('queues files when autoCommits=true', () => {
+    manager.onFileChanged('/tmp/test-repo/foo.ts', 'write');
+    expect(manager.getPendingCount()).toBe(1);
+  });
+
+  it('deduplicates the same file path', () => {
+    manager.onFileChanged('/tmp/test-repo/foo.ts', 'write');
+    manager.onFileChanged('/tmp/test-repo/foo.ts', 'edit');
+    expect(manager.getPendingCount()).toBe(1);
+  });
+
+  it('commitPendingChanges returns null when no pending files', async () => {
+    const result = await manager.commitPendingChanges();
+    expect(result).toBeNull();
+  });
+
+  it('commitPendingChanges commits staged files and clears pending queue', async () => {
+    const simpleGitMod = await import('simple-git');
+
+    const mockGit =
+      (simpleGitMod.simpleGit as any).mock.results[0]?.value ?? (simpleGitMod.simpleGit as any)();
+    mockGit.status.mockResolvedValueOnce({ staged: ['foo.ts'] });
+
+    manager.onFileChanged('/tmp/test-repo/foo.ts', 'write');
+    const result = await manager.commitPendingChanges();
+
+    expect(result).not.toBeNull();
+    expect(result?.hash).toBe('abc1234');
+    expect(manager.getPendingCount()).toBe(0);
+  });
+
+  it('getLastCommitHash returns the last commit hash after commit', async () => {
+    const simpleGitMod = await import('simple-git');
+
+    const mockGit =
+      (simpleGitMod.simpleGit as any).mock.results[0]?.value ?? (simpleGitMod.simpleGit as any)();
+    mockGit.status.mockResolvedValueOnce({ staged: ['foo.ts'] });
+
+    manager.onFileChanged('/tmp/test-repo/foo.ts', 'write');
+    await manager.commitPendingChanges();
+
+    expect(manager.getLastCommitHash()).toBe('abc1234');
+  });
+
+  it('updateConfig applies partial config update', () => {
+    manager.updateConfig({ autoCommits: false });
+    manager.onFileChanged('/tmp/test-repo/foo.ts', 'write');
+    // With autoCommits=false, nothing should be queued
+    expect(manager.getPendingCount()).toBe(0);
+  });
+
+  it('debounce timer fires commit after delay', async () => {
+    const simpleGitMod = await import('simple-git');
+
+    const mockGit =
+      (simpleGitMod.simpleGit as any).mock.results[0]?.value ?? (simpleGitMod.simpleGit as any)();
+    mockGit.status.mockResolvedValue({ staged: ['foo.ts'] });
+
+    manager.onFileChanged('/tmp/test-repo/foo.ts', 'write');
+    expect(manager.getPendingCount()).toBe(1);
+
+    // Fast-forward the debounce
+    await vi.runAllTimersAsync();
+
+    // After debounce, commitPendingChanges should have been called
+    expect(manager.getPendingCount()).toBe(0);
+  });
+});

--- a/tests/git/commitMessage.test.ts
+++ b/tests/git/commitMessage.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { buildHeuristicMessage } from '../../src/git/commitMessage.js';
+import type { ChangedFile } from '../../src/git/commitMessage.js';
+
+describe('buildHeuristicMessage', () => {
+  it('uses type=test for test files', () => {
+    const files: ChangedFile[] = [{ filePath: 'src/foo.test.ts', toolName: 'write' }];
+    const msg = buildHeuristicMessage(files, true);
+    expect(msg).toMatch(/^test:/);
+  });
+
+  it('uses type=docs for markdown files', () => {
+    const files: ChangedFile[] = [{ filePath: 'docs/README.md', toolName: 'write' }];
+    const msg = buildHeuristicMessage(files, true);
+    expect(msg).toMatch(/^docs:/);
+  });
+
+  it('uses type=chore for delete tool', () => {
+    const files: ChangedFile[] = [{ filePath: 'src/old.ts', toolName: 'delete' }];
+    const msg = buildHeuristicMessage(files, true);
+    expect(msg).toMatch(/^chore:/);
+  });
+
+  it('uses type=feat for generic source files', () => {
+    const files: ChangedFile[] = [{ filePath: 'src/feature.ts', toolName: 'write' }];
+    const msg = buildHeuristicMessage(files, true);
+    expect(msg).toMatch(/^feat:/);
+  });
+
+  it('includes single filename in message', () => {
+    const files: ChangedFile[] = [{ filePath: 'src/foo.ts', toolName: 'edit' }];
+    const msg = buildHeuristicMessage(files, true);
+    expect(msg).toContain('foo.ts');
+  });
+
+  it('includes multiple filenames when <= 3', () => {
+    const files: ChangedFile[] = [
+      { filePath: 'src/a.ts', toolName: 'edit' },
+      { filePath: 'src/b.ts', toolName: 'edit' },
+    ];
+    const msg = buildHeuristicMessage(files, true);
+    expect(msg).toContain('a.ts');
+    expect(msg).toContain('b.ts');
+  });
+
+  it('summarises when > 3 files', () => {
+    const files: ChangedFile[] = [
+      { filePath: 'src/a.ts', toolName: 'edit' },
+      { filePath: 'src/b.ts', toolName: 'edit' },
+      { filePath: 'src/c.ts', toolName: 'edit' },
+      { filePath: 'src/d.ts', toolName: 'edit' },
+    ];
+    const msg = buildHeuristicMessage(files, true);
+    // Should mention first 2 + "and 2 more"
+    expect(msg).toMatch(/and \d+ more/);
+  });
+
+  it('returns plain message without type prefix when conventional=false', () => {
+    const files: ChangedFile[] = [{ filePath: 'src/feature.ts', toolName: 'write' }];
+    const msg = buildHeuristicMessage(files, false);
+    expect(msg).not.toMatch(/^\w+:/);
+    expect(msg).toMatch(/^Update /);
+  });
+});


### PR DESCRIPTION
## Summary

- **Git auto-commits with attribution**: During agentic sessions, every file write/edit/delete is automatically staged and committed with a `Co-authored-by: Alexi AI <alexi@assistant.local>` trailer, giving a clear audit trail of AI-made changes.
- **Repository map**: Before answering, the agent scans the working directory using tree-sitter to extract top-level symbols (classes, functions, interfaces, types) from TypeScript and JavaScript files, ranks them by import-graph importance (PageRank), and prepends a token-budgeted structural overview to the system prompt — giving the model codebase context without requiring it to read every file.

## New files

| File | Purpose |
|---|---|
| `src/git/config.ts` | User-configurable auto-commit settings |
| `src/git/attribution.ts` | Build `Co-authored-by` trailers |
| `src/git/dirtyFiles.ts` | Detect which files changed since last commit |
| `src/git/commitMessage.ts` | Generate conventional-commit messages via LLM |
| `src/git/autoCommit.ts` | Orchestrate: diff → message → commit |
| `src/git/index.ts` | Public re-exports + `GitManager` class |
| `src/context/treeSitter.ts` | Lazy-init tree-sitter parsers for TS/TSX/JS |
| `src/context/symbols.ts` | Extract top-level symbols from AST |
| `src/context/ranking.ts` | Import-graph construction + simplified PageRank |
| `src/context/repoMap.ts` | Scan, rank, render token-budgeted repo map |
| `tests/git/attribution.test.ts` | 11 unit tests |
| `tests/git/autoCommit.test.ts` | 8 unit tests |
| `tests/git/commitMessage.test.ts` | 8 unit tests |

## Modified files

- `src/tool/index.ts`, `src/tool/tools/{write,edit,delete,multiedit}.ts` — pass `GitManager` through `ToolContext`; trigger auto-commit after each file mutation
- `src/core/agenticChat.ts` — accept `repoMapManager`; prepend repo map to system prompt
- `src/cli/interactive.ts` — `/map`, `/map-refresh`, `/map-tokens <n>` slash commands
- `src/cli/commands/agent.ts`, `src/cli/commands/interactive.ts` — `--map-tokens <n>` CLI flag

## Dependencies added

- `simple-git` — git operations
- `tree-sitter@0.21.1` + `tree-sitter-typescript@0.23.2` + `tree-sitter-javascript@0.21.4` — AST parsing (pinned for mutual compatibility)

## Tests

All 798 existing tests pass. 27 new tests added for the git module.

```
Test Files  36 passed (36)
      Tests 798 passed (798)
```