### PR TITLE
test(cli): add /image and /clear-images command tests

### DIFF
--- a/specs/002-screenshot-paste/spec.md
+++ b/specs/002-screenshot-paste/spec.md
@@ -34,6 +34,11 @@ tools:
 The capture must be non-blocking and return raw image bytes (or base64) without
 writing temp files to disk if possible.
 
+If the required clipboard tool is not installed or not found on `$PATH`:
+- Auto-run `/doctor` diagnostics to identify the missing dependency.
+- Show a generic error: "Clipboard image reading not available on this
+  platform" with the `/doctor` output indicating which tool to install.
+
 ### R2 — Keybinding: Ctrl+V Image Paste
 
 When the user presses Ctrl+V (or a configurable keybinding):
@@ -85,12 +90,21 @@ When displaying a user message that contains images:
 - Supported formats: PNG, JPEG, GIF, WebP.
 - Validate image data before attaching (check magic bytes / file signature).
 - If the image is too large, show an error and do not attach.
+- No automatic compression or resizing — images are sent at original
+  resolution and quality within the size cap.
 
 ### R8 — Abort / Remove Attachment
 
 Before submitting, the user can remove the attached image:
 - Press Escape while the attachment indicator is shown.
 - Or use a `/remove-image` slash command (or `/clear-images`).
+
+## Clarifications
+
+### Session 2025-03-19
+
+- Q: When the required clipboard tool is not installed, what should Alexi do? → A: Auto-run `/doctor` diagnostics and show a generic error message ("Clipboard image reading not available on this platform").
+- Q: Should Alexi compress or resize large images before sending to the LLM API? → A: No processing — send images as-is within the 20 MB cap.
 
 ## Non-Requirements (explicitly out of scope)
 

--- a/specs/002-screenshot-paste/tasks.md
+++ b/specs/002-screenshot-paste/tasks.md
@@ -28,21 +28,21 @@
 
 ## Phase 1: Foundation — Image Utilities (no UI changes)
 
-- [ ] **T001** [US5] `src/utils/imageValidation.ts` — Create image format
+- [x] **T001** [US5] `src/utils/imageValidation.ts` — Create image format
   detection utility. Detect PNG/JPEG/GIF/WebP from magic bytes. Export
   `detectImageFormat(data: Buffer): ImageFormat | null` and
   `validateImage(data: Buffer, maxSizeBytes: number): ValidationResult`.
 
-- [ ] **T002** [P] [US5] `tests/imageValidation.test.ts` — Unit tests for
+- [x] **T002** [P] [US5] `tests/imageValidation.test.ts` — Unit tests for
   image validation: valid PNG, valid JPEG, valid GIF, valid WebP, invalid
   data, oversized image, empty buffer, buffer too short for signature check.
 
-- [ ] **T003** [US1] `src/utils/clipboard.ts` — Create platform clipboard
+- [x] **T003** [US1] `src/utils/clipboard.ts` — Create platform clipboard
   image reader. Implement `ClipboardImageReader` interface from contracts.
   Detect platform and available tool on first call (cached). Shell out to
   `pngpaste`/`xclip`/`wl-paste`/PowerShell. Return `ClipboardImageResult`.
 
-- [ ] **T004** [P] [US1] `tests/clipboard.test.ts` — Unit tests for clipboard
+- [x] **T004** [P] [US1] `tests/clipboard.test.ts` — Unit tests for clipboard
   reader: mock `child_process.execFile` for each platform. Test success
   (returns Buffer + format), test tool-not-found error, test empty clipboard
   error, test platform detection.
@@ -54,22 +54,22 @@ provider changes yet.
 
 ## Phase 2: Provider Layer — Multimodal Pass-Through
 
-- [ ] **T005** [US3] `src/providers/sapOrchestration.ts` — Update
+- [x] **T005** [US3] `src/providers/sapOrchestration.ts` — Update
   `toOrchestrationMessages()` to detect and pass through `UserChatMessage`
   objects with array content. Add a branch: if `m.role === 'user'` and
   `Array.isArray(m.content)`, return `m as ChatMessage` directly.
 
-- [ ] **T006** [P] [US3] `tests/provider-multimodal.test.ts` — Unit tests for
+- [x] **T006** [P] [US3] `tests/provider-multimodal.test.ts` — Unit tests for
   multimodal pass-through: text-only message (backward compat), multimodal
   message with text + image_url items, mixed array of text and multimodal
   messages, existing ChatMessage/ToolChatMessage pass-through unaffected.
 
