### PR TITLE
feat: [skill] Honor disallowed-tools frontmatter for skills and slash commands (#504)

### DIFF
--- a/src/command/index.ts
+++ b/src/command/index.ts
@@ -28,6 +28,17 @@ export const CommandSchema = z.object({
   arguments: z.array(CommandArgumentSchema).optional(),
   template: z.string(),
   source: z.string().optional(), // file path if loaded from file
+  /**
+   * Tools this command is allowed to use (allowlist). Loaded from the `tools`
+   * frontmatter field of markdown commands.
+   */
+  tools: z.array(z.string()).optional(),
+  /**
+   * Tools that must not be available while this command is active (denylist).
+   * Loaded from `disallowed-tools` (upstream kebab-case), `disallowedTools`,
+   * or the legacy `disabledTools` frontmatter field — all three are synonyms.
+   */
+  disabledTools: z.array(z.string()).optional(),
 });
 
 export type Command = z.infer<typeof CommandSchema>;
@@ -234,6 +245,8 @@ export function loadCommandFromFile(filePath: string): Command | null {
       arguments: parsedArguments,
       template: templateContent.trim(),
       source: filePath,
+      tools: data.tools,
+      disabledTools: data['disallowed-tools'] ?? data.disallowedTools ?? data.disabledTools,
     };
 
     // Validate the command schema

--- a/src/core/__tests__/agenticChat.test.ts
+++ b/src/core/__tests__/agenticChat.test.ts
@@ -513,6 +513,145 @@ describe('agenticChat', () => {
     });
   });
 
