### PR TITLE
fix(tools): kill process group on timeout and abort to prevent zombie children

### DIFF
--- a/src/tool/tools/bash.ts
+++ b/src/tool/tools/bash.ts
@@ -64,15 +64,33 @@ Usage:
         cwd: workdir,
         env: { ...process.env, FORCE_COLOR: '0' },
         windowsHide: true,
+        detached: true,
       });
 
+      // Kill the entire process group (shell + all children)
+      const killGroup = (signal: NodeJS.Signals) => {
+        try {
+          if (proc.pid !== undefined) {
+            process.kill(-proc.pid, signal);
+          }
+        } catch {
+          // Process group may already be gone
+          try {
+            proc.kill(signal);
+          } catch {
+            // Ignore
+          }
+        }
+      };
+
       // Handle timeout
+      let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
       const timer = setTimeout(() => {
         timedOut = true;
-        proc.kill('SIGTERM');
-        setTimeout(() => {
+        killGroup('SIGTERM');
+        sigkillTimer = setTimeout(() => {
           if (!killed) {
-            proc.kill('SIGKILL');
+            killGroup('SIGKILL');
           }
         }, 5000);
       }, timeout);
@@ -80,8 +98,9 @@ Usage:
       // Handle abort signal
       const abortHandler = () => {
         killed = true;
-        proc.kill('SIGTERM');
         clearTimeout(timer);
+        killGroup('SIGTERM');
+        setTimeout(() => killGroup('SIGKILL'), 500);
       };
       context.signal?.addEventListener('abort', abortHandler);
 
@@ -95,6 +114,7 @@ Usage:
 
       proc.on('close', async (code) => {
         clearTimeout(timer);
+        clearTimeout(sigkillTimer);
         context.signal?.removeEventListener('abort', abortHandler);
         killed = true;
 
@@ -155,6 +175,7 @@ Usage:
 
       proc.on('error', (err) => {
         clearTimeout(timer);
+        clearTimeout(sigkillTimer);
         context.signal?.removeEventListener('abort', abortHandler);
         killed = true;
 


### PR DESCRIPTION
## Problem

CI was failing with 2 test timeouts in `bash.test.ts`:
- `bash tool > timeout behavior > should timeout a long-running command`
- `bash tool > abort signal > should abort when signal is triggered`

Both tests hit the 10000ms vitest limit despite having well-defined timeout/abort logic.

## Root Cause

`spawn()` with `shell: true` creates a shell wrapper process (e.g. `/bin/sh`). Sending `SIGTERM` to `proc` only kills the shell — child processes like `sleep 10` become orphans and keep running. Since the children still hold stdout/stderr handles open, `proc.on('close')` never fires (or fires late), causing the promise to never resolve within the test timeout.

Additionally, the SIGKILL fallback timer inside the timeout handler was never cleared in `proc.on('close')` or `proc.on('error')`, leaking the Node.js event loop.

## Fix

- Added `detached: true` to `spawn()` so the process spawns in its own process group
- Replaced `proc.kill(signal)` with `process.kill(-proc.pid, signal)` to send the signal to the **entire process group** (shell + all children)
- Stored `sigkillTimer` reference and clear it in both `close` and `error` handlers
- Abort handler now also schedules a SIGKILL after 500ms to guarantee termination

## Result

All 21 bash tool tests pass in ~600ms (was timing out at 10000ms+).