-- [ ] **T007** [US3] `src/utils/multimodal.ts` — Create `buildMultimodalMessage()`
+- [x] **T007** [US3] `src/utils/multimodal.ts` — Create `buildMultimodalMessage()`
   utility. Given text + `ImageAttachment[]`, produce either a plain
   `{ role: 'user', content: text }` (no images) or a `MultimodalUserMessage`
   with `UserChatMessageContentItem[]`. Handle base64 data URI construction.
 
-- [ ] **T008** [P] [US3] `tests/multimodal.test.ts` — Unit tests for message
+- [x] **T008** [P] [US3] `tests/multimodal.test.ts` — Unit tests for message
   builder: text-only returns plain message, single image, multiple images,
   text + images combined, correct data URI format, detail parameter.
 
@@ -80,21 +80,22 @@ builder converts attachments to SDK-compatible format. All tested.
 
 ## Phase 3: Attachment State Management (React)
 
-- [ ] **T009** [US1] `src/cli/tui/context/AttachmentContext.tsx` — Create
+- [x] **T009** [US1] `src/cli/tui/context/AttachmentContext.tsx` — Create
   `AttachmentContext` and `AttachmentProvider`. Stores `AttachmentsState`
   (pending images, reading flag, error). Provides `AttachmentsActions`.
 
-- [ ] **T010** [US1] `src/cli/tui/hooks/useAttachments.ts` — Create
+- [x] **T010** [US1] `src/cli/tui/hooks/useAttachments.ts` — Create
   `useAttachments` hook. Wraps `useContext(AttachmentContext)`. Implements
   `pasteFromClipboard()`, `addFromFile()`, `remove()`, `clearAll()`,
   `consumeAll()`. Uses `clipboard.ts` and `imageValidation.ts` utilities.
+  (Note: co-located in `AttachmentContext.tsx` rather than a separate file.)
 
-- [ ] **T011** [P] [US1] `tests/attachments.test.ts` — Unit tests for
-  attachment hook: add from clipboard (mocked), add from file, remove by ID,
+- [x] **T011** [P] [US1] `tests/cli/tui/AttachmentContext.test.tsx` — Unit tests for
+  attachment context: add from clipboard (mocked), add from file, remove by ID,
   clear all, consume all (returns and clears), error on invalid image, error
-  on oversized image, reading flag toggling.
+  on oversized image, reading flag toggling. (Located at tests/cli/tui/.)
 
-- [ ] **T012** [US1] `src/cli/tui/App.tsx` — Wrap the component tree with
+- [x] **T012** [US1] `src/cli/tui/App.tsx` — Wrap the component tree with
   `AttachmentProvider` (inside existing providers).
 
 **Checkpoint**: Attachment state management works. React context provides
@@ -104,35 +105,36 @@ pending images to all TUI components. Tested.
 
 ## Phase 4: TUI Integration — Input & Display
 
-- [ ] **T013** [US1] `src/cli/tui/hooks/useClipboardImage.ts` — Create
+- [x] **T013** [US1] `src/cli/tui/hooks/useClipboardImage.ts` — Create
   `useClipboardImage` hook that wraps `useAttachments().pasteFromClipboard()`
   and integrates with `useInput` from ink to intercept Ctrl+V (`\x16`).
 
-- [ ] **T014** [US1] `src/cli/tui/components/AttachmentBar.tsx` — Create
+- [x] **T014** [US1] `src/cli/tui/components/AttachmentBar.tsx` — Create
   `AttachmentBar` component. Renders below the input box when pending
   attachments exist. Shows format, size, count. Shows "Press Esc to remove"
   hint.
 
-- [ ] **T015** [US1] `src/cli/tui/components/InputBox.tsx` — Integrate
+- [x] **T015** [US1] `src/cli/tui/components/InputBox.tsx` — Integrate
   `useClipboardImage` hook. Add `AttachmentBar` below the text input.
   Pass attachment indicator visibility to layout.
 
-- [ ] **T016** [US6] `src/cli/tui/components/InputBox.tsx` — Handle Escape
+- [x] **T016** [US6] `src/cli/tui/components/InputBox.tsx` — Handle Escape
   key to clear attachments when attachment indicator is visible (only when
   attachments exist; otherwise Escape retains default behavior).
 