+  describe('active skill disabled tools filter', () => {
+    it('should remove skill-disabled tools from the per-turn tool list', async () => {
+      const readTool = {
+        name: 'read',
+        description: 'Read',
+        toFunctionSchema: () => ({
+          name: 'read',
+          description: 'Read',
+          parameters: { type: 'object', properties: {} },
+        }),
+        execute: vi.fn(),
+      };
+      const bashTool = {
+        name: 'bash',
+        description: 'Bash',
+        toFunctionSchema: () => ({
+          name: 'bash',
+          description: 'Bash',
+          parameters: { type: 'object', properties: {} },
+        }),
+        execute: vi.fn(),
+      };
+
+      mockToolRegistry.list.mockReturnValue([readTool, bashTool]);
+
+      mockProvider.complete.mockResolvedValue({
+        text: 'Response',
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      } satisfies CompletionResult);
+
+      await agenticChat('Test', {
+        activeSkill: {
+          id: 'no-bash',
+          name: 'No Bash',
+          description: '',
+          prompt: '',
+          disabledTools: ['bash'],
+        },
+      });
+
+      const completionCall = mockProvider.complete.mock.calls[0];
+      const options = completionCall[1];
+
+      const toolNames = (options.tools as Array<{ function: { name: string } }>).map(
+        (t) => t.function.name
+      );
+      expect(toolNames).toEqual(['read']);
+      expect(toolNames).not.toContain('bash');
+
+      // Global registry must not have been mutated
+      expect(mockToolRegistry.list()).toHaveLength(2);
+    });
+
+    it('should leave the tool list unfiltered when activeSkill has no disabledTools', async () => {
+      const readTool = {
+        name: 'read',
+        description: 'Read',
+        toFunctionSchema: () => ({
+          name: 'read',
+          description: 'Read',
+          parameters: { type: 'object', properties: {} },
+        }),
+        execute: vi.fn(),
+      };
+      const bashTool = {
+        name: 'bash',
+        description: 'Bash',
+        toFunctionSchema: () => ({
+          name: 'bash',
+          description: 'Bash',
+          parameters: { type: 'object', properties: {} },
+        }),
+        execute: vi.fn(),
+      };
+
+      mockToolRegistry.list.mockReturnValue([readTool, bashTool]);
+
+      mockProvider.complete.mockResolvedValue({
+        text: 'Response',
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      } satisfies CompletionResult);
+
+      await agenticChat('Test', {
+        activeSkill: {
+          id: 'open-skill',
+          name: 'Open Skill',
+          description: '',
+          prompt: '',
+        },
+      });
+
+      const completionCall = mockProvider.complete.mock.calls[0];
+      const options = completionCall[1];
+      const toolNames = (options.tools as Array<{ function: { name: string } }>).map(
+        (t) => t.function.name
+      );
+      expect(toolNames.sort()).toEqual(['bash', 'read']);
+    });
+
+    it('should leave the tool list unfiltered when no activeSkill is provided', async () => {
+      const readTool = {
+        name: 'read',
+        description: 'Read',
+        toFunctionSchema: () => ({
+          name: 'read',
+          description: 'Read',
+          parameters: { type: 'object', properties: {} },
+        }),
+        execute: vi.fn(),
+      };
+      const bashTool = {
+        name: 'bash',
+        description: 'Bash',
+        toFunctionSchema: () => ({
+          name: 'bash',
+          description: 'Bash',
+          parameters: { type: 'object', properties: {} },
+        }),
+        execute: vi.fn(),
+      };
+
+      mockToolRegistry.list.mockReturnValue([readTool, bashTool]);
+
+      mockProvider.complete.mockResolvedValue({
+        text: 'Response',
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      } satisfies CompletionResult);
+
+      await agenticChat('Test');
+
+      const completionCall = mockProvider.complete.mock.calls[0];
+      const options = completionCall[1];
+      const toolNames = (options.tools as Array<{ function: { name: string } }>).map(
+        (t) => t.function.name
+      );
+      expect(toolNames.sort()).toEqual(['bash', 'read']);
+    });
+  });
+
   describe('system prompt context injection', () => {
     beforeEach(() => {
       // Reset context mocks to return empty by default

--- a/src/core/agenticChat.ts
+++ b/src/core/agenticChat.ts
@@ -80,6 +80,12 @@ export interface AgenticChatOptions {
   effort?: EffortLevel;
   /** Agent ID to use for assembled system prompt (e.g. 'code', 'debug') */
   agentId?: string;
+  /**
+   * Active skill for this turn. If provided, its `disabledTools` denylist is
+   * applied as a per-turn filter (the global tool registry is NOT mutated).
+   * Honors the upstream `disallowed-tools` frontmatter field on skill markdown.
+   */
+  activeSkill?: import('../skill/index.js').Skill;
 }
 
 export interface AgenticProgressEvent {
@@ -364,6 +370,16 @@ export async function agenticChat(
   } else {
     enabledToolNames = allTools.map((t) => t.name);
   }
+
+  // Apply active skill's disabledTools denylist as a per-turn filter.
+  // This honors `disallowed-tools` frontmatter on skill markdown files
+  // (Claude Code v2.1.152 compatibility) without mutating the global registry.
+  const skillDisabled = options?.activeSkill?.disabledTools;
+  if (skillDisabled && skillDisabled.length > 0) {
+    const denied = new Set(skillDisabled);
+    enabledToolNames = enabledToolNames.filter((n) => !denied.has(n));
+  }
+
   const enabledTools = allTools.filter((t) => enabledToolNames.includes(t.name));
 
   const toolSchemas = enabledTools.map((t) => formatToolForApi(t.toFunctionSchema()));

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -82,7 +82,13 @@ export function defineSkill(definition: SkillDefinition): Skill {
 }
 
 /**
- * Load skill from markdown file with frontmatter
+ * Load skill from markdown file with frontmatter.
+ *
+ * Recognized frontmatter fields:
+ * - `tools` — allowlist of tools the skill may use
+ * - `disallowed-tools` (kebab-case, upstream Claude Code convention) — denylist of tools
+ *   the skill may not use. Also accepted as `disallowedTools` and the legacy `disabledTools`.
+ *   All three spellings are honored as synonyms; the kebab-case form takes precedence.
  */
 export function loadSkillFromFile(filePath: string): Skill | null {
   try {
@@ -96,7 +102,7 @@ export function loadSkillFromFile(filePath: string): Skill | null {
       prompt: promptContent.trim(),
       prompts: data.prompts,
       tools: data.tools,
-      disabledTools: data.disabledTools,
+      disabledTools: data['disallowed-tools'] ?? data.disallowedTools ?? data.disabledTools,
       preferredModel: data.preferredModel || data.model,
       temperature: data.temperature,
       maxTokens: data.maxTokens,

--- a/tests/command/loader.test.ts
+++ b/tests/command/loader.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for markdown command loader frontmatter parsing,
+ * specifically the disallowed-tools / disallowedTools / disabledTools
+ * synonyms (Claude Code v2.1.152 parity).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { loadCommandFromFile } from '../../src/command/index.js';
+
+describe('loadCommandFromFile - disallowed-tools frontmatter', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmd-frontmatter-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should parse kebab-case "disallowed-tools" into disabledTools', () => {
+    const content = `---
+name: kebab-cmd
+description: Uses upstream kebab-case
+disallowed-tools:
+  - bash
+  - write
+---
+
+Template body.
+`;
+    const filePath = path.join(tempDir, 'kebab-cmd.md');
+    fs.writeFileSync(filePath, content);
+
+    const cmd = loadCommandFromFile(filePath);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.disabledTools).toEqual(['bash', 'write']);
+  });
+
+  it('should parse camelCase "disallowedTools" into disabledTools', () => {
+    const content = `---
+name: camel-cmd
+description: Uses camelCase alias
+disallowedTools:
+  - bash
+---
+
+Template body.
+`;
+    const filePath = path.join(tempDir, 'camel-cmd.md');
+    fs.writeFileSync(filePath, content);
+
+    const cmd = loadCommandFromFile(filePath);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.disabledTools).toEqual(['bash']);
+  });
+
+  it('should parse legacy "disabledTools" frontmatter', () => {
+    const content = `---
+name: legacy-cmd
+description: Uses legacy form
+disabledTools:
+  - bash
+  - delete
+---
+
+Template body.
+`;
+    const filePath = path.join(tempDir, 'legacy-cmd.md');
+    fs.writeFileSync(filePath, content);
+
+    const cmd = loadCommandFromFile(filePath);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.disabledTools).toEqual(['bash', 'delete']);
+  });
+
+  it('should prefer kebab-case "disallowed-tools" when multiple aliases are present', () => {
+    const content = `---
+name: prio-cmd
+disallowed-tools:
+  - bash
+disallowedTools:
+  - write
+disabledTools:
+  - read
+---
+
+Body.
+`;
+    const filePath = path.join(tempDir, 'prio-cmd.md');
+    fs.writeFileSync(filePath, content);
+
+    const cmd = loadCommandFromFile(filePath);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.disabledTools).toEqual(['bash']);
+  });
+
+  it('should also parse the "tools" allowlist from frontmatter', () => {
+    const content = `---
+name: allow-cmd
+tools:
+  - read
+  - grep
+---
+
+Body.
+`;
+    const filePath = path.join(tempDir, 'allow-cmd.md');
+    fs.writeFileSync(filePath, content);
+
+    const cmd = loadCommandFromFile(filePath);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.tools).toEqual(['read', 'grep']);
+  });
+
+  it('should leave tool fields undefined when not provided', () => {
+    const content = `---
+name: bare-cmd
+description: No tool fields
+---
+
+Body.
+`;
+    const filePath = path.join(tempDir, 'bare-cmd.md');
+    fs.writeFileSync(filePath, content);
+
+    const cmd = loadCommandFromFile(filePath);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.disabledTools).toBeUndefined();
+    expect(cmd!.tools).toBeUndefined();
+  });
+});

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -133,6 +133,110 @@ You are a simple assistant.
       expect(skill).toBeNull();
     });
 
