### PR TITLE
feat: [skill] Symlink-aware skill directory discovery (#511)

### DIFF
--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -121,23 +121,93 @@ export function loadSkillFromFile(filePath: string): Skill | null {
 }
 
 /**
- * Load all skills from a directory
+ * Check whether a path has a skill file extension.
  */
-export function loadSkillsFromDirectory(dirPath: string): Skill[] {
+function isSkillFileName(name: string): boolean {
+  return name.endsWith('.md') || name.endsWith('.yaml') || name.endsWith('.yml');
+}
+
+/**
+ * Load all skills from a directory.
+ *
+ * Follows symlinks: a symlinked file with a skill extension is loaded, and a
+ * symlinked subdirectory is recursed into. Cycles are guarded by a visited
+ * set keyed on resolved (`fs.realpathSync`) paths. Broken symlinks are logged
+ * via `console.warn` and skipped without aborting the rest of the traversal.
+ */
+export function loadSkillsFromDirectory(dirPath: string, visited?: Set<string>): Skill[] {
   const skills: Skill[] = [];
 
   if (!fs.existsSync(dirPath)) {
     return skills;
   }
 
-  const files = fs.readdirSync(dirPath);
+  const seen = visited ?? new Set<string>();
 
-  for (const file of files) {
-    if (file.endsWith('.md') || file.endsWith('.yaml') || file.endsWith('.yml')) {
-      const skill = loadSkillFromFile(path.join(dirPath, file));
-      if (skill) {
-        skills.push(skill);
+  let resolvedDir: string;
+  try {
+    resolvedDir = fs.realpathSync(dirPath);
+  } catch (error) {
+    console.warn(`Failed to resolve skill directory ${dirPath}:`, error);
+    return skills;
+  }
+
+  if (seen.has(resolvedDir)) {
+    return skills;
+  }
+  seen.add(resolvedDir);
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(resolvedDir, { withFileTypes: true });
+  } catch (error) {
+    console.warn(`Failed to read skill directory ${resolvedDir}:`, error);
+    return skills;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(resolvedDir, entry.name);
+
+    if (entry.isFile()) {
+      if (isSkillFileName(entry.name)) {
+        const skill = loadSkillFromFile(entryPath);
+        if (skill) {
+          skills.push(skill);
+        }
       }
+      continue;
+    }
+
+    if (entry.isSymbolicLink()) {
+      let resolvedTarget: string;
+      try {
+        resolvedTarget = fs.realpathSync(entryPath);
+      } catch (error) {
+        console.warn(`Skipping broken skill symlink ${entryPath}:`, error);
+        continue;
+      }
+
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(resolvedTarget);
+      } catch (error) {
+        console.warn(`Skipping broken skill symlink ${entryPath}:`, error);
+        continue;
+      }
+
+      if (stat.isFile() && isSkillFileName(entry.name)) {
+        const skill = loadSkillFromFile(entryPath);
+        if (skill) {
+          skills.push(skill);
+        }
+      } else if (stat.isDirectory()) {
+        skills.push(...loadSkillsFromDirectory(resolvedTarget, seen));
+      }
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      skills.push(...loadSkillsFromDirectory(entryPath, seen));
     }
   }
 
@@ -145,23 +215,39 @@ export function loadSkillsFromDirectory(dirPath: string): Skill[] {
 }
 
 /**
- * Get skill directories in precedence order (project first, then global)
+ * Get skill directories in precedence order (project first, then global).
+ *
+ * Each directory is resolved with `fs.realpathSync` so that, e.g., a project
+ * `.alexi/skills` symlinked to the global skills dir is not loaded twice.
  */
 export function skillDirectories(projectRoot: string): string[] {
   const dirs: string[] = [];
+  const seenResolved = new Set<string>();
   const globalPaths = getGlobalPaths();
 
+  const tryAdd = (candidate: string): void => {
+    if (!fs.existsSync(candidate)) {
+      return;
+    }
+    let resolved: string;
+    try {
+      resolved = fs.realpathSync(candidate);
+    } catch (error) {
+      console.warn(`Failed to resolve skill directory ${candidate}:`, error);
+      return;
+    }
+    if (seenResolved.has(resolved)) {
+      return;
+    }
+    seenResolved.add(resolved);
+    dirs.push(candidate);
+  };
+
   // Add project skills FIRST (higher precedence)
-  const projectSkillsDir = path.join(projectRoot, '.alexi', 'skills');
-  if (fs.existsSync(projectSkillsDir)) {
-    dirs.push(projectSkillsDir);
-  }
+  tryAdd(path.join(projectRoot, '.alexi', 'skills'));
 
   // Add global skills (lower precedence)
-  const globalSkillsDir = globalPaths.skills;
-  if (fs.existsSync(globalSkillsDir)) {
-    dirs.push(globalSkillsDir);
-  }
+  tryAdd(globalPaths.skills);
 
   return dirs;
 }

--- a/src/skill/skill-symlink.test.ts
+++ b/src/skill/skill-symlink.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { loadSkillsFromDirectory } from './index.js';
+
+const SKILL_BODY = (id: string): string => `---
+id: ${id}
+name: ${id}
+description: Symlink test skill ${id}
+---
+
+Prompt for ${id}.
+`;
+
+describe('Skill symlink-aware discovery', () => {
+  let tempRoots: string[];
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempRoots = [];
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    for (const dir of tempRoots) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    warnSpy.mockRestore();
+  });
+
+  function mkTempDir(prefix = 'skill-symlink-'): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    // Resolve to canonical path so symlink-target comparisons work on macOS
+    // (where /tmp is itself a symlink to /private/tmp).
+    const resolved = fs.realpathSync(dir);
+    tempRoots.push(resolved);
+    return resolved;
+  }
+
+  it('loads a symlinked skill file and points sourcePath at the link entry', () => {
+    const dir = mkTempDir();
+    const realFile = path.join(dir, 'realSkill.md');
+    fs.writeFileSync(realFile, SKILL_BODY('real-skill'));
+
+    const linkFile = path.join(dir, 'linkedSkill.md');
+    fs.symlinkSync(realFile, linkFile);
+
+    const skills = loadSkillsFromDirectory(dir);
+
+    // Both entries map to the same skill id, so we get one unique id but two
+    // entries (real + link). The important behavior is the symlinked file is
+    // discovered at all; the loader does not silently skip it.
+    expect(skills.length).toBeGreaterThanOrEqual(1);
+    const ids = skills.map((s) => s.id);
+    expect(ids).toContain('real-skill');
+
+    // sourcePath of the symlinked entry should point at the symlink path.
+    const linkSkill = skills.find((s) => s.sourcePath === linkFile);
+    expect(linkSkill).toBeDefined();
+  });
+
+  it('recurses into a symlinked subdirectory and discovers its skills', () => {
+    const dirA = mkTempDir('skill-symlink-a-');
+    const dirB = mkTempDir('skill-symlink-b-');
+
+    const skillFile = path.join(dirB, 'shared-skill.md');
+    fs.writeFileSync(skillFile, SKILL_BODY('shared-skill'));
+
+    fs.symlinkSync(dirB, path.join(dirA, 'shared'));
+
+    const skills = loadSkillsFromDirectory(dirA);
+    const ids = skills.map((s) => s.id);
+
+    expect(ids).toContain('shared-skill');
+  });
+
+  it('does not infinitely loop on a circular symlink', () => {
+    const dirA = mkTempDir('skill-symlink-cycle-');
+
+    const concrete = path.join(dirA, 'concrete.md');
+    fs.writeFileSync(concrete, SKILL_BODY('concrete-skill'));
+
+    // A/loop -> A (cycle)
+    fs.symlinkSync(dirA, path.join(dirA, 'loop'));
+
+    const skills = loadSkillsFromDirectory(dirA);
+    const ids = skills.map((s) => s.id);
+
+    expect(ids).toContain('concrete-skill');
+  });
+
+  it('warns and continues on broken symlinks', () => {
+    const dir = mkTempDir('skill-symlink-broken-');
+
+    const valid = path.join(dir, 'valid.md');
+    fs.writeFileSync(valid, SKILL_BODY('valid-skill'));
+
+    // Broken symlink: target does not exist.
+    const broken = path.join(dir, 'dead.md');
+    fs.symlinkSync(path.join(dir, 'does-not-exist.md'), broken);
+
+    const skills = loadSkillsFromDirectory(dir);
+    const ids = skills.map((s) => s.id);
+
+    expect(ids).toContain('valid-skill');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation of #511 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 2
- **Branch**: `auto/511-skill-symlink-aware-skill-directory-discovery`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #511
