### PR TITLE
feat: [provider] Use getProviderForModelWithFallback in streamingOrchestrator and git/commitMessage (#517)

### DIFF
--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -3,7 +3,11 @@
  * Uses SAP AI SDK Orchestration provider exclusively
  */
 
-import { getProviderForModel, getDefaultModel, type StreamChunk } from '../providers/index.js';
+import {
+  getProviderForModelWithFallback,
+  getDefaultModel,
+  type StreamChunk,
+} from '../providers/index.js';
 import { routePrompt } from './router.js';
 import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
@@ -112,8 +116,13 @@ export async function* streamChat(
   // Add current user message
   messages.push({ role: 'user', content: message });
 
-  // Get SAP Orchestration provider for this model
-  const provider = getProviderForModel(modelId);
+  // Get SAP Orchestration provider for this model, falling back to
+  // routingConfig.preferences.fallbackModel if the primary id is not recognized.
+  const resolution = getProviderForModelWithFallback(modelId);
+  const provider = resolution.provider;
+  if (resolution.usedFallback) {
+    modelId = resolution.effectiveModelId;
+  }
 
   // Build agent observability headers
   const sessionId = options?.sessionManager?.getCurrentSession()?.metadata.id;

--- a/src/git/commitMessage.ts
+++ b/src/git/commitMessage.ts
@@ -4,7 +4,7 @@
  */
 
 import { routePrompt } from '../core/router.js';
-import { getProviderForModel } from '../providers/index.js';
+import { getProviderForModelWithFallback } from '../providers/index.js';
 import type { GitConfig } from './config.js';
 
 export interface ChangedFile {
@@ -62,11 +62,17 @@ export function buildHeuristicMessage(files: ChangedFile[], conventional: boolea
  */
 async function generateWithLLM(files: ChangedFile[], config: GitConfig): Promise<string | null> {
   try {
-    const modelId = config.commitMessage.model
+    let modelId = config.commitMessage.model
       ? config.commitMessage.model
       : routePrompt('summarize in 10 words', { preferCheap: true }).modelId;
 
-    const provider = getProviderForModel(modelId);
+    // Resolve provider, falling back to routingConfig.preferences.fallbackModel
+    // if the primary id is not recognized (e.g. typo in user config).
+    const resolution = getProviderForModelWithFallback(modelId);
+    const provider = resolution.provider;
+    if (resolution.usedFallback) {
+      modelId = resolution.effectiveModelId;
+    }
 
     const fileList = files
       .map((f) => {

--- a/tests/core/streamingOrchestrator.fallback.test.ts
+++ b/tests/core/streamingOrchestrator.fallback.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock dependencies before importing the module
+vi.mock('../../src/providers/index.js', () => ({
+  getProviderForModelWithFallback: vi.fn(),
+  getDefaultModel: vi.fn(() => 'gpt-4o'),
+}));
+
+vi.mock('../../src/core/router.js', () => ({
+  routePrompt: vi.fn(),
+}));
+
+// Import after mocking
+import { streamChat } from '../../src/core/streamingOrchestrator.js';
+import { getProviderForModelWithFallback, getDefaultModel } from '../../src/providers/index.js';
+
+// Helper to create a mock provider that yields a single chunk
+function createMockStreamProvider(chunks: Array<{ text: string; usage?: Record<string, number> }>) {
+  const streamCompleteFn = vi.fn().mockImplementation(function* () {
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  });
+
+  return {
+    streamComplete: streamCompleteFn,
+  };
+}
+
+describe('streamChat fallback model resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDefaultModel).mockReturnValue('gpt-4o');
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('uses the resolved effectiveModelId when getProviderForModelWithFallback fires the fallback', async () => {
+    const mockProvider = createMockStreamProvider([
+      { text: 'ok', usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 } },
+    ]);
+
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: mockProvider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: true,
+    });
+
+    const gen = streamChat('Hello', { modelOverride: 'totally-bogus-model' });
+
+    let next = await gen.next();
+    while (!next.done) {
+      next = await gen.next();
+    }
+    const result = next.value;
+
+    // Streaming orchestrator must surface the fallback model id, not the bogus one
+    expect(result.modelUsed).toBe('gpt-4o');
+    expect(getProviderForModelWithFallback).toHaveBeenCalledWith('totally-bogus-model');
+    expect(mockProvider.streamComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the requested model id when usedFallback is false', async () => {
+    const mockProvider = createMockStreamProvider([
+      { text: 'hi', usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 } },
+    ]);
+
+    vi.mocked(getProviderForModelWithFallback).mockImplementation((modelId: string) => ({
+      provider: mockProvider as never,
+      effectiveModelId: modelId,
+      usedFallback: false,
+    }));
+
+    const gen = streamChat('Hi', { modelOverride: 'anthropic--claude-4-sonnet' });
+
+    let next = await gen.next();
+    while (!next.done) {
+      next = await gen.next();
+    }
+    const result = next.value;
+
+    expect(result.modelUsed).toBe('anthropic--claude-4-sonnet');
+    expect(getProviderForModelWithFallback).toHaveBeenCalledWith('anthropic--claude-4-sonnet');
+    expect(mockProvider.streamComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/git/commitMessage.fallback.test.ts
+++ b/tests/git/commitMessage.fallback.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock dependencies before importing the module under test.
+vi.mock('../../src/providers/index.js', () => ({
+  getProviderForModelWithFallback: vi.fn(),
+}));
+
+vi.mock('../../src/core/router.js', () => ({
+  routePrompt: vi.fn(() => ({ modelId: 'gpt-4o-mini', reason: 'cheap', confidence: 0.9 })),
+}));
+
+import { generateCommitMessage } from '../../src/git/commitMessage.js';
+import { getProviderForModelWithFallback } from '../../src/providers/index.js';
+import type { GitConfig } from '../../src/git/config.js';
+
+const baseConfig: GitConfig = {
+  autoCommits: true,
+  dirtyCommits: true,
+  commitVerify: false,
+  attribution: {
+    style: 'co-authored-by',
+    name: 'Alexi AI',
+    email: 'alexi@assistant.local',
+  },
+  commitMessage: {
+    useAI: true,
+    conventional: true,
+  },
+};
+
+describe('generateCommitMessage fallback model resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('uses the LLM result when getProviderForModelWithFallback fires the fallback', async () => {
+    const completeFn = vi.fn().mockResolvedValue({
+      text: 'feat: add fallback resolution',
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: { complete: completeFn } as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: true,
+    });
+
+    const msg = await generateCommitMessage([{ filePath: 'src/foo.ts', toolName: 'write' }], {
+      ...baseConfig,
+      commitMessage: { ...baseConfig.commitMessage, model: 'totally-bogus' },
+    });
+
+    expect(getProviderForModelWithFallback).toHaveBeenCalledWith('totally-bogus');
+    expect(completeFn).toHaveBeenCalledTimes(1);
+    expect(msg).toBe('feat: add fallback resolution');
+  });
+
+  it('uses the LLM result on the no-fallback path', async () => {
+    const completeFn = vi.fn().mockResolvedValue({
+      text: 'feat: a new thing',
+      usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+    });
+
+    vi.mocked(getProviderForModelWithFallback).mockImplementation((modelId: string) => ({
+      provider: { complete: completeFn } as never,
+      effectiveModelId: modelId,
+      usedFallback: false,
+    }));
+
+    const msg = await generateCommitMessage([{ filePath: 'src/foo.ts', toolName: 'write' }], {
+      ...baseConfig,
+      commitMessage: { ...baseConfig.commitMessage, model: 'gpt-4o' },
+    });
+
+    expect(getProviderForModelWithFallback).toHaveBeenCalledWith('gpt-4o');
+    expect(completeFn).toHaveBeenCalledTimes(1);
+    expect(msg).toBe('feat: a new thing');
+  });
+
+  it('falls back to heuristic message when provider.complete throws', async () => {
+    const completeFn = vi.fn().mockRejectedValue(new Error('boom'));
+
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: { complete: completeFn } as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: true,
+    });
+
+    const msg = await generateCommitMessage([{ filePath: 'src/foo.ts', toolName: 'write' }], {
+      ...baseConfig,
+      commitMessage: { ...baseConfig.commitMessage, model: 'totally-bogus' },
+    });
+
+    // Heuristic path must run; the function still returns a non-empty message
+    expect(getProviderForModelWithFallback).toHaveBeenCalledWith('totally-bogus');
+    expect(typeof msg).toBe('string');
+    expect(msg.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/streamingOrchestratorHeaders.test.ts
+++ b/tests/streamingOrchestratorHeaders.test.ts
@@ -1,10 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies before importing the module
-vi.mock('../src/providers/index.js', () => ({
-  getProviderForModel: vi.fn(),
-  getDefaultModel: vi.fn(),
-}));
+vi.mock('../src/providers/index.js', () => {
+  const getProviderForModel = vi.fn();
+  return {
+    getProviderForModel,
+    // Delegate to getProviderForModel so existing tests that mock
+    // getProviderForModel continue to work without modification.
+    getProviderForModelWithFallback: vi.fn((modelId: string) => ({
+      provider: getProviderForModel(modelId),
+      effectiveModelId: modelId,
+      usedFallback: false,
+    })),
+    getDefaultModel: vi.fn(),
+  };
+});
 
 vi.mock('../src/core/router.js', () => ({
   routePrompt: vi.fn(),


### PR DESCRIPTION
## Summary

Automated implementation of #517 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 5
- **Branch**: `auto/517-provider-use-getproviderformodelwithfallback-in-st`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #517
