### PR TITLE
ci: add auto-merge workflow to squash-merge PRs when CI passes

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,25 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    # Skip release branches - those are merged manually via on-release-merge workflow
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --auto \
+            --squash \
+            --delete-branch


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-merge.yml` that automatically enables squash auto-merge on every PR when it is opened, synchronized, or reopened
- Skips `release/*` branches which follow the existing `on-release-merge` flow
- Uses `GH_PAT` secret (falls back to `GITHUB_TOKEN`) so the merge action has sufficient permissions
- Combined with the repo settings already configured (`allow_auto_merge=true`, `delete_branch_on_merge=true`) and branch protection requiring all CI status checks to pass, PRs will now merge and clean up automatically without manual intervention

## Repo settings already applied (done directly via API, not in this PR)
- `allow_auto_merge`: enabled
- `delete_branch_on_merge`: enabled
- Branch protection on `master`: requires `Install Dependencies`, `Lint`, `Type Check`, `Format Check`, `Tests`, `Build` to pass before merge