### PR TITLE
docs: update TESTING.md, CONFIGURATION.md, CONTRIBUTING.md, CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-03-19
+
+### Added
+
+- Unit tests for TUI slash commands (`/image` and `/clear-images`)
+  - Tests command registration with correct names and aliases
+  - Tests clipboard paste functionality when no arguments provided
+  - Tests file path handling for image attachments
+  - Uses ink-testing-library with React context mocking
+  - Comprehensive coverage of command dispatch logic
+- Support for graceful tree-sitter parser initialization failures
+  - Parser functions now return null instead of throwing when Parser is unavailable
+  - Enables operation in environments without native bindings
+
+### Changed
+
+- Enhanced user configuration API with batch update support
+  - Added `updateGlobal()` function for atomic multi-key updates
+  - Added `UpdateGlobalOptions` interface with disposal control
+  - Maintains backward compatibility with default dispose behavior
+- Edit tool now preserves line endings during replacements
+  - Automatically detects CRLF vs LF line endings in target files
+  - Normalizes oldString and newString parameters to match file format
+  - Ensures consistent line ending style throughout edited files
+
+### Fixed
+
+- Tree-sitter parser initialization no longer fails in environments without native support
+- Edit tool correctly handles multiline replacements with different line ending styles
+
 ## [0.2.5] - 2026-03-19
 
 ### Added
@@ -156,7 +186,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rule-based configuration system
 - Autonomous self-updating from upstream repositories
 
-[Unreleased]: https://github.com/ausardcompany/alexi/compare/v0.2.5...HEAD
+[Unreleased]: https://github.com/ausardcompany/alexi/compare/v0.2.6...HEAD
+[0.2.6]: https://github.com/ausardcompany/alexi/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/ausardcompany/alexi/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/ausardcompany/alexi/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/ausardcompany/alexi/compare/v0.2.2...v0.2.3

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,6 +48,14 @@ Default model to use when no model is specified. Can be overridden by user confi
 export AICORE_MODEL=gpt-4o
 ```
 
+#### ALEXI_MAX_IMAGE_SIZE_MB
+
+Maximum size in megabytes for image attachments. Defaults to 20MB if not specified.
+
+```bash
+export ALEXI_MAX_IMAGE_SIZE_MB=20
+```
+
 #### SAP_PROXY_BASE_URL
 
 Base URL for OpenAI-compatible proxy endpoint (for proxy mode).
@@ -164,7 +172,40 @@ function deleteConfigValue(key: string): void
 // Typed accessors
 function getConfigDefaultModel(): string | undefined
 function setConfigDefaultModel(model: string): void
+
+// Batch update with options
+interface UpdateGlobalOptions {
+  dispose?: boolean;
+}
+
+function updateGlobal(
+  updates: Partial<Record<string, unknown>>,
+  options?: UpdateGlobalOptions
+): void
 ```
+
+#### Batch Configuration Updates
+
+The `updateGlobal` function allows updating multiple configuration keys atomically:
+
+```typescript
+import { updateGlobal } from './config/userConfig.js';
+
+// Update multiple settings at once
+updateGlobal({
+  defaultModel: 'gpt-4o',
+  soundEnabled: false,
+  autoRoute: true
+});
+
+// Update with disposal control
+updateGlobal(
+  { defaultModel: 'anthropic--claude-4.5-sonnet' },
+  { dispose: false }
+);
+```
+
+The `dispose` option controls whether cached configuration instances should be disposed after update. Default behavior preserves backward compatibility with `dispose: true`.
 
 ## Routing Configuration
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -199,6 +199,28 @@ graph LR
    const value = context && context.workdir ? context.workdir : process.cwd();
    ```
 
+6. **Graceful Degradation**: Handle optional dependencies gracefully
+   ```typescript
+   // Good - Return null if initialization fails
+   function getTsParser(): Parser | null {
+     if (!Parser) {
+       return null;
+     }
+     if (!tsParser) {
+       tsParser = new Parser();
+       tsParser.setLanguage(TypeScript.typescript);
+     }
+     return tsParser;
+   }
+   
+   // Usage - Check for null before using
+   const parser = getTsParser();
+   if (!parser) {
+     return null; // Skip parsing, don't fail
+   }
+   const tree = parser.parse(source);
+   ```
+
 ### File Organization
 
 ```
@@ -305,7 +327,66 @@ npm test -- --coverage
 
 # Watch mode
 npm test -- --watch
+
+# Run TUI command tests
+npm test -- tests/commands-image.test.tsx
+
+# Run tests matching a pattern
+npm test -- --grep "line endings"
 ```
+
+### Testing TUI Commands
+
+TUI commands require special testing patterns with React context mocking:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+
+// Mock contexts BEFORE importing hooks
+const mockPasteFromClipboard = vi.fn().mockResolvedValue(undefined);
+const mockAddFromFile = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../src/cli/tui/context/AttachmentContext.js', () => ({
+  useAttachments: () => ({
+    pasteFromClipboard: mockPasteFromClipboard,
+    addFromFile: mockAddFromFile,
+    clearAll: vi.fn(),
+  }),
+}));
+
+// Import AFTER mocks
+import { useCommands } from '../src/cli/tui/hooks/useCommands.js';
+
+describe('TUI commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should handle /image command', async () => {
+    let captured;
+    function CommandCapture() {
+      captured = useCommands();
+      return <Text>ready</Text>;
+    }
+    
+    render(<CommandCapture />);
+    
+    const handled = await captured.handleCommand('/image ./photo.png');
+    expect(handled).toBe(true);
+    expect(mockAddFromFile).toHaveBeenCalledWith('./photo.png');
+  });
+});
+```
+
+Key principles for TUI testing:
+1. Mock all React contexts before importing hooks
+2. Use ink-testing-library for rendering
+3. Capture hook return values through a component
+4. Clear mocks between tests with vi.clearAllMocks()
+5. Test both command dispatch and context interactions
 
 ## Pull Request Process
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -230,6 +230,14 @@ All file operation tools have comprehensive test coverage:
 | `glob` | `tests/tool/tools/glob.test.ts` | 16+ cases |
 | `grep` | `tests/tool/tools/grep.test.ts` | 20+ cases |
 
