### PR TITLE
feat(cli): add /memory command for instruction file management

### DIFF
--- a/src/agent/system.ts
+++ b/src/agent/system.ts
@@ -6,13 +6,14 @@
  *   2. Model-specific instructions
  *   3. Environment info
  *   4. Agent role prompt
- *   5. AGENTS.md (project-specific instructions)
+ *   5. Instruction files (AGENTS.md, ~/.alexi/ALEXI.md, .alexi/rules/*.md)
  *   6. Custom rules (user-provided)
  *
  * Each layer is optional and only included when applicable.
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
 
@@ -121,20 +122,59 @@ function buildEnvBlock(info: EnvInfo): string {
 }
 
 // ---------------------------------------------------------------------------
-// AGENTS.md loading
+// Instruction file loading (AGENTS.md, ALEXI.md, .alexi/rules/)
 // ---------------------------------------------------------------------------
 
-function loadAgentsMd(workdir: string): string {
+/** Load a single text file, returning empty string on failure. */
+function loadTextFile(filePath: string): string {
   try {
-    const agentsMdPath = path.join(workdir, 'AGENTS.md');
-    const content = fs.readFileSync(agentsMdPath, 'utf-8').trim();
-    if (content) {
-      return `<agents-md>\n${content}\n</agents-md>`;
+    return fs.readFileSync(filePath, 'utf-8').trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Load all instruction files and return them as a combined tagged block.
+ *
+ * Sources (in order):
+ *   1. Project-level AGENTS.md  (workdir/AGENTS.md)
+ *   2. User-level ALEXI.md     (~/.alexi/ALEXI.md)
+ *   3. Project-level rule files (workdir/.alexi/rules/*.md)
+ */
+function loadInstructionFiles(workdir: string): string {
+  const parts: string[] = [];
+
+  // 1. Project AGENTS.md
+  const agentsMd = loadTextFile(path.join(workdir, 'AGENTS.md'));
+  if (agentsMd) {
+    parts.push(`<agents-md>\n${agentsMd}\n</agents-md>`);
+  }
+
+  // 2. User-level ~/.alexi/ALEXI.md
+  const userMd = loadTextFile(path.join(os.homedir(), '.alexi', 'ALEXI.md'));
+  if (userMd) {
+    parts.push(`<user-instructions>\n${userMd}\n</user-instructions>`);
+  }
+
+  // 3. Project .alexi/rules/*.md
+  const rulesDir = path.join(workdir, '.alexi', 'rules');
+  try {
+    const ruleFiles = fs
+      .readdirSync(rulesDir)
+      .filter((f) => f.endsWith('.md'))
+      .sort();
+    for (const rf of ruleFiles) {
+      const content = loadTextFile(path.join(rulesDir, rf));
+      if (content) {
+        parts.push(`<rule file="${rf}">\n${content}\n</rule>`);
+      }
     }
   } catch {
-    // AGENTS.md doesn't exist — that's fine
+    // rules directory doesn't exist — that's fine
   }
-  return '';
+
+  return parts.join('\n\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -152,7 +192,7 @@ export interface AssembleOptions {
   customRules?: string;
   /** Whether to skip environment info block (useful for tests). */
   skipEnv?: boolean;
-  /** Whether to skip AGENTS.md loading (useful for tests). */
+  /** Whether to skip instruction file loading — AGENTS.md, ALEXI.md, rules (useful for tests). */
   skipAgentsMd?: boolean;
 }
 
@@ -164,7 +204,7 @@ export interface AssembleOptions {
  *   2. Model-specific prompt (based on modelId)
  *   3. Environment info block
  *   4. Agent role prompt (based on agentId)
- *   5. AGENTS.md content (if present in workdir)
+ *   5. Instruction files (AGENTS.md, ~/.alexi/ALEXI.md, .alexi/rules/*.md)
  *   6. Custom rules (user-provided)
  */
 export function buildAssembledSystemPrompt(options: AssembleOptions = {}): string {
@@ -212,11 +252,11 @@ export function buildAssembledSystemPrompt(options: AssembleOptions = {}): strin
     }
   }
 
-  // 5. AGENTS.md
+  // 5. Instruction files (AGENTS.md, ALEXI.md, .alexi/rules/)
   if (!options.skipAgentsMd) {
-    const agentsMd = loadAgentsMd(workdir);
-    if (agentsMd) {
-      parts.push(agentsMd);
+    const instructions = loadInstructionFiles(workdir);
+    if (instructions) {
+      parts.push(instructions);
     }
   }
 

--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -227,10 +227,20 @@ function printHelp(): void {
     c('yellow', '  /remember <text>') +
       c('gray', '   - Save a memory (use #tags for categorization)')
   );
-  console.log(c('yellow', '  /memory') + c('gray', '            - List all memories'));
-  console.log(c('yellow', '  /memory search <q>') + c('gray', ' - Search memories by text or tag'));
-  console.log(c('yellow', '  /memory stats') + c('gray', '      - Show memory statistics'));
-  console.log(c('yellow', '  /memory export') + c('gray', '     - Export memories to JSON'));
+  console.log(c('yellow', '  /mem') + c('gray', '               - List all stored memories'));
+  console.log(c('yellow', '  /mem search <q>') + c('gray', '    - Search memories by text or tag'));
+  console.log(c('yellow', '  /mem stats') + c('gray', '         - Show memory statistics'));
+  console.log(c('yellow', '  /mem export') + c('gray', '        - Export memories to JSON'));
+  console.log();
+  console.log(c('cyan', '  Instruction Files:'));
+  console.log();
+  console.log(
+    c('yellow', '  /memory') + c('gray', '            - List instruction files (AGENTS.md, etc.)')
+  );
+  console.log(
+    c('yellow', '  /memory edit [target]') + c('gray', ' - Open instruction file in $EDITOR')
+  );
+  console.log(c('yellow', '  /memory init') + c('gray', '       - Create AGENTS.md from template'));
   console.log();
   console.log(c('cyan', '  Data & Export:'));
   console.log();
@@ -1047,7 +1057,7 @@ async function handleCommand(input: string, state: ReplState): Promise<boolean> 
       return true;
     }
 
-    case 'memory': {
+    case 'mem': {
       const memoryManager = getMemoryManager();
       const subCmd = args[0]?.toLowerCase();
 
@@ -1124,9 +1134,165 @@ async function handleCommand(input: string, state: ReplState): Promise<boolean> 
         console.log(c('green', `\n  Memories exported to: ${exportPath}\n`));
       } else {
         console.log(
-          c('yellow', '\n  Usage: /memory [list|search <query>|delete <id>|clear|stats|export]\n')
+          c('yellow', '\n  Usage: /mem [list|search <query>|delete <id>|clear|stats|export]\n')
         );
       }
+      return true;
+    }
+
+    case 'memory': {
+      // Claude-like /memory command: list & edit instruction files
+      const subCmd = args[0]?.toLowerCase();
+      const workdir = process.cwd();
+
+      // Gather all instruction file paths
+      const instructionFiles: { label: string; filePath: string; exists: boolean }[] = [];
+
+      // 1. Project-level AGENTS.md
+      const agentsMdPath = path.join(workdir, 'AGENTS.md');
+      instructionFiles.push({
+        label: 'Project instructions',
+        filePath: agentsMdPath,
+        exists: fs.existsSync(agentsMdPath),
+      });
+
+      // 2. User-level ~/.alexi/ALEXI.md
+      const userMdPath = path.join(os.homedir(), '.alexi', 'ALEXI.md');
+      instructionFiles.push({
+        label: 'User instructions',
+        filePath: userMdPath,
+        exists: fs.existsSync(userMdPath),
+      });
+
+      // 3. Project-level .alexi/rules/*.md
+      const rulesDir = path.join(workdir, '.alexi', 'rules');
+      if (fs.existsSync(rulesDir)) {
+        const ruleFiles = fs
+          .readdirSync(rulesDir)
+          .filter((f) => f.endsWith('.md'))
+          .sort();
+        for (const rf of ruleFiles) {
+          instructionFiles.push({
+            label: `Rule: ${rf}`,
+            filePath: path.join(rulesDir, rf),
+            exists: true,
+          });
+        }
+      }
+
+      if (subCmd === 'edit') {
+        // /memory edit [project|user|<filename>]
+        const target = args[1]?.toLowerCase();
+        let targetFile: string | undefined;
+
+        if (!target || target === 'project') {
+          targetFile = agentsMdPath;
+        } else if (target === 'user') {
+          // Ensure ~/.alexi/ directory exists
+          const alexiDir = path.join(os.homedir(), '.alexi');
+          if (!fs.existsSync(alexiDir)) {
+            fs.mkdirSync(alexiDir, { recursive: true });
+          }
+          targetFile = userMdPath;
+        } else {
+          // Try to match a rule file or exact path
+          const match = instructionFiles.find(
+            (f) => f.filePath.endsWith(target) || f.label.toLowerCase().includes(target)
+          );
+          targetFile = match?.filePath;
+        }
+
+        if (!targetFile) {
+          console.log(c('red', `\n  Unknown target: ${args[1]}\n`));
+          console.log(c('dim', '  Usage: /memory edit [project|user|<filename>]'));
+          return true;
+        }
+
+        // Create file if it doesn't exist
+        if (!fs.existsSync(targetFile)) {
+          const dir = path.dirname(targetFile);
+          if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+          }
+          const header =
+            targetFile === agentsMdPath
+              ? '# AGENTS.md\n\nProject-specific instructions for AI agents.\n'
+              : targetFile === userMdPath
+                ? '# ALEXI.md\n\nUser-level instructions loaded into every session.\n'
+                : '# Rule\n\nScoped rule file.\n';
+          fs.writeFileSync(targetFile, header);
+          console.log(c('green', `\n  Created: ${targetFile}`));
+        }
+
+        // Open in $EDITOR / $VISUAL / vi
+        const editor = process.env.VISUAL || process.env.EDITOR || 'vi';
+        console.log(c('dim', `\n  Opening ${targetFile} in ${editor}...`));
+        try {
+          execSync(`${editor} "${targetFile}"`, { stdio: 'inherit' });
+          console.log(c('green', '  File saved. Changes will take effect on next prompt.\n'));
+        } catch {
+          console.log(c('red', `\n  Failed to open editor: ${editor}\n`));
+        }
+        return true;
+      }
+
+      if (subCmd === 'init') {
+        // /memory init — create AGENTS.md from template if missing
+        if (fs.existsSync(agentsMdPath)) {
+          console.log(c('yellow', `\n  AGENTS.md already exists at: ${agentsMdPath}\n`));
+          console.log(c('dim', '  Use /memory edit project to modify it.'));
+        } else {
+          const template = [
+            '# AGENTS.md',
+            '',
+            '## Project Overview',
+            '',
+            'Describe your project here so AI agents understand the codebase.',
+            '',
+            '## Build & Test Commands',
+            '',
+            '```bash',
+            'npm run build',
+            'npm test',
+            '```',
+            '',
+            '## Code Style',
+            '',
+            '- Add your coding conventions here',
+            '',
+            '## Important Notes',
+            '',
+            '- Add project-specific rules for the AI agent',
+            '',
+          ].join('\n');
+          fs.writeFileSync(agentsMdPath, template);
+          console.log(c('green', `\n  Created AGENTS.md at: ${agentsMdPath}`));
+          console.log(c('dim', '  Use /memory edit project to customize it.\n'));
+        }
+        return true;
+      }
+
+      // Default: /memory — list all instruction files
+      console.log(c('cyan', '\n  Instruction Files:\n'));
+      for (let i = 0; i < instructionFiles.length; i++) {
+        const f = instructionFiles[i];
+        const status = f.exists ? c('green', '[loaded]') : c('dim', '[not found]');
+        const num = c('yellow', `  ${i + 1}.`);
+        console.log(`${num} ${status} ${c('gray', f.label)}`);
+        console.log(c('dim', `     ${f.filePath}`));
+      }
+
+      // Show potential rules directory
+      if (!fs.existsSync(rulesDir)) {
+        console.log(c('dim', `\n  Rules directory not found: ${rulesDir}`));
+        console.log(c('dim', '  Create .alexi/rules/*.md for scoped instruction files.'));
+      }
+
+      console.log();
+      console.log(c('cyan', '  Commands:'));
+      console.log(c('dim', '    /memory edit [project|user]  - Open file in $EDITOR'));
+      console.log(c('dim', '    /memory init                 - Create AGENTS.md from template'));
+      console.log();
       return true;
     }
 

--- a/src/cli/tui/hooks/useCommands.ts
+++ b/src/cli/tui/hooks/useCommands.ts
@@ -288,6 +288,29 @@ function buildCommands(deps: BuildCommandsDeps): SlashCommand[] {
         return true;
       },
     },
+
+    // /memory --------------------------------------------------------------
+    {
+      name: 'memory',
+      description: 'List instruction files (AGENTS.md, ALEXI.md)',
+      category: 'config',
+      execute: async (_args, _ctx) => {
+        // TUI cannot open $EDITOR; signal handled and let the TUI
+        // render a status message. Full editing is in the REPL.
+        return true;
+      },
+    },
+
+    // /mem ------------------------------------------------------------------
+    {
+      name: 'mem',
+      description: 'List stored memories (JSON key-value)',
+      category: 'config',
+      execute: async (_args, _ctx) => {
+        // TUI stub — full memory management is in the REPL.
+        return true;
+      },
+    },
   ];
 }
 

--- a/src/sync/analyzer.ts
+++ b/src/sync/analyzer.ts
@@ -83,6 +83,7 @@ export const OUR_FEATURES = {
     '/template',
     '/cost',
     '/memory',
+    '/mem',
     '/doctor',
     '/config',
     '/compact',


### PR DESCRIPTION
## Summary

- Implement Claude-like `/memory` command that manages project and user instruction files (`AGENTS.md`, `~/.alexi/ALEXI.md`, `.alexi/rules/*.md`)
- Rename existing JSON memory command from `/memory` to `/mem` to avoid collision
- Load all instruction file sources into the system prompt via new `loadInstructionFiles()` function

## Changes

### New `/memory` command (`src/cli/interactive.ts`)
- `/memory` — Lists all instruction files with `[loaded]` / `[not found]` status and file paths
- `/memory edit [project|user|<filename>]` — Opens file in `$VISUAL`/`$EDITOR`/`vi`, creates file with template if missing
- `/memory init` — Scaffolds `AGENTS.md` from a starter template

### System prompt updates (`src/agent/system.ts`)
- Replaced `loadAgentsMd()` with `loadInstructionFiles()` which loads 3 sources:
  1. `AGENTS.md` (project root) → `<agents-md>` tags
  2. `~/.alexi/ALEXI.md` (user-level) → `<user-instructions>` tags
  3. `.alexi/rules/*.md` (scoped rules) → `<rule file="name.md">` tags
- All sources injected as layer 5 of the 6-layer system prompt

### TUI stubs (`src/cli/tui/hooks/useCommands.ts`)
- Added `/memory` and `/mem` stub commands (TUI cannot spawn `$EDITOR`)

### Other
- Added `/mem` to sync analyzer known commands list (`src/sync/analyzer.ts`)

## Verification
- **Typecheck**: ✅ `tsc --noEmit` passes
- **Lint**: ✅ No new warnings or errors
- **Tests**: ✅ All 80 files, 1494 tests pass