### PR TITLE
feat: [command] Surface getProviderForModel fallback warnings in TUI status bar (#519)

### DIFF
--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -273,6 +273,16 @@ export const SessionEnded = defineEvent(
   })
 );
 
+// Provider events
+export const ProviderModelFellBack = defineEvent(
+  'provider.modelFellBack',
+  z.object({
+    requestedModel: z.string(),
+    effectiveModel: z.string(),
+    timestamp: z.number(),
+  })
+);
+
 // Error events
 export const ErrorOccurred = defineEvent(
   'error.occurred',

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -8,10 +8,23 @@
 
 import { Command } from 'commander';
 import { createRequire } from 'module';
+import { ProviderModelFellBack } from '../bus/index.js';
 import { registerAllCommands } from './commands/index.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
+
+// Default fallback subscriber for non-TUI runs (CLI one-shots, scripts, tests).
+// The TUI subscribes its own handler in StatusBar.tsx and always renders,
+// regardless of TTY state. This subscriber only writes to stderr when stdout
+// is not a TTY (piped output) or when ALEXI_NON_INTERACTIVE is explicitly set.
+ProviderModelFellBack.subscribe((p) => {
+  if (!process.stdout.isTTY || process.env.ALEXI_NON_INTERACTIVE) {
+    process.stderr.write(
+      `warning: model '${p.requestedModel}' not recognized — using '${p.effectiveModel}' for this session\n`
+    );
+  }
+});
 
 const program = new Command();
 program

--- a/src/cli/tui/components/StatusBar.tsx
+++ b/src/cli/tui/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 
+import { ProviderModelFellBack } from '../../../bus/index.js';
 import { useTheme } from '../context/ThemeContext.js';
 import { Spinner } from './Spinner.js';
 
@@ -53,6 +54,22 @@ export function StatusBar({
   const { theme } = useTheme();
   const { colors } = theme;
 
+  // Subscribe to provider fallback events so the user can see when their
+  // configured model id was not recognized and a different one is being used.
+  // Persists for the rest of the session (matches the dedup-once semantics on
+  // the publisher side in src/providers/index.ts).
+  const [fallbackWarning, setFallbackWarning] = React.useState<{
+    requested: string;
+    effective: string;
+  } | null>(null);
+
+  React.useEffect(() => {
+    const unsub = ProviderModelFellBack.subscribe((p) => {
+      setFallbackWarning({ requested: p.requestedModel, effective: p.effectiveModel });
+    });
+    return unsub;
+  }, []);
+
   const currencySymbol = CURRENCY_SYMBOLS[cost.currency] ?? `${cost.currency} `;
   const costStr = `${currencySymbol}${cost.totalCost.toFixed(4)}`;
 
@@ -96,6 +113,15 @@ export function StatusBar({
           </Text>
         )}
       </Box>
+
+      {/* Fallback warning (only when model id was not recognized) */}
+      {fallbackWarning && (
+        <Box backgroundColor={colors.backgroundDarker} paddingX={1}>
+          <Text color={colors.warning} backgroundColor={colors.backgroundDarker}>
+            ! model {fallbackWarning.requested} unavailable → using {fallbackWarning.effective}
+          </Text>
+        </Box>
+      )}
 
       {/* Segment 3: Streaming indicator or agent */}
       <Box backgroundColor={colors.backgroundSecondary} paddingX={1}>

--- a/src/providers/index.test.ts
+++ b/src/providers/index.test.ts
@@ -32,10 +32,12 @@ vi.mock('../config/userConfig.js', () => ({
 
 import { isOrchestrationModel } from './sapOrchestration.js';
 import { loadRoutingConfig } from '../config/routingConfig.js';
+import { ProviderModelFellBack } from '../bus/index.js';
 import { getProviderForModelWithFallback, _resetFallbackWarningCache } from './index.js';
 
 describe('getProviderForModelWithFallback', () => {
-  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let events: Array<{ requestedModel: string; effectiveModel: string; timestamp: number }>;
+  let unsubscribe: () => void;
 
   beforeEach(() => {
     _resetFallbackWarningCache();
@@ -52,30 +54,35 @@ describe('getProviderForModelWithFallback', () => {
         fallbackModel: 'gpt-4o',
       },
     });
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    events = [];
+    unsubscribe = ProviderModelFellBack.subscribe((p) => {
+      events.push(p);
+    });
   });
 
   afterEach(() => {
-    warnSpy.mockRestore();
+    unsubscribe();
     vi.clearAllMocks();
   });
 
   describe('fallback path', () => {
-    it('returns the fallback model and warns once when primary is unknown', () => {
+    it('returns the fallback model and publishes once when primary is unknown', () => {
       const result = getProviderForModelWithFallback('gpt-typo');
 
       expect(result.effectiveModelId).toBe('gpt-4o');
       expect(result.usedFallback).toBe(true);
       expect(result.provider).toBeDefined();
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Primary model 'gpt-typo' not recognized, falling back to 'gpt-4o' for this session"
-        )
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          requestedModel: 'gpt-typo',
+          effectiveModel: 'gpt-4o',
+        })
       );
+      expect(typeof events[0].timestamp).toBe('number');
     });
 
-    it('deduplicates the warning across repeated calls with the same bad id', () => {
+    it('deduplicates the event across repeated calls with the same bad id', () => {
       const first = getProviderForModelWithFallback('gpt-typo');
       const second = getProviderForModelWithFallback('gpt-typo');
 
@@ -85,15 +92,17 @@ describe('getProviderForModelWithFallback', () => {
       expect(second).toEqual(
         expect.objectContaining({ effectiveModelId: 'gpt-4o', usedFallback: true })
       );
-      // Only one warn for the same bad id, even after two calls
-      expect(warnSpy).toHaveBeenCalledTimes(1);
+      // Only one publish for the same bad id, even after two calls
+      expect(events).toHaveLength(1);
     });
 
-    it('warns separately for distinct bad model ids', () => {
+    it('publishes separately for distinct bad model ids', () => {
       getProviderForModelWithFallback('gpt-typo');
       getProviderForModelWithFallback('another-bad-id');
 
-      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(events).toHaveLength(2);
+      expect(events[0].requestedModel).toBe('gpt-typo');
+      expect(events[1].requestedModel).toBe('another-bad-id');
     });
 
     it('honors an explicit fallbackModel argument over routing config', () => {
@@ -101,8 +110,11 @@ describe('getProviderForModelWithFallback', () => {
 
       expect(result.effectiveModelId).toBe('gemini-2.5-pro');
       expect(result.usedFallback).toBe(true);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("falling back to 'gemini-2.5-pro'")
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          requestedModel: 'gpt-typo',
+          effectiveModel: 'gemini-2.5-pro',
+        })
       );
     });
 
@@ -119,21 +131,21 @@ describe('getProviderForModelWithFallback', () => {
   });
 
   describe('no-fallback path (regression)', () => {
-    it("returns the primary model and never warns when 'gpt-4o' is valid", () => {
+    it("returns the primary model and never publishes when 'gpt-4o' is valid", () => {
       const result = getProviderForModelWithFallback('gpt-4o');
 
       expect(result.effectiveModelId).toBe('gpt-4o');
       expect(result.usedFallback).toBe(false);
       expect(result.provider).toBeDefined();
-      expect(warnSpy).not.toHaveBeenCalled();
+      expect(events).toHaveLength(0);
     });
 
-    it('does not warn for any number of valid-id calls', () => {
+    it('does not publish for any number of valid-id calls', () => {
       getProviderForModelWithFallback('gpt-4o');
       getProviderForModelWithFallback('gemini-2.5-pro');
       getProviderForModelWithFallback('gpt-4o');
 
-      expect(warnSpy).not.toHaveBeenCalled();
+      expect(events).toHaveLength(0);
     });
   });
 });

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,6 +5,7 @@
  * for all LLM operations through SAP AI Core.
  */
 
+import { ProviderModelFellBack } from '../bus/index.js';
 import { env } from '../config/env.js';
 import { loadRoutingConfig } from '../config/routingConfig.js';
 import { getConfigDefaultModel } from '../config/userConfig.js';
@@ -109,11 +110,14 @@ function resolveFallbackModelId(fallbackModel?: string): string {
  * falling back to the configured `fallbackModel` if the primary id is not
  * recognized.
  *
- * If `modelId` is unknown, a single `console.warn` is emitted (deduplicated
- * per bad-model-id for the process lifetime) and a provider is built for the
- * fallback id instead. This mirrors Claude Code v2.1.152 behavior so a
- * misconfigured `AICORE_MODEL` (typo, renamed deployment id, etc.) does not
- * break every chat turn.
+ * If `modelId` is unknown, a `ProviderModelFellBack` event is published on the
+ * application bus (deduplicated per bad-model-id for the process lifetime) and
+ * a provider is built for the fallback id instead. The TUI subscribes to this
+ * event to surface a one-line status banner; non-TUI callers (e.g. the
+ * `alexi chat -m ...` one-shot path) print a stderr warning. This mirrors
+ * Claude Code v2.1.152 behavior so a misconfigured `AICORE_MODEL` (typo,
+ * renamed deployment id, etc.) is visible at first turn instead of silently
+ * masquerading as a working configuration.
  *
  * `getProviderForModel` remains the low-level primitive that does no
  * validation; this helper is the recommended entry point for chat pipelines.
@@ -138,9 +142,11 @@ export function getProviderForModelWithFallback(
 
   if (!warnedFor.has(modelId)) {
     warnedFor.add(modelId);
-    console.warn(
-      `Primary model '${modelId}' not recognized, falling back to '${fallbackId}' for this session`
-    );
+    ProviderModelFellBack.publish({
+      requestedModel: modelId,
+      effectiveModel: fallbackId,
+      timestamp: Date.now(),
+    });
   }
 
   return {

--- a/tests/cli/tui/StatusBar.fallbackWarning.test.tsx
+++ b/tests/cli/tui/StatusBar.fallbackWarning.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+
+import { ProviderModelFellBack } from '../../../src/bus/index.js';
+import { StatusBar } from '../../../src/cli/tui/components/StatusBar.js';
+import { ThemeProvider } from '../../../src/cli/tui/context/ThemeContext.js';
+
+function Wrapper({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+describe('StatusBar fallback warning', () => {
+  const defaultProps = {
+    agent: 'code',
+    model: 'gpt-4o',
+    cost: { totalCost: 0, currency: 'USD' },
+    isStreaming: false,
+    leaderActive: false,
+  };
+
+  it('does not render the warning by default', () => {
+    const { lastFrame } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+    expect(lastFrame()).not.toContain('unavailable');
+  });
+
+  it('renders the fallback warning when ProviderModelFellBack fires', () => {
+    const { lastFrame, rerender } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+
+    ProviderModelFellBack.publish({
+      requestedModel: 'fake-model',
+      effectiveModel: 'gpt-4o',
+      timestamp: Date.now(),
+    });
+
+    // Force a re-render so the React effect-driven state shows up
+    rerender(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('fake-model');
+    expect(frame).toContain('unavailable');
+    expect(frame).toContain('gpt-4o');
+  });
+});

--- a/tests/providers/fallbackEvent.test.ts
+++ b/tests/providers/fallbackEvent.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Integration test for the ProviderModelFellBack bus event published by
+ * getProviderForModelWithFallback when the primary model id is not recognized.
+ *
+ * Counterpart to src/providers/index.test.ts (which is the unit test). This
+ * file exercises the publish/subscribe contract from the consumer's perspective:
+ * a subscriber registered before the call should fire exactly once per
+ * (bad-model-id) per process lifetime.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../src/providers/sapOrchestration.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/providers/sapOrchestration.js')>();
+  class MockProvider {
+    modelName: string;
+    constructor(cfg: { modelName: string }) {
+      this.modelName = cfg.modelName;
+    }
+  }
+  return {
+    ...actual,
+    isOrchestrationModel: vi.fn(),
+    SapOrchestrationProvider: MockProvider,
+  };
+});
+
+vi.mock('../../src/config/routingConfig.js', () => ({
+  loadRoutingConfig: vi.fn(),
+}));
+
+vi.mock('../../src/config/env.js', () => ({
+  env: vi.fn(() => undefined),
+}));
+
+vi.mock('../../src/config/userConfig.js', () => ({
+  getConfigDefaultModel: vi.fn(() => undefined),
+}));
+
+import { isOrchestrationModel } from '../../src/providers/sapOrchestration.js';
+import { loadRoutingConfig } from '../../src/config/routingConfig.js';
+import { ProviderModelFellBack } from '../../src/bus/index.js';
+import {
+  getProviderForModelWithFallback,
+  _resetFallbackWarningCache,
+} from '../../src/providers/index.js';
+
+describe('ProviderModelFellBack event', () => {
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    _resetFallbackWarningCache();
+    vi.mocked(isOrchestrationModel).mockImplementation((id: string) => id === 'gpt-4o');
+    vi.mocked(loadRoutingConfig).mockReturnValue({
+      models: [],
+      rules: [],
+      preferences: {
+        defaultCostTier: 'medium',
+        preferCheapWhenPossible: false,
+        maxCostPerRequest: null,
+        fallbackModel: 'gpt-4o',
+      },
+    });
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    vi.clearAllMocks();
+  });
+
+  it('fires the subscriber when fallback engages, with the requested + effective model ids', () => {
+    const handler = vi.fn();
+    unsubscribe = ProviderModelFellBack.subscribe(handler);
+
+    getProviderForModelWithFallback('totally-fake-model');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedModel: 'totally-fake-model',
+        effectiveModel: 'gpt-4o',
+      })
+    );
+  });
+
+  it('does not fire the subscriber twice for the same bad id (dedup)', () => {
+    const handler = vi.fn();
+    unsubscribe = ProviderModelFellBack.subscribe(handler);
+
+    getProviderForModelWithFallback('totally-fake-model');
+    getProviderForModelWithFallback('totally-fake-model');
+    getProviderForModelWithFallback('totally-fake-model');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire the subscriber when the primary model is recognized', () => {
+    const handler = vi.fn();
+    unsubscribe = ProviderModelFellBack.subscribe(handler);
+
+    getProviderForModelWithFallback('gpt-4o');
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation of #519 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 7
- **Branch**: `auto/519-command-surface-getproviderformodel-fallback-warni`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #519