+### TUI Command Test Coverage
+
+TUI slash commands are tested through the `useCommands` hook with React context mocking:
+
+| Command | Test File | Test Cases |
+|---------|-----------|------------|
+| `/image`, `/clear-images` | `tests/commands-image.test.tsx` | 10+ cases |
+
 ### Test Categories
 
 Each tool is tested across multiple categories:
@@ -255,6 +263,56 @@ Each tool is tested across multiple categories:
    - Correct tool names
    - Description presence
    - Schema generation
+
+5. **Line Ending Preservation** (Edit Tool)
+   - Detect and preserve CRLF vs LF line endings
+   - Normalize parameters to match file's line ending style
+   - Ensure replacements maintain original file format
+
+#### Testing Line Ending Preservation
+
+The edit tool preserves line endings when performing replacements:
+
+```typescript
+describe('edit tool line endings', () => {
+  it('should preserve CRLF line endings', async () => {
+    // Create file with CRLF endings
+    const content = 'line1\r\nline2\r\nline3\r\n';
+    await fs.writeFile(filePath, content, 'utf-8');
+
+    // Perform edit with LF in parameters
+    const result = await editTool.execute({
+      filePath,
+      oldString: 'line2\n',
+      newString: 'modified\n'
+    }, context);
+
+    expect(result.success).toBe(true);
+
+    // Verify CRLF preserved in output
+    const updated = await fs.readFile(filePath, 'utf-8');
+    expect(updated).toContain('\r\n');
+    expect(updated).toBe('line1\r\nmodified\r\nline3\r\n');
+  });
+
+  it('should preserve LF line endings', async () => {
+    const content = 'line1\nline2\nline3\n';
+    await fs.writeFile(filePath, content, 'utf-8');
+
+    const result = await editTool.execute({
+      filePath,
+      oldString: 'line2',
+      newString: 'modified'
+    }, context);
+
+    expect(result.success).toBe(true);
+
+    const updated = await fs.readFile(filePath, 'utf-8');
+    expect(updated).not.toContain('\r\n');
+    expect(updated).toBe('line1\nmodified\nline3\n');
+  });
+});
+```
 
 ## Testing Providers
 
@@ -473,6 +531,77 @@ describe('tool metadata', () => {
   });
 });
 ```
+
+### 8. Test TUI Commands with Context Mocking
+
+TUI commands require mocking React contexts and using ink-testing-library:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+
+// Mock contexts before importing hooks
+const mockPasteFromClipboard = vi.fn().mockResolvedValue(undefined);
+const mockAddFromFile = vi.fn().mockResolvedValue(undefined);
+const mockClearAll = vi.fn();
+
+vi.mock('../src/cli/tui/context/AttachmentContext.js', () => ({
+  useAttachments: () => ({
+    pending: [],
+    reading: false,
+    error: null,
+    pasteFromClipboard: mockPasteFromClipboard,
+    addFromFile: mockAddFromFile,
+    clearAll: mockClearAll,
+  }),
+}));
+
+// Import after mocks
+import { useCommands } from '../src/cli/tui/hooks/useCommands.js';
+
+describe('/image command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call pasteFromClipboard when no args given', async () => {
+    let captured;
+    function CommandCapture() {
+      captured = useCommands();
+      return <Text>ready</Text>;
+    }
+    
+    render(<CommandCapture />);
+    
+    const handled = await captured.handleCommand('/image');
+    expect(handled).toBe(true);
+    expect(mockPasteFromClipboard).toHaveBeenCalledOnce();
+  });
+
+  it('should call addFromFile when path provided', async () => {
+    let captured;
+    function CommandCapture() {
+      captured = useCommands();
+      return <Text>ready</Text>;
+    }
+    
+    render(<CommandCapture />);
+    
+    await captured.handleCommand('/image ./screenshot.png');
+    expect(mockAddFromFile).toHaveBeenCalledWith('./screenshot.png');
+  });
+});
+```
+
+Key patterns for TUI command testing:
+
+1. **Mock Before Import**: Declare all vi.mock() calls before importing the hook
+2. **Capture Hook Return**: Use a component to capture the hook's return value
+3. **Render with Ink**: Use ink-testing-library's render() function
+4. **Test Command Dispatch**: Call handleCommand() and verify behavior
+5. **Clear Mocks**: Use vi.clearAllMocks() in beforeEach()
 
 ## Testing with SAP AI Core
 


### PR DESCRIPTION
## Summary

Auto-generated documentation from PR #71 (screenshot paste command tests). The documentation workflow completed successfully but pushed after the PR was auto-merged, so these doc changes need a separate PR.

### Files Updated
- `docs/TESTING.md` — Updated with new `commands-image.test.tsx` test coverage
- `docs/CONFIGURATION.md` — Updated with `ALEXI_MAX_IMAGE_SIZE_MB` env var documentation
- `docs/CONTRIBUTING.md` — Updated contributing guidelines
- `CHANGELOG.md` — Updated with PR #71 entry