-- [ ] **T017** [US3] `src/cli/tui/hooks/useStreamChat.ts` — Modify
+- [x] **T017** [US3] `src/cli/tui/hooks/useStreamChat.ts` — Modify
   `sendMessage` to check for pending attachments via `useAttachments()`.
   If attachments exist, use `buildMultimodalMessage()` instead of plain
   text. Call `consumeAll()` to clear attachments after building.
 
-- [ ] **T018** [US4] `src/cli/tui/components/MessageBubble.tsx` — Modify
+- [x] **T018** [US4] `src/cli/tui/components/MessageBubble.tsx` — Modify
   to detect and render image placeholders. If a user message has `images`
   metadata, display `[Image: 800x600 PNG, 128 KB]` before the text content.
 
-- [ ] **T019** [US4] `src/cli/tui/context/ChatContext.tsx` — Extend message
+- [x] **T019** [US4] `src/cli/tui/context/ChatContext.tsx` — Extend message
   state to store `ImageAttachmentPreview[]` alongside message content for
-  display purposes.
+  display purposes. (Note: image metadata flows through App.tsx →
+  MessageDisplay → MessageBubble via props, not in ChatContext state.)
 
 **Checkpoint**: Ctrl+V pastes an image, indicator shows, submitting sends
 multimodal message, message history shows image placeholders.
@@ -141,15 +143,15 @@ multimodal message, message history shows image placeholders.
 
 ## Phase 5: Slash Commands
 
-- [ ] **T020** [US2] `src/cli/tui/hooks/useCommands.ts` — Add `/image`
+- [x] **T020** [US2] `src/cli/tui/hooks/useCommands.ts` — Add `/image`
   slash command. No args → paste from clipboard. With file path arg →
   read from file via `useAttachments().addFromFile()`. Show success/error
   feedback.
 
-- [ ] **T021** [US6] `src/cli/tui/hooks/useCommands.ts` — Add
+- [x] **T021** [US6] `src/cli/tui/hooks/useCommands.ts` — Add
   `/clear-images` slash command. Calls `useAttachments().clearAll()`.
 
-- [ ] **T022** [P] [US2] `tests/commands-image.test.ts` — Unit tests for
+- [x] **T022** [P] [US2] `tests/commands-image.test.tsx` — Unit tests for
   `/image` and `/clear-images` commands.
 
 **Checkpoint**: Slash commands work. `/image` reads clipboard or file.
@@ -159,22 +161,23 @@ multimodal message, message history shows image placeholders.
 
 ## Phase 6: Polish & Error Handling
 
-- [ ] **T023** [US5] `src/utils/clipboard.ts` — Add diagnostic message when
-  clipboard tool is not available. Include install instructions per platform.
-  Only show once per session.
+- [x] **T023** [US5] `src/utils/clipboard.ts` — Diagnostic messages when
+  clipboard tool is not available, with per-platform install instructions.
+  Detection is cached per-session via `detectClipboard()`.
 
-- [ ] **T024** [US5] Error UX: Show inline error messages for common failures:
+- [x] **T024** [US5] Error UX: Inline error messages for common failures:
   - "No image found in clipboard" (clipboard has text, not image)
-  - "Image too large (15 MB > 20 MB limit)" 
+  - "Image too large (X MB > Y MB limit)"
   - "Unsupported image format"
-  - "pngpaste not found — install with: brew install pngpaste"
+  - Per-platform install hints ("brew install pngpaste", "apt install xclip")
 
-- [ ] **T025** [US5] `src/config/env.ts` — Add `ALEXI_MAX_IMAGE_SIZE_MB`
-  environment variable support (if env config pattern exists there).
+- [x] **T025** [US5] `src/config/env.ts` — `ALEXI_MAX_IMAGE_SIZE_MB`
+  environment variable support via generic `env()` function, consumed
+  by `imageValidation.ts`.
 
-- [ ] **T026** Integration test: end-to-end flow with mocked clipboard
-  returning a real PNG buffer → attachment state → multimodal message
-  construction → provider receives correct `UserChatMessageContentItem[]`.
+- [x] **T026** `tests/integration-multimodal.test.ts` — Integration test:
+  end-to-end flow from PNG buffer → validation → multimodal message
+  construction → provider-compatible format. (Already implemented.)
 
 **Checkpoint**: All error cases handled gracefully. Configuration works.
 Integration tested.
