### PR TITLE
fix(cli): wire useCommands hook to intercept slash commands in TUI

### DIFF
--- a/src/cli/tui/App.tsx
+++ b/src/cli/tui/App.tsx
@@ -11,6 +11,7 @@ import type { ImageAttachmentPreview } from './context/AttachmentContext.js';
 import { useStreamChat } from './hooks/useStreamChat.js';
 import { usePermission } from './hooks/usePermission.js';
 import { useKeyboard } from './hooks/useKeyboard.js';
+import { useCommands } from './hooks/useCommands.js';
 
 import { PermissionDialog } from './dialogs/PermissionDialog.js';
 import type { PermissionDialogProps } from './dialogs/PermissionDialog.js';
@@ -127,6 +128,7 @@ function AppLayout(): React.JSX.Element {
   const chat = useChat();
   const { sendMessage } = useStreamChat();
   const { pending: pendingAttachments } = useAttachments();
+  const { handleCommand, commands } = useCommands();
   useToolEvents();
   usePermission();
 
@@ -162,12 +164,14 @@ function AppLayout(): React.JSX.Element {
       /* no-op for now — session management TBD */
     },
     isInputActive: !keybindState.leaderActive,
+    commands,
   });
 
   const handleSubmit = useCallback(
     (text: string): void => {
-      if (text === '/exit') {
-        exit();
+      // Intercept slash commands — if handled, do NOT send to LLM
+      if (text.startsWith('/')) {
+        void handleCommand(text);
         return;
       }
 
@@ -195,7 +199,7 @@ function AppLayout(): React.JSX.Element {
       // Fire and forget — streaming updates flow through ChatContext
       void sendMessage(text);
     },
-    [exit, pendingAttachments, sendMessage]
+    [handleCommand, pendingAttachments, sendMessage]
   );
 
   const agentColor = theme.colors.agents[agent as AgentName] ?? theme.colors.primary;
@@ -242,6 +246,7 @@ function AppLayout(): React.JSX.Element {
             disabled={chat.isStreaming}
             onSubmit={handleSubmit}
             isFocused={!keybindState.leaderActive}
+            commands={commands}
           />
 
           {/* Status Bar — height: 1 */}

--- a/src/cli/tui/components/InputBox.tsx
+++ b/src/cli/tui/components/InputBox.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
 
 import type { InputBoxProps } from '../types/props.js';
+import type { SlashCommand } from '../hooks/useCommands.js';
 import { useClipboardImage } from '../hooks/useClipboardImage.js';
 import { useAttachments } from '../context/AttachmentContext.js';
 import { AttachmentBar } from './AttachmentBar.js';
@@ -21,12 +22,15 @@ export type { InputBoxProps };
  * - Down arrow: navigate history forwards (newer entries / back to current)
  * - Disabled state during streaming
  */
+const MAX_SUGGESTIONS = 6;
+
 export function InputBox({
   agent,
   agentColor,
   disabled,
   onSubmit,
   isFocused,
+  commands = [],
 }: InputBoxProps): React.JSX.Element {
   const [value, setValue] = useState('');
   // history[0] = oldest, history[history.length-1] = newest
@@ -35,12 +39,33 @@ export function InputBox({
   const [historyIndex, setHistoryIndex] = useState(-1);
   // Saved current input before we started navigating history
   const savedInputRef = useRef('');
+  // Autocomplete selection index (-1 = none selected)
+  const [selectedSuggestion, setSelectedSuggestion] = useState(-1);
 
   // Clipboard image paste (Ctrl+V interception)
   useClipboardImage({ enabled: isFocused && !disabled });
   const { pending, clearAll: clearAttachments } = useAttachments();
 
-  // Handle Up/Down arrow keys + Escape for history navigation and attachment clearing.
+  // Autocomplete: compute filtered suggestions when value starts with '/'
+  const suggestions: SlashCommand[] = useMemo(() => {
+    if (!value.startsWith('/') || value.includes(' ')) {
+      return [];
+    }
+    const partial = value.slice(1).toLowerCase();
+    if (partial.length === 0) {
+      // Show all commands when just '/' is typed
+      return commands.slice(0, MAX_SUGGESTIONS);
+    }
+    return commands
+      .filter(
+        (cmd) =>
+          cmd.name.toLowerCase().startsWith(partial) ||
+          (cmd.aliases?.some((a) => a.toLowerCase().startsWith(partial)) ?? false)
+      )
+      .slice(0, MAX_SUGGESTIONS);
+  }, [value, commands]);
+
+  // Handle Up/Down arrow keys, Tab for autocomplete, and Escape.
   // useInput fires even when TextInput is focused (we guard with isFocused + !disabled).
   useInput(
     (_input, key) => {
@@ -48,13 +73,42 @@ export function InputBox({
         return;
       }
 
-      // Escape — clear attachments when they exist
-      if (key.escape && pending.length > 0) {
-        clearAttachments();
+      // Escape — dismiss autocomplete, or clear attachments
+      if (key.escape) {
+        if (suggestions.length > 0 && selectedSuggestion >= 0) {
+          setSelectedSuggestion(-1);
+          return;
+        }
+        if (pending.length > 0) {
+          clearAttachments();
+          return;
+        }
+        return;
+      }
+
+      // Tab — autocomplete navigation / acceptance
+      if (key.tab && suggestions.length > 0) {
+        if (key.shift) {
+          // Shift+Tab — move selection up
+          setSelectedSuggestion((prev) => (prev <= 0 ? suggestions.length - 1 : prev - 1));
+        } else if (selectedSuggestion >= 0) {
+          // Tab with active selection — accept the suggestion
+          const chosen = suggestions[selectedSuggestion];
+          setValue(`/${chosen.name} `);
+          setSelectedSuggestion(-1);
+        } else {
+          // Tab with no selection — select first
+          setSelectedSuggestion(0);
+        }
         return;
       }
 
       if (key.upArrow) {
+        // If autocomplete is showing, navigate suggestions
+        if (suggestions.length > 0) {
+          setSelectedSuggestion((prev) => (prev <= 0 ? suggestions.length - 1 : prev - 1));
+          return;
+        }
         if (history.length === 0) {
           return;
         }
@@ -70,6 +124,11 @@ export function InputBox({
         }
         // At oldest entry — stay
       } else if (key.downArrow) {
+        // If autocomplete is showing, navigate suggestions
+        if (suggestions.length > 0) {
+          setSelectedSuggestion((prev) => (prev >= suggestions.length - 1 ? 0 : prev + 1));
+          return;
+        }
         if (historyIndex === -1) {
           return;
         }
@@ -91,6 +150,8 @@ export function InputBox({
     (val: string) => {
       if (!disabled) {
         setValue(val);
+        // Reset autocomplete selection when user types
+        setSelectedSuggestion(-1);
         // Typing while in history navigation resets the navigation index
         if (historyIndex !== -1) {
           setHistoryIndex(-1);
@@ -103,6 +164,14 @@ export function InputBox({
 
   const handleSubmit = useCallback(
     (text: string) => {
+      // If a suggestion is selected and Enter is pressed, accept the suggestion
+      if (selectedSuggestion >= 0 && suggestions.length > 0) {
+        const chosen = suggestions[selectedSuggestion];
+        setValue(`/${chosen.name} `);
+        setSelectedSuggestion(-1);
+        return;
+      }
+
       const trimmed = text.trim();
       if (!trimmed || disabled) {
         return;
@@ -117,9 +186,10 @@ export function InputBox({
       setHistoryIndex(-1);
       savedInputRef.current = '';
       setValue('');
+      setSelectedSuggestion(-1);
       onSubmit(trimmed);
     },
-    [disabled, onSubmit]
+    [disabled, onSubmit, selectedSuggestion, suggestions]
   );
 
   if (disabled) {
@@ -155,6 +225,30 @@ export function InputBox({
       borderRight={false}
     >
       <AttachmentBar />
+      {/* Autocomplete suggestion list */}
+      {suggestions.length > 0 && (
+        <Box flexDirection="column" paddingX={1}>
+          {suggestions.map((cmd, idx) => {
+            const isSelected = idx === selectedSuggestion;
+            const aliases = cmd.aliases?.length ? ` (${cmd.aliases.join(', ')})` : '';
+            return (
+              <Text key={cmd.name}>
+                <Text color={isSelected ? agentColor : 'gray'} bold={isSelected}>
+                  {isSelected ? '❯ ' : '  '}
+                </Text>
+                <Text color={isSelected ? agentColor : 'white'} bold={isSelected}>
+                  /{cmd.name}
+                </Text>
+                <Text color="gray">{aliases}</Text>
+                <Text color="gray" dimColor>
+                  {' '}
+                  {cmd.description}
+                </Text>
+              </Text>
+            );
+          })}
+        </Box>
+      )}
       <Box paddingX={1}>
         <Text color={agentColor} bold>
           {agent} ❯{' '}

--- a/src/cli/tui/hooks/useKeyboard.ts
+++ b/src/cli/tui/hooks/useKeyboard.ts
@@ -5,6 +5,8 @@ import { useKeybind } from '../context/KeybindContext.js';
 import { useDialog } from '../context/DialogContext.js';
 import { useChat } from '../context/ChatContext.js';
 import type { ModelGroup } from '../dialogs/ModelPicker.js';
+import type { SlashCommand } from './useCommands.js';
+import type { CommandEntry } from '../components/CommandPalette.js';
 
 // ---------------------------------------------------------------------------
 // Static model groups (same constant as in useCommands.ts)
@@ -54,6 +56,8 @@ export interface UseKeyboardOptions {
   onNewSession: () => void;
   /** Whether the input box is currently accepting text input (i.e. NOT in leader mode) */
   isInputActive: boolean;
+  /** Available slash commands (passed to command palette when opened via Ctrl+K) */
+  commands?: SlashCommand[];
 }
 
 // ---------------------------------------------------------------------------
@@ -61,7 +65,7 @@ export interface UseKeyboardOptions {
 // ---------------------------------------------------------------------------
 
 export function useKeyboard(options: UseKeyboardOptions): void {
-  const { onExit, onClear, onNewSession } = options;
+  const { onExit, onClear, onNewSession, commands = [] } = options;
 
   const { cycleAgent } = useSession();
   const { state: keybindState, activateLeader, deactivateLeader } = useKeybind();
@@ -89,7 +93,12 @@ export function useKeyboard(options: UseKeyboardOptions): void {
 
     // Ctrl+K — open command palette
     if (key.ctrl && input === 'k') {
-      open('command-palette', { commands: [] }).catch(() => {
+      const paletteCommands: CommandEntry[] = commands.map((cmd) => ({
+        name: cmd.name,
+        description: cmd.description,
+        category: cmd.category,
+      }));
+      open('command-palette', { commands: paletteCommands }).catch(() => {
         // user cancelled — no-op
       });
       return;

--- a/src/cli/tui/types/props.ts
+++ b/src/cli/tui/types/props.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ImageAttachmentPreview } from '../context/AttachmentContext.js';
+import type { SlashCommand } from '../hooks/useCommands.js';
 
 // ---------------------------------------------------------------------------
 // Header & StatusBar  (from contracts/app-layout.ts)
@@ -44,6 +45,8 @@ export interface InputBoxProps {
   onSubmit: (text: string) => void;
   /** Whether this component has focus */
   isFocused: boolean;
+  /** Available slash commands for inline autocomplete */
+  commands?: SlashCommand[];
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/cli/tui/InputBox.test.tsx
+++ b/tests/cli/tui/InputBox.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../../../src/cli/tui/context/AttachmentContext.js', () => ({
 }));
 
 import { InputBox } from '../../../src/cli/tui/components/InputBox.js';
+import type { SlashCommand } from '../../../src/cli/tui/hooks/useCommands.js';
 import { ThemeProvider } from '../../../src/cli/tui/context/ThemeContext.js';
 
 /** Wrap component in ThemeProvider since AttachmentBar uses useTheme(). */
@@ -95,5 +96,87 @@ describe('InputBox', () => {
       </Wrapper>
     );
     expect(lastFrame()).not.toContain('Type a message or /command');
+  });
+
+  describe('autocomplete', () => {
+    const mockCommands: SlashCommand[] = [
+      {
+        name: 'help',
+        aliases: ['h'],
+        description: 'Show available commands',
+        category: 'general',
+        execute: async () => true,
+      },
+      {
+        name: 'exit',
+        aliases: ['quit', 'q'],
+        description: 'Exit the TUI',
+        category: 'general',
+        execute: async () => true,
+      },
+      {
+        name: 'model',
+        description: 'Show or switch the current model',
+        category: 'model',
+        execute: async () => true,
+      },
+      {
+        name: 'agent',
+        description: 'Show or switch the current agent',
+        category: 'session',
+        execute: async () => true,
+      },
+    ];
+
+    it('renders without crashing when commands prop is provided', () => {
+      const { lastFrame } = render(
+        <Wrapper>
+          <InputBox {...defaultProps} commands={mockCommands} />
+        </Wrapper>
+      );
+      expect(lastFrame()).toContain('code');
+      expect(lastFrame()).toContain('❯');
+    });
+
+    it('does not show suggestions when input is empty', () => {
+      const { lastFrame } = render(
+        <Wrapper>
+          <InputBox {...defaultProps} commands={mockCommands} />
+        </Wrapper>
+      );
+      const frame = lastFrame() ?? '';
+      // None of the command names should appear as suggestions
+      expect(frame).not.toContain('/help');
+      expect(frame).not.toContain('/exit');
+    });
+
+    it('renders with commands prop and shows placeholder', () => {
+      const { lastFrame } = render(
+        <Wrapper>
+          <InputBox {...defaultProps} commands={mockCommands} />
+        </Wrapper>
+      );
+      expect(lastFrame()).toContain('Type a message or /command');
+    });
+
+    it('accepts empty commands array without errors', () => {
+      expect(() => {
+        render(
+          <Wrapper>
+            <InputBox {...defaultProps} commands={[]} />
+          </Wrapper>
+        );
+      }).not.toThrow();
+    });
+
+    it('accepts undefined commands without errors', () => {
+      expect(() => {
+        render(
+          <Wrapper>
+            <InputBox {...defaultProps} />
+          </Wrapper>
+        );
+      }).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Fix slash command leak**: Slash commands (`/help`, `/model`, `/exit`, etc.) were being sent directly to the LLM instead of being intercepted. The `useCommands` hook was fully implemented but never imported into `App.tsx`. Now all 11 slash commands are properly intercepted.
- **Add inline autocomplete**: When typing `/` in the input box, a filtered suggestion list appears showing matching commands with descriptions. Navigate with Up/Down/Tab, accept with Enter/Tab.
- **Populate Command Palette**: `Ctrl+K` now opens the command palette with all registered commands instead of an empty array.

## Changes

| File | What |
|------|------|
| `src/cli/tui/App.tsx` | Import `useCommands`, intercept `/` commands in `handleSubmit`, pass `commands` to `InputBox` and `useKeyboard` |
| `src/cli/tui/components/InputBox.tsx` | Add autocomplete UI with `useMemo` filtering, Tab/Arrow navigation, and suggestion rendering |
| `src/cli/tui/hooks/useKeyboard.ts` | Accept `commands` option, map `SlashCommand[]` → `CommandEntry[]` for `Ctrl+K` palette |
| `src/cli/tui/types/props.ts` | Add optional `commands?: SlashCommand[]` to `InputBoxProps` |
| `tests/cli/tui/InputBox.test.tsx` | Add 5 tests for autocomplete prop handling |

## Testing

- All 1493 tests pass
- TypeScript: clean
- ESLint: 0 new errors (999 pre-existing warnings)