+    it('should accept kebab-case "disallowed-tools" frontmatter (upstream alias)', () => {
+      const skillContent = `---
+id: kebab-skill
+name: Kebab Skill
+description: Uses kebab-case disallowed-tools
+disallowed-tools:
+  - bash
+  - write
+---
+
+You may not use bash or write.
+`;
+      const filePath = path.join(tempDir, 'kebab-skill.md');
+      fs.writeFileSync(filePath, skillContent);
+
+      const skill = loadSkillFromFile(filePath);
+
+      expect(skill).not.toBeNull();
+      expect(skill!.disabledTools).toEqual(['bash', 'write']);
+    });
+
+    it('should accept camelCase "disallowedTools" frontmatter alias', () => {
+      const skillContent = `---
+id: camel-skill
+name: Camel Skill
+description: Uses camelCase disallowedTools
+disallowedTools:
+  - bash
+---
+
+No bash here.
+`;
+      const filePath = path.join(tempDir, 'camel-skill.md');
+      fs.writeFileSync(filePath, skillContent);
+
+      const skill = loadSkillFromFile(filePath);
+
+      expect(skill).not.toBeNull();
+      expect(skill!.disabledTools).toEqual(['bash']);
+    });
+
+    it('should accept legacy "disabledTools" frontmatter', () => {
+      const skillContent = `---
+id: legacy-skill
+name: Legacy Skill
+description: Uses legacy disabledTools
+disabledTools:
+  - bash
+  - delete
+---
+
+Legacy form.
+`;
+      const filePath = path.join(tempDir, 'legacy-skill.md');
+      fs.writeFileSync(filePath, skillContent);
+
+      const skill = loadSkillFromFile(filePath);
+
+      expect(skill).not.toBeNull();
+      expect(skill!.disabledTools).toEqual(['bash', 'delete']);
+    });
+
+    it('should prefer kebab-case "disallowed-tools" over other aliases', () => {
+      const skillContent = `---
+id: prio-skill
+name: Priority Skill
+description: All three present, kebab wins
+disallowed-tools:
+  - bash
+disallowedTools:
+  - write
+disabledTools:
+  - read
+---
+
+Priority test.
+`;
+      const filePath = path.join(tempDir, 'prio-skill.md');
+      fs.writeFileSync(filePath, skillContent);
+
+      const skill = loadSkillFromFile(filePath);
+
+      expect(skill).not.toBeNull();
+      expect(skill!.disabledTools).toEqual(['bash']);
+    });
+
+    it('should leave disabledTools undefined when no denylist field is present', () => {
+      const skillContent = `---
+id: nodeny-skill
+name: No Deny Skill
+description: No denylist
+---
+
+Nothing to deny.
+`;
+      const filePath = path.join(tempDir, 'nodeny-skill.md');
+      fs.writeFileSync(filePath, skillContent);
+
+      const skill = loadSkillFromFile(filePath);
+
+      expect(skill).not.toBeNull();
+      expect(skill!.disabledTools).toBeUndefined();
+    });
+
     it('should handle file with no frontmatter', () => {
       const skillContent = `You are a plain assistant without frontmatter.`;
 

--- a/verify-results.txt
+++ b/verify-results.txt
@@ -1,6 +1,6 @@
 
 - ✅ typecheck
-- ❌ lint
+- ✅ lint
 - ✅ format
 - ✅ build
 - ✅ tests


### PR DESCRIPTION
## Summary

Automated implementation of #504 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 7
- **Branch**: `auto/504-skill-honor-disallowed-tools-frontmatter-for-skill`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #504
