### PR TITLE
feat: [config] Add tool filtering to hook definitions (#395)

### DIFF
--- a/src/hooks/__tests__/hooks.test.ts
+++ b/src/hooks/__tests__/hooks.test.ts
@@ -756,4 +756,134 @@ describe('Hooks System', () => {
       expect(results[0].error).toContain('Script error');
     });
   });
+
+  describe('Tool Filtering', () => {
+    it('should only fire hook for matching tool when tools filter is set', async () => {
+      manager.register({
+        event: 'PostToolUse',
+        type: 'command',
+        command: 'echo "write-only"',
+        tools: ['write'],
+      });
+
+      const writeContext: HookContext = {
+        event: 'PostToolUse',
+        timestamp: Date.now(),
+        toolName: 'write',
+      };
+
+      const readContext: HookContext = {
+        event: 'PostToolUse',
+        timestamp: Date.now(),
+        toolName: 'read',
+      };
+
+      const writeResults = await manager.execute('PostToolUse', writeContext);
+      const readResults = await manager.execute('PostToolUse', readContext);
+
+      expect(writeResults).toHaveLength(1);
+      expect(writeResults[0].success).toBe(true);
+      expect(writeResults[0].output?.trim()).toBe('write-only');
+
+      expect(readResults).toHaveLength(0);
+    });
+
+    it('should fire hook for any tool in the tools array', async () => {
+      manager.register({
+        event: 'PreToolUse',
+        type: 'command',
+        command: 'echo "matched"',
+        tools: ['bash', 'write'],
+      });
+
+      const bashContext: HookContext = {
+        event: 'PreToolUse',
+        timestamp: Date.now(),
+        toolName: 'bash',
+      };
+
+      const writeContext: HookContext = {
+        event: 'PreToolUse',
+        timestamp: Date.now(),
+        toolName: 'write',
+      };
+
+      const editContext: HookContext = {
+        event: 'PreToolUse',
+        timestamp: Date.now(),
+        toolName: 'edit',
+      };
+
+      const bashResults = await manager.execute('PreToolUse', bashContext);
+      const writeResults = await manager.execute('PreToolUse', writeContext);
+      const editResults = await manager.execute('PreToolUse', editContext);
+
+      expect(bashResults).toHaveLength(1);
+      expect(bashResults[0].success).toBe(true);
+
+      expect(writeResults).toHaveLength(1);
+      expect(writeResults[0].success).toBe(true);
+
+      expect(editResults).toHaveLength(0);
+    });
+
+    it('should fire hook for all tools when tools field is not set (backward compatible)', async () => {
+      manager.register({
+        event: 'PostToolUse',
+        type: 'command',
+        command: 'echo "no-filter"',
+      });
+
+      const readContext: HookContext = {
+        event: 'PostToolUse',
+        timestamp: Date.now(),
+        toolName: 'read',
+      };
+
+      const bashContext: HookContext = {
+        event: 'PostToolUse',
+        timestamp: Date.now(),
+        toolName: 'bash',
+      };
+
+      const readResults = await manager.execute('PostToolUse', readContext);
+      const bashResults = await manager.execute('PostToolUse', bashContext);
+
+      expect(readResults).toHaveLength(1);
+      expect(readResults[0].success).toBe(true);
+
+      expect(bashResults).toHaveLength(1);
+      expect(bashResults[0].success).toBe(true);
+    });
+
+    it('should fire hook for all tools when tools is an empty array (no filter)', async () => {
+      manager.register({
+        event: 'PostToolUse',
+        type: 'command',
+        command: 'echo "empty-filter"',
+        tools: [],
+      });
+
+      const readContext: HookContext = {
+        event: 'PostToolUse',
+        timestamp: Date.now(),
+        toolName: 'read',
+      };
+
+      const writeContext: HookContext = {
+        event: 'PostToolUse',
+        timestamp: Date.now(),
+        toolName: 'write',
+      };
+
+      const readResults = await manager.execute('PostToolUse', readContext);
+      const writeResults = await manager.execute('PostToolUse', writeContext);
+
+      expect(readResults).toHaveLength(1);
+      expect(readResults[0].success).toBe(true);
+
+      expect(writeResults).toHaveLength(1);
+      expect(writeResults[0].success).toBe(true);
+    });
+  });
 });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -52,6 +52,10 @@ export interface HookDefinition {
   enabled?: boolean; // Default true
   description?: string; // Human-readable description
 
+  // Tool filtering
+  /** When set, restricts this hook to only fire for the specified tool names */
+  tools?: string[];
+
   // Rejection behavior
   /** When true, hook rejection feeds the error back to the model instead of halting */
   continueOnBlock?: boolean;
@@ -101,6 +105,7 @@ export const HookDefinitionSchema = z.object({
   timeout: z.number().positive().optional(),
   enabled: z.boolean().optional(),
   description: z.string().optional(),
+  tools: z.array(z.string()).optional(),
   continueOnBlock: z.boolean().optional(),
 });
 
@@ -517,6 +522,11 @@ export class HookManagerImpl implements HookManager {
     for (const hook of eventHooks) {
       // Skip disabled hooks
       if (hook.enabled === false) {
+        continue;
+      }
+
+      // Skip hooks whose tool filter doesn't match the current tool
+      if (hook.tools && hook.tools.length > 0 && !hook.tools.includes(context.toolName ?? '')) {
         continue;
       }
 


### PR DESCRIPTION
## Summary

Automated implementation of #395 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 2
- **Branch**: `auto/395-config-add-tool-filtering-to-hook-definitions`
- **Model**: `sap-ai-core/anthropic--claude-4.6-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #395
