### PR TITLE
feat: [provider] Wire agent observability headers into provider API calls (#334)

### DIFF
--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -9,6 +9,7 @@ import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
 import { type EffortLevel, getEffortConfig, DEFAULT_EFFORT } from './effortLevel.js';
 import { buildAssembledSystemPrompt } from '../agent/system.js';
+import { buildSessionHeaders } from '../providers/sessionHeaders.js';
 
 export interface StreamingOptions {
   modelOverride?: string;
@@ -114,6 +115,15 @@ export async function* streamChat(
   // Get SAP Orchestration provider for this model
   const provider = getProviderForModel(modelId);
 
+  // Build agent observability headers
+  const sessionId = options?.sessionManager?.getCurrentSession()?.metadata.id;
+  const extraHeaders = buildSessionHeaders(
+    sessionId ?? 'anonymous',
+    undefined,
+    options?.agentId,
+    undefined // parentAgentId - future enhancement
+  );
+
   let fullText = '';
   let finalUsage: StreamingResult['usage'];
 
@@ -122,6 +132,7 @@ export async function* streamChat(
     maxTokens: options?.maxTokens ?? effortConfig.maxTokens,
     temperature: options?.temperature,
     signal: options?.signal,
+    headers: extraHeaders as Record<string, string>,
   })) {
     fullText += chunk.text;
     if (chunk.usage) finalUsage = chunk.usage;

--- a/src/providers/sapOrchestration.ts
+++ b/src/providers/sapOrchestration.ts
@@ -303,6 +303,8 @@ export interface CompletionOptions {
   tools?: ChatCompletionTool[];
   /** Override tool choice for this call */
   toolChoice?: OrchestrationConfig['toolChoice'];
+  /** Extra HTTP headers to include in the request (e.g. agent observability headers) */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -663,9 +665,12 @@ export class SapOrchestrationProvider {
     const client = this.createClient(options);
     const orchestrationMessages = toOrchestrationMessages(messages);
 
-    const response = await client.chatCompletion({
-      messages: orchestrationMessages,
-    });
+    const requestConfig = options?.headers ? { headers: options.headers } : undefined;
+
+    const response = await client.chatCompletion(
+      { messages: orchestrationMessages },
+      requestConfig
+    );
 
     const tokenUsage = response.getTokenUsage();
     const toolCalls = response.getToolCalls();
@@ -733,7 +738,13 @@ export class SapOrchestrationProvider {
     const orchestrationMessages = toOrchestrationMessages(messages);
 
     // Use SAP SDK streaming with AbortSignal support
-    const response = await client.stream({ messages: orchestrationMessages }, options?.signal);
+    const requestConfig = options?.headers ? { headers: options.headers } : undefined;
+    const response = await client.stream(
+      { messages: orchestrationMessages },
+      options?.signal,
+      undefined,
+      requestConfig
+    );
 
     // Stream chunks using the iterator
     for await (const chunk of response.stream) {

--- a/tests/streamingOrchestratorHeaders.test.ts
+++ b/tests/streamingOrchestratorHeaders.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock dependencies before importing the module
+vi.mock('../src/providers/index.js', () => ({
+  getProviderForModel: vi.fn(),
+  getDefaultModel: vi.fn(),
+}));
+
+vi.mock('../src/core/router.js', () => ({
+  routePrompt: vi.fn(),
+}));
+
+// Import after mocking
+import { streamChat } from '../src/core/streamingOrchestrator.js';
+import { getProviderForModel, getDefaultModel } from '../src/providers/index.js';
+import { SessionManager } from '../src/core/sessionManager.js';
+
+// Helper to create a mock provider that captures options passed to streamComplete
+function createMockStreamProvider(chunks: Array<{ text: string; usage?: Record<string, number> }>) {
+  const streamCompleteFn = vi.fn().mockImplementation(function* () {
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  });
+
+  return {
+    streamComplete: streamCompleteFn,
+  };
+}
+
+describe('Streaming Orchestrator - Agent Observability Headers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDefaultModel).mockReturnValue('gpt-4o');
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should pass x-alexi-agent-id header when agentId is provided', async () => {
+    const mockProvider = createMockStreamProvider([
+      { text: 'Hello', usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } },
+    ]);
+
+    vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+
+    const gen = streamChat('Test message', { agentId: 'code' });
+
+    // Drain the generator
+    let next = await gen.next();
+    while (!next.done) {
+      next = await gen.next();
+    }
+    const result = next.value;
+
+    expect(result.modelUsed).toBe('gpt-4o');
+
+    // Verify streamComplete was called with headers containing agent ID
+    const callOptions = mockProvider.streamComplete.mock.calls[0][1];
+    expect(callOptions.headers).toBeDefined();
+    expect(callOptions.headers['x-alexi-agent-id']).toBe('code');
+  });
+
+  it('should use session ID for x-session-affinity when sessionManager is provided', async () => {
+    const mockProvider = createMockStreamProvider([
+      { text: 'Response', usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 } },
+    ]);
+
+    vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+
+    const sessionManager = new SessionManager();
+    sessionManager.createSession('gpt-4o');
+    const sessionId = sessionManager.getCurrentSession()?.metadata.id;
+
+    const gen = streamChat('Test', { sessionManager, agentId: 'debug' });
+
+    // Drain the generator
+    let next = await gen.next();
+    while (!next.done) {
+      next = await gen.next();
+    }
+
+    const callOptions = mockProvider.streamComplete.mock.calls[0][1];
+    expect(callOptions.headers['x-session-affinity']).toBe(sessionId);
+    expect(callOptions.headers['x-alexi-agent-id']).toBe('debug');
+  });
+
+  it('should use "anonymous" for session affinity when no sessionManager is provided', async () => {
+    const mockProvider = createMockStreamProvider([
+      { text: 'Hi', usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 } },
+    ]);
+
+    vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+
+    const gen = streamChat('Test', { agentId: 'explore' });
+
+    // Drain the generator
+    let next = await gen.next();
+    while (!next.done) {
+      next = await gen.next();
+    }
+
+    const callOptions = mockProvider.streamComplete.mock.calls[0][1];
+    expect(callOptions.headers['x-session-affinity']).toBe('anonymous');
+    expect(callOptions.headers['x-alexi-agent-id']).toBe('explore');
+  });
+
+  it('should omit x-alexi-agent-id when agentId is not provided', async () => {
+    const mockProvider = createMockStreamProvider([
+      { text: 'Response', usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 } },
+    ]);
+
+    vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+
+    const gen = streamChat('Test');
+
+    // Drain the generator
+    let next = await gen.next();
+    while (!next.done) {
+      next = await gen.next();
+    }
+
+    const callOptions = mockProvider.streamComplete.mock.calls[0][1];
+    // x-session-affinity should always be present
+    expect(callOptions.headers['x-session-affinity']).toBe('anonymous');
+    // agent-id should NOT be present when agentId is not passed
+    expect(callOptions.headers['x-alexi-agent-id']).toBeUndefined();
+  });
+
+  it('should not include x-alexi-parent-agent-id (future enhancement)', async () => {
+    const mockProvider = createMockStreamProvider([
+      { text: 'Hi', usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 } },
+    ]);
+
+    vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+
+    const gen = streamChat('Test', { agentId: 'code' });
+
+    // Drain the generator
+    let next = await gen.next();
+    while (!next.done) {
+      next = await gen.next();
+    }
+
+    const callOptions = mockProvider.streamComplete.mock.calls[0][1];
+    expect(callOptions.headers['x-alexi-parent-agent-id']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation of #334 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 3
- **Branch**: `auto/334-provider-wire-agent-observability-headers-into-pro`
- **Model**: `sap-ai-core/anthropic--claude-4.6-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #334
