### PR TITLE
feat: [config] Hook rejection feedback loop (continueOnBlock) (#348)

### DIFF
--- a/src/core/agenticChat.ts
+++ b/src/core/agenticChat.ts
@@ -23,6 +23,7 @@ import { type EffortLevel, getEffortConfig, DEFAULT_EFFORT } from './effortLevel
 import { buildAssembledSystemPrompt } from '../agent/system.js';
 import { initReferenceService, getReferenceService } from '../reference/reference.js';
 import { initRepositoryCache } from '../reference/repository-cache.js';
+import { executeHooks, createHookContext } from '../hooks/index.js';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -480,6 +481,9 @@ export async function agenticChat(
       });
 
       // Execute each tool call
+      let hookBlocked = false;
+      let hookBlockHalt = false;
+
       for (const toolCall of result.toolCalls) {
         const { id, result: toolResult } = await executeToolCall(
           toolCall as ToolCall,
@@ -494,12 +498,64 @@ export async function agenticChat(
           error: toolResult.error,
         });
 
-        // Add tool response to messages
-        messages.push({
-          role: 'tool',
-          tool_call_id: id,
-          content: JSON.stringify(toolResult),
-        });
+        // Invoke PostToolUse hooks after tool execution
+        const hookResults = await executeHooks(
+          'PostToolUse',
+          createHookContext('PostToolUse', {
+            toolName: toolCall.function.name,
+            toolResult: toolResult,
+          })
+        );
+
+        // Check if any hook blocked the execution
+        const blockingResult = hookResults.find((hr) => hr.blocked);
+        if (blockingResult) {
+          const rejectionMessage = `[Hook Rejection] ${blockingResult.error || blockingResult.output || 'Tool execution rejected by hook'}`;
+
+          if (blockingResult.continueOnBlock) {
+            // Feed rejection back to model as tool error and continue
+            messages.push({
+              role: 'tool',
+              tool_call_id: id,
+              content: JSON.stringify({
+                success: false,
+                error: rejectionMessage,
+              }),
+            });
+            hookBlocked = true;
+          } else {
+            // Halt: add tool response then break out
+            messages.push({
+              role: 'tool',
+              tool_call_id: id,
+              content: JSON.stringify({
+                success: false,
+                error: rejectionMessage,
+              }),
+            });
+            hookBlockHalt = true;
+            finalText = rejectionMessage;
+            break;
+          }
+        } else {
+          // No blocking — add normal tool response to messages
+          messages.push({
+            role: 'tool',
+            tool_call_id: id,
+            content: JSON.stringify(toolResult),
+          });
+        }
+      }
+
+      // If a hook halted execution, break the outer loop
+      if (hookBlockHalt) {
+        break;
+      }
+
+      // If a hook blocked with continueOnBlock, the rejection is already
+      // in the messages — continue the loop so the LLM can self-correct
+      if (hookBlocked) {
+        // Continue loop to let LLM process the rejection feedback
       }
 
       // Continue loop to let LLM process tool results

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -51,6 +51,8 @@ export interface HookDefinition {
   timeout?: number; // Max execution time in ms, default 30000
   enabled?: boolean; // Default true
   description?: string; // Human-readable description
+  /** When true, feed rejection back to model instead of halting */
+  continueOnBlock?: boolean;
 }
 
 export interface HookContext {
@@ -70,6 +72,10 @@ export interface HookResult {
   output?: string;
   error?: string;
   duration: number;
+  /** True when hook explicitly rejected the tool execution */
+  blocked?: boolean;
+  /** Mirrors the hook's continueOnBlock setting for consumer convenience */
+  continueOnBlock?: boolean;
 }
 
 // Zod schemas for validation
@@ -93,6 +99,10 @@ export const HookDefinitionSchema = z.object({
   timeout: z.number().positive().optional(),
   enabled: z.boolean().optional(),
   description: z.string().optional(),
+  continueOnBlock: z
+    .boolean()
+    .optional()
+    .describe('When true, feed rejection back to model instead of halting'),
 });
 
 export const HookContextSchema = z.object({
@@ -507,6 +517,12 @@ export class HookManagerImpl implements HookManager {
           error: `Hook execution error: ${err instanceof Error ? err.message : String(err)}`,
           duration: 0,
         };
+      }
+
+      // Mark blocked results with the hook's continueOnBlock preference
+      if (!result.success) {
+        result.blocked = true;
+        result.continueOnBlock = hook.continueOnBlock ?? false;
       }
 
       results.push(result);

--- a/tests/hooks/continueOnBlock.test.ts
+++ b/tests/hooks/continueOnBlock.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Tests for hook continueOnBlock feature
+ *
+ * Verifies that PostToolUse hook rejections are handled correctly:
+ * - continueOnBlock: true feeds error back to model and continues
+ * - continueOnBlock: false (default) halts the agent turn
+ * - Successful hooks don't affect flow
+ * - Multiple hooks with mixed blocking behavior
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { CompletionResult } from '../../src/providers/sapOrchestration.js';
+
+// Mock memory module (dynamic import)
+vi.mock('../../src/core/memory.js', () => ({
+  getMemoryManager: vi.fn(() => ({
+    getContextString: vi.fn().mockReturnValue(''),
+  })),
+}));
+
+// Mock session context module (dynamic import)
+vi.mock('../../src/core/sessionContext.js', () => ({
+  getSessionContextString: vi.fn().mockReturnValue(''),
+}));
+
+// Mock the providers module
+vi.mock('../../src/providers/index.js', () => ({
+  getProviderForModel: vi.fn(),
+  getDefaultModel: vi.fn(() => 'gpt-4o'),
+}));
+
+// Mock the router
+vi.mock('../../src/core/router.js', () => ({
+  routePrompt: vi.fn(() => ({
+    modelId: 'gpt-4o',
+    reason: 'test routing',
+    confidence: 0.9,
+  })),
+}));
+
+// Mock the cost tracker
+vi.mock('../../src/core/costTracker.js', () => ({
+  getCostTracker: vi.fn(() => ({
+    recordUsage: vi.fn(),
+  })),
+}));
+
+// Mock the tool registry
+const mockToolRegistry = {
+  list: vi.fn(),
+  get: vi.fn(),
+};
+
+vi.mock('../../src/tool/index.js', () => ({
+  getToolRegistry: () => mockToolRegistry,
+  registerTool: vi.fn(),
+}));
+
+// Mock registerBuiltInTools
+vi.mock('../../src/tool/tools/index.js', () => ({
+  registerBuiltInTools: vi.fn(),
+}));
+
+// Mock hooks module
+const mockExecuteHooks = vi.fn();
+const mockCreateHookContext = vi.fn();
+
+vi.mock('../../src/hooks/index.js', () => ({
+  executeHooks: (...args: unknown[]) => mockExecuteHooks(...args),
+  createHookContext: (...args: unknown[]) => mockCreateHookContext(...args),
+}));
+
+import { agenticChat } from '../../src/core/agenticChat.js';
+import { getProviderForModel } from '../../src/providers/index.js';
+
+describe('continueOnBlock', () => {
+  let mockProvider: {
+    complete: ReturnType<typeof vi.fn>;
+  };
+
+  const mockWriteTool = {
+    name: 'write',
+    description: 'Write file',
+    toFunctionSchema: () => ({
+      name: 'write',
+      description: 'Write file',
+      parameters: { type: 'object', properties: {} },
+    }),
+    execute: vi.fn().mockResolvedValue({
+      success: true,
+      data: { written: true },
+    }),
+  };
+
+  beforeEach(() => {
+    mockProvider = {
+      complete: vi.fn(),
+    };
+    vi.mocked(getProviderForModel).mockReturnValue(
+      mockProvider as unknown as ReturnType<typeof getProviderForModel>
+    );
+
+    mockToolRegistry.list.mockReturnValue([mockWriteTool]);
+    mockToolRegistry.get.mockImplementation((name: string) =>
+      name === 'write' ? mockWriteTool : undefined
+    );
+
+    // Default: hooks return success
+    mockExecuteHooks.mockResolvedValue([]);
+    mockCreateHookContext.mockImplementation((event: string, data: unknown) => ({
+      event,
+      timestamp: Date.now(),
+      ...(data as Record<string, unknown>),
+    }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should continue loop when hook blocks with continueOnBlock: true', async () => {
+    // Hook rejects with continueOnBlock: true
+    mockExecuteHooks.mockResolvedValue([
+      {
+        success: false,
+        error: 'Writing to /etc is not allowed',
+        duration: 5,
+        blocked: true,
+        continueOnBlock: true,
+      },
+    ]);
+
+    // First call: LLM wants to write
+    mockProvider.complete.mockResolvedValueOnce({
+      text: '',
+      toolCalls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'write',
+            arguments: '{"filePath": "/etc/passwd", "content": "hack"}',
+          },
+        },
+      ],
+      usage: { prompt_tokens: 50, completion_tokens: 20, total_tokens: 70 },
+    } satisfies CompletionResult);
+
+    // Second call: LLM self-corrects and responds with text
+    mockProvider.complete.mockResolvedValueOnce({
+      text: 'I cannot write to /etc. Let me try a different path.',
+      usage: { prompt_tokens: 80, completion_tokens: 15, total_tokens: 95 },
+    } satisfies CompletionResult);
+
+    const result = await agenticChat('Write hack to /etc/passwd');
+
+    // Should have continued (2 iterations — first with tool call, second with final text)
+    expect(result.iterations).toBe(2);
+    expect(result.text).toBe('I cannot write to /etc. Let me try a different path.');
+
+    // Verify hooks were invoked
+    expect(mockExecuteHooks).toHaveBeenCalledWith('PostToolUse', expect.any(Object));
+    expect(mockCreateHookContext).toHaveBeenCalledWith(
+      'PostToolUse',
+      expect.objectContaining({
+        toolName: 'write',
+      })
+    );
+
+    // Verify the rejection was fed back as a tool message
+    const secondCallMessages = mockProvider.complete.mock.calls[1][0];
+    const toolMessage = secondCallMessages.find(
+      (m: Record<string, unknown>) => m['role'] === 'tool'
+    );
+    expect(toolMessage).toBeDefined();
+    const toolContent = JSON.parse(toolMessage.content);
+    expect(toolContent.success).toBe(false);
+    expect(toolContent.error).toContain('[Hook Rejection]');
+    expect(toolContent.error).toContain('Writing to /etc is not allowed');
+  });
+
+  it('should halt the loop when hook blocks without continueOnBlock', async () => {
+    // Hook rejects with continueOnBlock: false (default)
+    mockExecuteHooks.mockResolvedValue([
+      {
+        success: false,
+        error: 'Security violation: forbidden path',
+        duration: 3,
+        blocked: true,
+        continueOnBlock: false,
+      },
+    ]);
+
+    // First call: LLM wants to write
+    mockProvider.complete.mockResolvedValueOnce({
+      text: '',
+      toolCalls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'write',
+            arguments: '{"filePath": "/etc/shadow", "content": "bad"}',
+          },
+        },
+      ],
+      usage: { prompt_tokens: 50, completion_tokens: 20, total_tokens: 70 },
+    } satisfies CompletionResult);
+
+    const result = await agenticChat('Write to shadow file');
+
+    // Should have halted after first iteration (no second LLM call)
+    expect(result.iterations).toBe(1);
+    expect(result.text).toContain('[Hook Rejection]');
+    expect(result.text).toContain('Security violation: forbidden path');
+
+    // LLM should only have been called once
+    expect(mockProvider.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not affect flow when hooks succeed', async () => {
+    // All hooks pass
+    mockExecuteHooks.mockResolvedValue([
+      {
+        success: true,
+        output: 'Hook passed',
+        duration: 2,
+      },
+    ]);
+
+    // First call: LLM uses write tool
+    mockProvider.complete.mockResolvedValueOnce({
+      text: '',
+      toolCalls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'write',
+            arguments: '{"filePath": "/home/user/file.txt", "content": "hello"}',
+          },
+        },
+      ],
+      usage: { prompt_tokens: 50, completion_tokens: 20, total_tokens: 70 },
+    } satisfies CompletionResult);
+
+    // Second call: LLM responds with text
+    mockProvider.complete.mockResolvedValueOnce({
+      text: 'File written successfully.',
+      usage: { prompt_tokens: 80, completion_tokens: 10, total_tokens: 90 },
+    } satisfies CompletionResult);
+
+    const result = await agenticChat('Write hello to file');
+
+    expect(result.iterations).toBe(2);
+    expect(result.text).toBe('File written successfully.');
+    expect(result.toolCallsExecuted).toBe(1);
+
+    // Tool result should be the normal success result
+    const secondCallMessages = mockProvider.complete.mock.calls[1][0];
+    const toolMessage = secondCallMessages.find(
+      (m: Record<string, unknown>) => m['role'] === 'tool'
+    );
+    expect(toolMessage).toBeDefined();
+    const toolContent = JSON.parse(toolMessage.content);
+    expect(toolContent.success).toBe(true);
+  });
+
+  it('should handle multiple hooks where one blocks and one passes', async () => {
+    // Multiple hooks: first passes, second blocks with continueOnBlock: true
+    mockExecuteHooks.mockResolvedValue([
+      {
+        success: true,
+        output: 'Logging hook passed',
+        duration: 1,
+      },
+      {
+        success: false,
+        error: 'Rate limit exceeded',
+        duration: 2,
+        blocked: true,
+        continueOnBlock: true,
+      },
+    ]);
+
+    // First call: LLM uses write tool
+    mockProvider.complete.mockResolvedValueOnce({
+      text: '',
+      toolCalls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'write',
+            arguments: '{"filePath": "/tmp/test.txt", "content": "data"}',
+          },
+        },
+      ],
+      usage: { prompt_tokens: 50, completion_tokens: 20, total_tokens: 70 },
+    } satisfies CompletionResult);
+
+    // Second call: LLM self-corrects
+    mockProvider.complete.mockResolvedValueOnce({
+      text: 'Rate limit hit, waiting before retry.',
+      usage: { prompt_tokens: 80, completion_tokens: 12, total_tokens: 92 },
+    } satisfies CompletionResult);
+
+    const result = await agenticChat('Write data to file');
+
+    // Should continue because the blocking hook has continueOnBlock: true
+    expect(result.iterations).toBe(2);
+    expect(result.text).toBe('Rate limit hit, waiting before retry.');
+
+    // Rejection message should mention rate limit
+    const secondCallMessages = mockProvider.complete.mock.calls[1][0];
+    const toolMessage = secondCallMessages.find(
+      (m: Record<string, unknown>) => m['role'] === 'tool'
+    );
+    const toolContent = JSON.parse(toolMessage.content);
+    expect(toolContent.error).toContain('Rate limit exceeded');
+  });
+
+  it('should use hook output when error is not available in rejection message', async () => {
+    // Hook rejects with output but no error
+    mockExecuteHooks.mockResolvedValue([
+      {
+        success: false,
+        output: 'Blocked by security policy',
+        duration: 4,
+        blocked: true,
+        continueOnBlock: true,
+      },
+    ]);
+
+    // First call: LLM uses write tool
+    mockProvider.complete.mockResolvedValueOnce({
+      text: '',
+      toolCalls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'write',
+            arguments: '{"filePath": "/tmp/test.txt", "content": "data"}',
+          },
+        },
+      ],
+      usage: { prompt_tokens: 50, completion_tokens: 20, total_tokens: 70 },
+    } satisfies CompletionResult);
+
+    // Second call: LLM responds
+    mockProvider.complete.mockResolvedValueOnce({
+      text: 'Understood, adjusting approach.',
+      usage: { prompt_tokens: 80, completion_tokens: 10, total_tokens: 90 },
+    } satisfies CompletionResult);
+
+    const result = await agenticChat('Write data');
+
+    expect(result.iterations).toBe(2);
+
+    const secondCallMessages = mockProvider.complete.mock.calls[1][0];
+    const toolMessage = secondCallMessages.find(
+      (m: Record<string, unknown>) => m['role'] === 'tool'
+    );
+    const toolContent = JSON.parse(toolMessage.content);
+    expect(toolContent.error).toContain('[Hook Rejection]');
+    expect(toolContent.error).toContain('Blocked by security policy');
+  });
+
+  it('should halt on first blocking hook with continueOnBlock: false even if others have continueOnBlock: true', async () => {
+    // First blocking hook has continueOnBlock: false — should halt
+    mockExecuteHooks.mockResolvedValue([
+      {
+        success: false,
+        error: 'Critical security violation',
+        duration: 1,
+        blocked: true,
+        continueOnBlock: false,
+      },
+      {
+        success: false,
+        error: 'Rate limit (would continue)',
+        duration: 2,
+        blocked: true,
+        continueOnBlock: true,
+      },
+    ]);
+
+    // First call: LLM uses write tool
+    mockProvider.complete.mockResolvedValueOnce({
+      text: '',
+      toolCalls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'write',
+            arguments: '{"filePath": "/etc/passwd", "content": "bad"}',
+          },
+        },
+      ],
+      usage: { prompt_tokens: 50, completion_tokens: 20, total_tokens: 70 },
+    } satisfies CompletionResult);
+
+    const result = await agenticChat('Attempt dangerous write');
+
+    // Should halt — first blocking hook says no continue
+    expect(result.iterations).toBe(1);
+    expect(result.text).toContain('[Hook Rejection]');
+    expect(result.text).toContain('Critical security violation');
+    expect(mockProvider.complete).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation of #348 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 3
- **Branch**: `auto/348-config-hook-rejection-feedback-loop-continueonbloc`
- **Model**: `sap-ai-core/anthropic--claude-4.6-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #348