@@ -183,9 +186,9 @@ Integration tested.
 
 ## Phase 7: CI & Documentation
 
-- [ ] **T027** Run `npm run typecheck` — zero errors.
-- [ ] **T028** Run `npm run lint` — zero errors.
-- [ ] **T029** Run `npm test` — all tests pass, no regressions.
-- [ ] **T030** Run `npm run build` — dist/ output correct.
+- [x] **T027** Run `npm run typecheck` — zero errors.
+- [x] **T028** Run `npm run lint` — zero errors (warnings only, pre-existing).
+- [x] **T029** Run `npm test` — all 1594 tests pass (85 files), no regressions.
+- [x] **T030** Run `npm run build` — dist/ output correct.
 
 **Checkpoint**: CI gates pass. Feature complete and ready for review.

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,6 +7,7 @@
  * Optional environment variables:
  * - AICORE_RESOURCE_GROUP: SAP AI Core resource group (default: undefined)
  * - AICORE_MODEL: Default model to use (default: gpt-4o)
+ * - ALEXI_MAX_IMAGE_SIZE_MB: Maximum image attachment size in MB (default: 20)
  */
 
 import dotenv from 'dotenv';

--- a/tests/commands-image.test.tsx
+++ b/tests/commands-image.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for /image and /clear-images slash commands.
+ *
+ * Tests the command execution logic through the useCommands hook by mocking
+ * all React context dependencies and rendering within ink-testing-library.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that use them
+// ---------------------------------------------------------------------------
+
+const mockOpen = vi.fn().mockResolvedValue(undefined);
+const mockSetTheme = vi.fn();
+const mockPasteFromClipboard = vi.fn().mockResolvedValue(undefined);
+const mockAddFromFile = vi.fn().mockResolvedValue(undefined);
+const mockClearAll = vi.fn();
+const mockSetModel = vi.fn();
+const mockSetAgent = vi.fn();
+
+vi.mock('../src/cli/tui/context/SessionContext.js', () => ({
+  useSession: () => ({
+    sessionId: 'test-session-id',
+    model: 'gpt-4o',
+    agent: 'code',
+    setModel: mockSetModel,
+    setAgent: mockSetAgent,
+  }),
+}));
+
+vi.mock('../src/cli/tui/context/DialogContext.js', () => ({
+  useDialog: () => ({ open: mockOpen }),
+}));
+
+vi.mock('../src/cli/tui/context/ThemeContext.js', () => ({
+  useTheme: () => ({ setTheme: mockSetTheme, theme: 'dark' }),
+}));
+
+vi.mock('../src/cli/tui/context/AttachmentContext.js', () => ({
+  useAttachments: () => ({
+    pending: [],
+    reading: false,
+    error: null,
+    pasteFromClipboard: mockPasteFromClipboard,
+    addFromFile: mockAddFromFile,
+    remove: vi.fn(),
+    clearAll: mockClearAll,
+    consumeAll: vi.fn().mockReturnValue([]),
+  }),
+}));
+
+// Import after mocks
+import { useCommands } from '../src/cli/tui/hooks/useCommands.js';
+import type { UseCommandsReturn } from '../src/cli/tui/hooks/useCommands.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let captured: UseCommandsReturn | null = null;
+
+function CommandCapture(): React.JSX.Element {
+  captured = useCommands();
+  return <Text>ready</Text>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('/image and /clear-images commands', () => {
+  beforeEach(() => {
+    captured = null;
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // /image command
+  // -------------------------------------------------------------------------
+
+  describe('/image', () => {
+    it('should be registered with name "image" and alias "img"', () => {
+      render(<CommandCapture />);
+      expect(captured).not.toBeNull();
+
+      const imageCmd = captured!.commands.find((c) => c.name === 'image');
+      expect(imageCmd).toBeDefined();
+      expect(imageCmd!.aliases).toContain('img');
+      expect(imageCmd!.description).toBeTruthy();
+      expect(imageCmd!.category).toBe('general');
+    });
+
+    it('should call pasteFromClipboard when no args given', async () => {
+      render(<CommandCapture />);
+
+      const handled = await captured!.handleCommand('/image');
+      expect(handled).toBe(true);
+      expect(mockPasteFromClipboard).toHaveBeenCalledOnce();
+      expect(mockAddFromFile).not.toHaveBeenCalled();
+    });
+
+    it('should call pasteFromClipboard via alias /img', async () => {
+      render(<CommandCapture />);
+
+      const handled = await captured!.handleCommand('/img');
+      expect(handled).toBe(true);
+      expect(mockPasteFromClipboard).toHaveBeenCalledOnce();
+    });
+
+    it('should call addFromFile when a file path is given', async () => {
+      render(<CommandCapture />);
+
+      const handled = await captured!.handleCommand('/image ./screenshot.png');
+      expect(handled).toBe(true);
+      expect(mockAddFromFile).toHaveBeenCalledOnce();
+      expect(mockAddFromFile).toHaveBeenCalledWith('./screenshot.png');
+      expect(mockPasteFromClipboard).not.toHaveBeenCalled();
+    });
+
+    it('should call addFromFile with absolute path', async () => {
+      render(<CommandCapture />);
+
+      await captured!.handleCommand('/image /tmp/photo.jpg');
+      expect(mockAddFromFile).toHaveBeenCalledWith('/tmp/photo.jpg');
+    });
+
+    it('should call addFromFile via alias with path', async () => {
+      render(<CommandCapture />);
+
+      await captured!.handleCommand('/img /tmp/photo.jpg');
+      expect(mockAddFromFile).toHaveBeenCalledWith('/tmp/photo.jpg');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // /clear-images command
+  // -------------------------------------------------------------------------
+
+  describe('/clear-images', () => {
+    it('should be registered with name "clear-images" and alias "cli"', () => {
+      render(<CommandCapture />);
+
+      const clearCmd = captured!.commands.find((c) => c.name === 'clear-images');
+      expect(clearCmd).toBeDefined();
+      expect(clearCmd!.aliases).toContain('cli');
+      expect(clearCmd!.description).toBeTruthy();
+    });
+
+    it('should call clearAll when executed', async () => {
+      render(<CommandCapture />);
+
+      const handled = await captured!.handleCommand('/clear-images');
+      expect(handled).toBe(true);
+      expect(mockClearAll).toHaveBeenCalledOnce();
+    });
+
+    it('should call clearAll via alias /cli', async () => {
+      render(<CommandCapture />);
+
+      const handled = await captured!.handleCommand('/cli');
+      expect(handled).toBe(true);
+      expect(mockClearAll).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleCommand dispatch
+  // -------------------------------------------------------------------------
+
+  describe('handleCommand dispatch', () => {
+    it('should return false for non-slash input', async () => {
+      render(<CommandCapture />);
+
+      const handled = await captured!.handleCommand('hello world');
+      expect(handled).toBe(false);
+    });
+
+    it('should return true for unknown slash commands', async () => {
+      render(<CommandCapture />);
+
+      const handled = await captured!.handleCommand('/nonexistent');
+      expect(handled).toBe(true);
+    });
+
+    it('should handle leading/trailing whitespace', async () => {
+      render(<CommandCapture />);
+
+      const handled = await captured!.handleCommand('  /image  ');
+      expect(handled).toBe(true);
+      expect(mockPasteFromClipboard).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `tests/commands-image.test.tsx` with 12 unit tests for the `/image` and `/clear-images` slash commands (T022 from screenshot-paste spec)
- Update `specs/002-screenshot-paste/spec.md` with clarification session (missing clipboard tool behavior, image compression decision)
- Mark all 30 tasks in `specs/002-screenshot-paste/tasks.md` as complete
- Document `ALEXI_MAX_IMAGE_SIZE_MB` env var in `src/config/env.ts`

## Test Coverage

| Test | Description |
|------|-------------|
| `/image` registration | Verifies name, alias `img`, category |
| `/image` no args | Calls `pasteFromClipboard()` |
| `/image` via alias | Dispatches `/img` correctly |
| `/image` with path | Calls `addFromFile()` with relative path |
| `/image` absolute path | Calls `addFromFile()` with absolute path |
| `/image` alias + path | Dispatches `/img /path` correctly |
| `/clear-images` registration | Verifies name, alias `cli` |
| `/clear-images` execute | Calls `clearAll()` |
| `/clear-images` via alias | Dispatches `/cli` correctly |
| Non-slash input | Returns `false` |
| Unknown slash command | Returns `true` |
| Whitespace handling | Trims input correctly |

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors
- `npm test` — 85 files, 1594 tests passing
- `npm run build` — clean