### PR TITLE
ci(ci): fix workflow bugs — ESM imports and PR-based push

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -49,74 +49,63 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_SYNC: ${{ github.event.inputs.force || 'false' }}
         run: |
-          node -e "
-          const { SyncManager } = require('./dist/sync/index.js');
-          const { FeatureAnalyzer } = require('./dist/sync/analyzer.js');
-          const fs = require('fs');
+          node --input-type=module <<'NODE_EOF'
+          import { SyncManager } from './dist/sync/index.js';
+          import { FeatureAnalyzer } from './dist/sync/analyzer.js';
+          import { appendFileSync, writeFileSync } from 'fs';
 
-          async function main() {
-            const syncManager = new SyncManager({ githubToken: process.env.GITHUB_TOKEN });
-            const analyzer = new FeatureAnalyzer();
+          const syncManager = new SyncManager({ githubToken: process.env.GITHUB_TOKEN });
+          const analyzer = new FeatureAnalyzer();
 
-            console.log('Starting repository sync...');
+          console.log('Starting repository sync...');
 
-            try {
-              // Run sync
-              const report = await syncManager.sync({ force: process.env.FORCE_SYNC === 'true' });
+          try {
+            const report = await syncManager.sync({ force: process.env.FORCE_SYNC === 'true' });
 
-              console.log('Sync completed!');
-              console.log('Repositories checked:', report.repositoriesChecked);
-              console.log('New changes found:', report.newChangesFound);
+            console.log('Sync completed!');
+            console.log('Repositories checked:', report.repositoriesChecked);
+            console.log('New changes found:', report.newChangesFound);
 
-              if (report.errors.length > 0) {
-                console.log('Errors:', report.errors.join(', '));
-              }
-
-              // Analyze changes
-              const analysis = analyzer.analyzeChanges(report.changes);
-
-              // Generate reports
-              const syncReport = syncManager.generateMarkdownReport(report);
-              const analysisReport = analyzer.generateReport(analysis);
-
-              // Save reports as artifacts
-              fs.writeFileSync('sync-report.md', syncReport);
-              fs.writeFileSync('analysis-report.md', analysisReport);
-
-              // Set outputs using environment file
-              const highPriorityCount = report.changes.filter(c => c.priority === 'high').length;
-              const providerGaps = analysis.featureGaps.filter(g => g.category === 'provider').length;
-              const toolGaps = analysis.featureGaps.filter(g => g.category === 'tool').length;
-
-              fs.appendFileSync(process.env.GITHUB_OUTPUT, 'changes_found=' + report.newChangesFound + '\\n');
-              fs.appendFileSync(process.env.GITHUB_OUTPUT, 'high_priority=' + highPriorityCount + '\\n');
-              fs.appendFileSync(process.env.GITHUB_OUTPUT, 'provider_gaps=' + providerGaps + '\\n');
-              fs.appendFileSync(process.env.GITHUB_OUTPUT, 'tool_gaps=' + toolGaps + '\\n');
-
-              // Summary
-              const summary = [
-                '## Repository Sync Summary',
-                '',
-                '| Metric | Value |',
-                '|--------|-------|',
-                '| Repositories Checked | ' + report.repositoriesChecked + ' |',
-                '| New Changes Found | ' + report.newChangesFound + ' |',
-                '| High Priority Changes | ' + highPriorityCount + ' |',
-                '| Provider Gaps | ' + providerGaps + ' |',
-                '| Tool Gaps | ' + toolGaps + ' |',
-                '',
-              ].join('\\n');
-
-              fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
-
-            } catch (error) {
-              console.error('Sync failed:', error.message);
-              process.exit(1);
+            if (report.errors.length > 0) {
+              console.log('Errors:', report.errors.join(', '));
             }
-          }
 
-          main();
-          "
+            const analysis = analyzer.analyzeChanges(report.changes);
+
+            const syncReport = syncManager.generateMarkdownReport(report);
+            const analysisReport = analyzer.generateReport(analysis);
+
+            writeFileSync('sync-report.md', syncReport);
+            writeFileSync('analysis-report.md', analysisReport);
+
+            const highPriorityCount = report.changes.filter(c => c.priority === 'high').length;
+            const providerGaps = analysis.featureGaps.filter(g => g.category === 'provider').length;
+            const toolGaps = analysis.featureGaps.filter(g => g.category === 'tool').length;
+
+            appendFileSync(process.env.GITHUB_OUTPUT, 'changes_found=' + report.newChangesFound + '\n');
+            appendFileSync(process.env.GITHUB_OUTPUT, 'high_priority=' + highPriorityCount + '\n');
+            appendFileSync(process.env.GITHUB_OUTPUT, 'provider_gaps=' + providerGaps + '\n');
+            appendFileSync(process.env.GITHUB_OUTPUT, 'tool_gaps=' + toolGaps + '\n');
+
+            const summary = [
+              '## Repository Sync Summary',
+              '',
+              '| Metric | Value |',
+              '|--------|-------|',
+              '| Repositories Checked | ' + report.repositoriesChecked + ' |',
+              '| New Changes Found | ' + report.newChangesFound + ' |',
+              '| High Priority Changes | ' + highPriorityCount + ' |',
+              '| Provider Gaps | ' + providerGaps + ' |',
+              '| Tool Gaps | ' + toolGaps + ' |',
+              '',
+            ].join('\n');
+
+            appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+          } catch (error) {
+            console.error('Sync failed:', error.message);
+            process.exit(1);
+          }
+          NODE_EOF
 
       - name: Upload Sync Report
         uses: actions/upload-artifact@v4
@@ -150,7 +139,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -168,64 +157,54 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          node -e "
-          const { FeatureAnalyzer } = require('./dist/sync/analyzer.js');
-          const { PRGenerator } = require('./dist/sync/pr-generator.js');
-          const { execSync } = require('child_process');
+          node --input-type=module <<'NODE_EOF'
+          import { FeatureAnalyzer } from './dist/sync/analyzer.js';
+          import { PRGenerator } from './dist/sync/pr-generator.js';
+          import { execSync } from 'child_process';
+          import { writeFileSync } from 'fs';
 
-          async function main() {
-            const analyzer = new FeatureAnalyzer();
-            const generator = new PRGenerator({ dryRun: false });
+          const analyzer = new FeatureAnalyzer();
+          const generator = new PRGenerator({ dryRun: false });
 
-            // Analyze with empty changes to get feature gaps
-            const analysis = analyzer.analyzeChanges([]);
+          const analysis = analyzer.analyzeChanges([]);
 
-            // Get high priority gaps that are providers or tools
-            const importantGaps = analysis.featureGaps
-              .filter(g => g.priority === 'high' && ['provider', 'tool'].includes(g.category))
-              .slice(0, 3);
+          const importantGaps = analysis.featureGaps
+            .filter(g => g.priority === 'high' && ['provider', 'tool'].includes(g.category))
+            .slice(0, 3);
 
-            console.log('Creating issues for', importantGaps.length, 'feature gaps...');
+          console.log('Creating issues for', importantGaps.length, 'feature gaps...');
 
-            for (const gap of importantGaps) {
-              try {
-                // Check if issue already exists
-                const searchResult = execSync(
-                  'gh issue list --search \"' + gap.feature + ' in:title\" --json number --limit 1',
-                  { encoding: 'utf-8' }
-                );
-                const existingIssues = JSON.parse(searchResult);
+          for (const gap of importantGaps) {
+            try {
+              const searchResult = execSync(
+                'gh issue list --search "' + gap.feature + ' in:title" --json number --limit 1',
+                { encoding: 'utf-8' }
+              );
+              const existingIssues = JSON.parse(searchResult);
 
-                if (existingIssues.length > 0) {
-                  console.log('Issue already exists for:', gap.feature);
-                  continue;
-                }
-
-                // Create issue
-                const template = generator.generateFromFeatureGap(gap);
-                const labels = template.labels.join(',');
-                
-                // Write body to temp file to avoid escaping issues
-                const fs = require('fs');
-                fs.writeFileSync('/tmp/issue-body.md', template.body);
-
-                execSync(
-                  'gh issue create --title \"' + template.title + '\" --label \"' + labels + '\" --body-file /tmp/issue-body.md',
-                  { stdio: 'inherit' }
-                );
-
-                console.log('Created issue for:', gap.feature);
-
-                // Rate limit
-                await new Promise(r => setTimeout(r, 1000));
-              } catch (error) {
-                console.error('Failed to create issue for', gap.feature, ':', error.message);
+              if (existingIssues.length > 0) {
+                console.log('Issue already exists for:', gap.feature);
+                continue;
               }
+
+              const template = generator.generateFromFeatureGap(gap);
+              const labels = template.labels.join(',');
+
+              writeFileSync('/tmp/issue-body.md', template.body);
+
+              execSync(
+                'gh issue create --title "' + template.title + '" --label "' + labels + '" --body-file /tmp/issue-body.md',
+                { stdio: 'inherit' }
+              );
+
+              console.log('Created issue for:', gap.feature);
+
+              await new Promise(r => setTimeout(r, 1000));
+            } catch (error) {
+              console.error('Failed to create issue for', gap.feature, ':', error.message);
             }
           }
-
-          main().catch(console.error);
-          "
+          NODE_EOF
 
   notify:
     name: Send Notification

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -547,68 +547,29 @@ jobs:
           echo "=== END DRY RUN ==="
 
       # =================================================================
-      # DIRECT COMMIT TO MAIN (Autonomous mode - no PR required)
-      # This approach commits directly to main for fully autonomous operation.
-      # The two-stage AI process (Opus planning + Sonnet execution) ensures
-      # quality control before changes are committed.
+      # CREATE PR (branch protection safe — never pushes directly to master)
+      # The AI-generated changes are committed to a dated feature branch.
+      # auto-merge.yml then enables squash auto-merge so it lands in master
+      # automatically once CI passes.
       # =================================================================
 
-      - name: Commit and push changes to main
+      - name: Commit changes to feature branch and open PR
         if: inputs.dry_run != true && steps.kilo-changes.outputs.kilo_made_changes == 'true'
         id: commit-changes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # Stage all changes
-          git add -A
-          
-          # Create detailed commit message
-          COMMIT_MSG=$(cat << EOF
-          feat: sync upstream changes ($(date +%Y-%m-%d))
 
-          Synchronized changes from upstream repositories:
-          - kilocode: ${{ steps.prev-commits.outputs.prev_kilocode }} -> ${{ steps.current-commits.outputs.current_kilocode }}
-          - opencode: ${{ steps.prev-commits.outputs.prev_opencode }} -> ${{ steps.current-commits.outputs.current_opencode }}
-          - claude-code: ${{ steps.prev-commits.outputs.prev_claude_code }} -> ${{ steps.current-commits.outputs.current_claude_code }}
+          # Create a dated feature branch
+          BRANCH="auto/sync-upstream-$(date +%Y-%m-%d)"
+          git checkout -b "$BRANCH"
 
-          Two-stage AI process:
-          - Stage 1 (Planning): anthropic--claude-4.5-opus
-          - Stage 2 (Execution): anthropic--claude-4.5-sonnet
-
-          See .github/reports/update-plan-$(date +%Y-%m-%d).md for the AI-generated plan.
-          EOF
-          )
-          
-          git commit -m "$COMMIT_MSG"
-          
-          # Push to current branch (could be main or master)
-          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          echo "Current branch: $CURRENT_BRANCH"
-          git push origin "$CURRENT_BRANCH"
-          
-          # Get commit SHA for output
-          COMMIT_SHA=$(git rev-parse HEAD)
-          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          echo "Committed and pushed: $COMMIT_SHA"
-
-      - name: Update last-sync-commits.json
-        if: inputs.dry_run != true && steps.kilo-changes.outputs.kilo_made_changes == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Get current branch and pull latest
-          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          git pull origin "$CURRENT_BRANCH"
-          
-          # Ensure directory exists
+          # Update last-sync-commits.json on the same branch
           mkdir -p .github
-          
-          # Update the sync commits file with nested format
           SYNCED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          cat > .github/last-sync-commits.json << EOF
+          cat > .github/last-sync-commits.json << SYNC_EOF
           {
             "kilocode": {
               "last_synced_commit": "${{ steps.current-commits.outputs.current_kilocode }}",
@@ -634,18 +595,55 @@ jobs:
               "description": "Tracks last synced commits from upstream repositories"
             }
           }
-          EOF
-          
-          # Commit and push
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          git add .github/last-sync-commits.json
-          git commit -m "chore: update last-sync-commits.json [skip ci]" || {
-            echo "No changes to commit"
-            exit 0
-          }
-          git push origin "$CURRENT_BRANCH"
+          SYNC_EOF
+
+          # Stage everything (AI changes + updated sync state)
+          git add -A
+
+          # Commit
+          git commit -m "feat(sync): apply upstream changes ($(date +%Y-%m-%d))
+
+          Synchronized changes from upstream repositories:
+          - kilocode: ${{ steps.prev-commits.outputs.prev_kilocode }} -> ${{ steps.current-commits.outputs.current_kilocode }}
+          - opencode: ${{ steps.prev-commits.outputs.prev_opencode }} -> ${{ steps.current-commits.outputs.current_opencode }}
+          - claude-code: ${{ steps.prev-commits.outputs.prev_claude_code }} -> ${{ steps.current-commits.outputs.current_claude_code }}
+
+          Two-stage AI process:
+          - Stage 1 (Planning): anthropic--claude-4.5-opus
+          - Stage 2 (Execution): anthropic--claude-4.5-sonnet"
+
+          git push -u origin "$BRANCH"
+
+          # Create PR — auto-merge.yml will enable squash auto-merge on open
+          PLAN_FILE=".github/reports/update-plan-$(date +%Y-%m-%d).md"
+          PR_BODY="## Upstream Sync — $(date +%Y-%m-%d)
+
+          Auto-generated by \`sync-upstream.yml\`.
+
+          ### Repositories analysed
+          | Repo | Previous | Current |
+          |------|----------|---------|
+          | kilocode | \`${{ steps.prev-commits.outputs.prev_kilocode }}\` | \`${{ steps.current-commits.outputs.current_kilocode }}\` |
+          | opencode | \`${{ steps.prev-commits.outputs.prev_opencode }}\` | \`${{ steps.current-commits.outputs.current_opencode }}\` |
+          | claude-code | \`${{ steps.prev-commits.outputs.prev_claude_code }}\` | \`${{ steps.current-commits.outputs.current_claude_code }}\` |
+
+          ### Process
+          1. **Planning** — \`anthropic--claude-4.5-opus\` analysed diffs and produced an update plan
+          2. **Execution** — \`anthropic--claude-4.5-sonnet\` applied the plan using file tools
+
+          See \`$PLAN_FILE\` in the workflow artifacts for the full AI-generated plan."
+
+          PR_URL=$(gh pr create \
+            --title "feat(sync): apply upstream changes ($(date +%Y-%m-%d))" \
+            --body "$PR_BODY" \
+            --base master \
+            --head "$BRANCH" \
+            --label "auto-sync")
+
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "PR created: $PR_URL"
 
       - name: Summary
         run: |
@@ -660,6 +658,9 @@ jobs:
           echo "| Changes Detected | ${{ steps.check-changes.outputs.has_changes }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Bot Made Changes | ${{ steps.kilo-changes.outputs.kilo_made_changes }} |" >> $GITHUB_STEP_SUMMARY
           
+          if [ "${{ steps.commit-changes.outputs.pr_url }}" != "" ]; then
+            echo "| PR | ${{ steps.commit-changes.outputs.pr_url }} |" >> $GITHUB_STEP_SUMMARY
+          fi
           if [ "${{ steps.commit-changes.outputs.commit_sha }}" != "" ]; then
             echo "| Commit | \`${{ steps.commit-changes.outputs.commit_sha }}\` |" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
## Summary

- **`sync-upstream.yml`**: replaced direct push to `master` with a dated feature branch (`auto/sync-upstream-YYYY-MM-DD`) + PR creation. Branch protection now requires PRs, so the old `git push origin master` would have been rejected. Also adds the PR URL to the workflow step summary.
- **`repo-sync.yml`**: replaced `require()` calls with `node --input-type=module` heredocs using ESM `import()` syntax. The compiled output is pure ESM (`"type": "module"` in `package.json`), so `require()` would fail at runtime. Also bumps Node.js from v20 → v22 to match the project requirement.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/sync-upstream.yml` | PR-based push + summary PR URL |
| `.github/workflows/repo-sync.yml` | ESM `import()` + Node.js v22 |