### PR TITLE
feat: [hook] SessionStart reloadSkills output and /reload-skills command (#534)

### DIFF
--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -229,6 +229,9 @@ function printHelp(): void {
     c('yellow', '  /effort [low|med|high]') + c('gray', ' - Set effort level (cost/quality)')
   );
   console.log(c('yellow', '  /doctor') + c('gray', '            - Run environment health checks'));
+  console.log(
+    c('yellow', '  /reload-skills') + c('gray', '     - Re-scan skill directories without restart')
+  );
   console.log(c('yellow', '  /clear-history') + c('gray', '     - Clear conversation history'));
   console.log(c('yellow', '  /bug, /feedback') + c('gray', '    - Report issues and feedback'));
   console.log();
@@ -2071,6 +2074,19 @@ async function handleCommand(input: string, state: ReplState): Promise<boolean> 
       console.log(
         c('green', `\n  Repo map token budget set to ${n}. Run /map-refresh to apply.\n`)
       );
+      return true;
+    }
+
+    case 'reload-skills': {
+      try {
+        const { runReloadSkills } = await import('../command/reloadSkills.js');
+        const summary = await runReloadSkills(process.cwd());
+        console.log(c('green', `\n  ${summary}\n`));
+      } catch (err) {
+        console.log(
+          c('red', `\n  Skill reload failed: ${err instanceof Error ? err.message : String(err)}\n`)
+        );
+      }
       return true;
     }
 

--- a/src/cli/tui/hooks/useCommands.ts
+++ b/src/cli/tui/hooks/useCommands.ts
@@ -498,6 +498,25 @@ function buildCommands(deps: BuildCommandsDeps): SlashCommand[] {
       },
     },
 
+    // /reload-skills --------------------------------------------------------
+    {
+      name: 'reload-skills',
+      description: 'Re-scan skill directories and refresh the active registry',
+      category: 'config',
+      execute: async (_args, _ctx) => {
+        try {
+          const { runReloadSkills } = await import('../../../command/reloadSkills.js');
+          const summary = await runReloadSkills(process.cwd());
+          deps.addSystemMessage(summary);
+        } catch (err) {
+          deps.addSystemMessage(
+            `Skill reload failed: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+        return true;
+      },
+    },
+
     // /rewind ---------------------------------------------------------------
     {
       name: 'rewind',

--- a/src/cli/utils/completer.ts
+++ b/src/cli/utils/completer.ts
@@ -150,6 +150,11 @@ export const SLASH_COMMANDS: readonly CommandDef[] = [
   { name: 'effort', description: 'Set effort level', category: 'config' },
   { name: 'doctor', description: 'Run environment health checks', category: 'config' },
   { name: 'memory', description: 'List/edit instruction files', category: 'config' },
+  {
+    name: 'reload-skills',
+    description: 'Re-scan skill directories and refresh the active registry',
+    category: 'config',
+  },
   { name: 'alias', description: 'Manage command aliases', category: 'config' },
   { name: 'snippet', description: 'Manage code snippets', category: 'config' },
   { name: 'template', description: 'Manage message templates', category: 'config' },

--- a/src/command/reloadSkills.test.ts
+++ b/src/command/reloadSkills.test.ts
@@ -1,0 +1,39 @@
+/**
+ * `/reload-skills` command-layer test.
+ *
+ * Stubs the underlying `reloadSkills` registry function and verifies the
+ * command formats the count summary correctly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { reloadSkillsMock } = vi.hoisted(() => ({ reloadSkillsMock: vi.fn() }));
+
+vi.mock('../skill/index.js', () => ({
+  reloadSkills: reloadSkillsMock,
+}));
+
+import { runReloadSkills } from './reloadSkills.js';
+
+describe('runReloadSkills', () => {
+  beforeEach(() => {
+    reloadSkillsMock.mockReset();
+  });
+
+  it('returns a one-line summary using the underlying reloadSkills counts', async () => {
+    reloadSkillsMock.mockReturnValue({ added: 2, removed: 1, total: 7 });
+
+    const summary = await runReloadSkills('/some/workdir');
+
+    expect(reloadSkillsMock).toHaveBeenCalledWith('/some/workdir');
+    expect(summary).toBe('Skills reloaded: +2 added, -1 removed, 7 total.');
+  });
+
+  it('handles a no-op reload (no skills changed)', async () => {
+    reloadSkillsMock.mockReturnValue({ added: 0, removed: 0, total: 0 });
+
+    const summary = await runReloadSkills(process.cwd());
+
+    expect(summary).toBe('Skills reloaded: +0 added, -0 removed, 0 total.');
+  });
+});

--- a/src/command/reloadSkills.ts
+++ b/src/command/reloadSkills.ts
@@ -1,0 +1,20 @@
+/**
+ * /reload-skills — re-scan skill directories and refresh the active registry.
+ *
+ * No arguments. Prints a one-line summary of added/removed/total counts.
+ *
+ * Mirrors the SessionStart hook `reloadSkills` follow-up but exposes it as an
+ * interactive slash command so users can pull in newly installed skills
+ * without restarting the session.
+ */
+
+import { reloadSkills } from '../skill/index.js';
+
+/**
+ * Re-scan skill directories rooted at `workdir` and produce a human-readable
+ * summary suitable for echoing back to the TUI / REPL.
+ */
+export async function runReloadSkills(workdir: string): Promise<string> {
+  const { added, removed, total } = reloadSkills(workdir);
+  return `Skills reloaded: +${added} added, -${removed} removed, ${total} total.`;
+}

--- a/src/hooks/__tests__/reload-skills.test.ts
+++ b/src/hooks/__tests__/reload-skills.test.ts
@@ -1,0 +1,166 @@
+/**
+ * SessionStart `reloadSkills` follow-up tests.
+ *
+ * The hook manager must:
+ * - parse `hookSpecificOutput.reloadSkills` out of a successful SessionStart
+ *   hook's stdout JSON;
+ * - call `reloadSkills(cwd)` from `src/skill/index.ts` exactly once per
+ *   `execute()` invocation, even if multiple hooks request a reload;
+ * - leave non-SessionStart events alone.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const reloadSkillsMock = vi.fn(() => ({ added: 0, removed: 0, total: 0 }));
+
+vi.mock('../../skill/index.js', () => ({
+  reloadSkills: reloadSkillsMock,
+}));
+
+import {
+  HookManagerImpl,
+  parseHookSpecificOutput,
+  type HookContext,
+  type HookDefinition,
+} from '../index.js';
+
+describe('SessionStart reloadSkills follow-up', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    reloadSkillsMock.mockClear();
+    reloadSkillsMock.mockReturnValue({ added: 1, removed: 0, total: 5 });
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reload-skills-hook-'));
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('parseHookSpecificOutput', () => {
+    it('extracts the reloadSkills flag from a JSON stdout payload', () => {
+      const out = JSON.stringify({ hookSpecificOutput: { reloadSkills: true } });
+      expect(parseHookSpecificOutput(out)).toEqual({ reloadSkills: true });
+    });
+
+    it('returns undefined for plain text output', () => {
+      expect(parseHookSpecificOutput('not json at all')).toBeUndefined();
+    });
+
+    it('returns undefined for objects without a hookSpecificOutput key', () => {
+      expect(parseHookSpecificOutput({ unrelated: true })).toBeUndefined();
+    });
+
+    it('accepts an object value directly (script return path)', () => {
+      const ret = { hookSpecificOutput: { reloadSkills: true, sessionTitle: 'Hi' } };
+      expect(parseHookSpecificOutput(ret)).toEqual({
+        reloadSkills: true,
+        sessionTitle: 'Hi',
+      });
+    });
+
+    it('rejects malformed shapes safely', () => {
+      const bad = JSON.stringify({ hookSpecificOutput: { reloadSkills: 'yes' } });
+      expect(parseHookSpecificOutput(bad)).toBeUndefined();
+    });
+  });
+
+  describe('SessionStart hook integration', () => {
+    it('invokes reloadSkills once when a SessionStart hook requests it', async () => {
+      const manager = new HookManagerImpl();
+      const payload = JSON.stringify({ hookSpecificOutput: { reloadSkills: true } });
+      // printf avoids appending a trailing newline on POSIX shells; cmd.exe
+      // quirks aren't material here because the JSON is robust to trailing
+      // whitespace via parseHookSpecificOutput.
+      const command =
+        process.platform === 'win32'
+          ? `echo ${payload.replace(/"/g, '\\"')}`
+          : `printf '%s' '${payload}'`;
+
+      const hook: HookDefinition = {
+        event: 'SessionStart',
+        type: 'command',
+        command,
+      };
+      manager.register(hook);
+
+      const ctx: HookContext = {
+        event: 'SessionStart',
+        timestamp: Date.now(),
+      };
+
+      const results = await manager.execute('SessionStart', ctx);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(true);
+      expect(results[0].hookSpecificOutput?.reloadSkills).toBe(true);
+      expect(reloadSkillsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not invoke reloadSkills for hooks that do not request it', async () => {
+      const manager = new HookManagerImpl();
+      const command = process.platform === 'win32' ? `echo hello` : `printf 'hello'`;
+
+      manager.register({
+        event: 'SessionStart',
+        type: 'command',
+        command,
+      });
+
+      await manager.execute('SessionStart', {
+        event: 'SessionStart',
+        timestamp: Date.now(),
+      });
+
+      expect(reloadSkillsMock).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke reloadSkills for non-SessionStart events', async () => {
+      const manager = new HookManagerImpl();
+      const payload = JSON.stringify({ hookSpecificOutput: { reloadSkills: true } });
+      const command =
+        process.platform === 'win32'
+          ? `echo ${payload.replace(/"/g, '\\"')}`
+          : `printf '%s' '${payload}'`;
+
+      // PostToolUse accepts command hooks too; reloadSkills must be ignored.
+      manager.register({
+        event: 'PostToolUse',
+        type: 'command',
+        command,
+      });
+
+      await manager.execute('PostToolUse', {
+        event: 'PostToolUse',
+        timestamp: Date.now(),
+        toolName: 'read',
+      });
+
+      expect(reloadSkillsMock).not.toHaveBeenCalled();
+    });
+
+    it('only fires reloadSkills once even when multiple hooks request it', async () => {
+      const manager = new HookManagerImpl();
+      const payload = JSON.stringify({ hookSpecificOutput: { reloadSkills: true } });
+      const command =
+        process.platform === 'win32'
+          ? `echo ${payload.replace(/"/g, '\\"')}`
+          : `printf '%s' '${payload}'`;
+
+      manager.register({ event: 'SessionStart', type: 'command', command });
+      manager.register({ event: 'SessionStart', type: 'command', command });
+
+      await manager.execute('SessionStart', {
+        event: 'SessionStart',
+        timestamp: Date.now(),
+      });
+
+      expect(reloadSkillsMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -17,6 +17,7 @@ import path from 'path';
 import os from 'os';
 import { pathToFileURL } from 'url';
 import { defineEvent } from '../bus/index.js';
+import { logger } from '../utils/logger.js';
 
 // ============ Type Definitions ============
 
@@ -73,6 +74,17 @@ export interface HookContext {
   error?: string;
 }
 
+export interface HookSpecificOutput {
+  /**
+   * When true on a SessionStart result, the runtime re-scans skill
+   * directories and replaces the active skill registry. Other events
+   * ignore this flag.
+   */
+  reloadSkills?: boolean;
+  /** Reserved for future SessionStart customisations. */
+  sessionTitle?: string;
+}
+
 export interface HookResult {
   success: boolean;
   output?: string;
@@ -82,9 +94,35 @@ export interface HookResult {
   capped?: boolean;
   /** When true, callers should feed the rejection reason back to the model instead of halting */
   continueOnBlock?: boolean;
+
+  /**
+   * Hook-specific structured output. Hooks can populate selected fields to
+   * request follow-up actions from the runtime. Currently only meaningful
+   * for `SessionStart` hooks.
+   *
+   * Surfaced from a hook by emitting a JSON object on stdout (command hooks),
+   * the HTTP response body (http hooks), or the function return value
+   * (script hooks) with shape `{ "hookSpecificOutput": { ... } }`.
+   */
+  hookSpecificOutput?: HookSpecificOutput;
 }
 
 // Zod schemas for validation
+export const HookSpecificOutputSchema = z.object({
+  reloadSkills: z.boolean().optional(),
+  sessionTitle: z.string().optional(),
+});
+
+export const HookResultSchema = z.object({
+  success: z.boolean(),
+  output: z.string().optional(),
+  error: z.string().optional(),
+  duration: z.number(),
+  capped: z.boolean().optional(),
+  continueOnBlock: z.boolean().optional(),
+  hookSpecificOutput: HookSpecificOutputSchema.optional(),
+});
+
 export const HookDefinitionSchema = z.object({
   event: z.enum([
     'SessionStart',
@@ -175,6 +213,47 @@ export function getBlockCap(): number {
     }
   }
   return STOP_HOOK_BLOCK_CAP;
+}
+
+// ============ Hook-Specific Output Parsing ============
+
+/**
+ * Attempt to extract a `hookSpecificOutput` block from arbitrary hook output.
+ *
+ * Accepts either a raw string (stdout / HTTP body) or an object (script return
+ * value). Strings are parsed as JSON; if the parse fails or the shape is wrong
+ * the function returns `undefined`. Unknown extra fields are ignored — only
+ * the keys defined on {@link HookSpecificOutputSchema} are honored.
+ */
+export function parseHookSpecificOutput(value: unknown): HookSpecificOutput | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  let candidate: unknown = value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed.startsWith('{')) {
+      return undefined;
+    }
+    try {
+      candidate = JSON.parse(trimmed);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (typeof candidate !== 'object' || candidate === null) {
+    return undefined;
+  }
+
+  const block = (candidate as { hookSpecificOutput?: unknown }).hookSpecificOutput;
+  if (block === undefined) {
+    return undefined;
+  }
+
+  const parsed = HookSpecificOutputSchema.safeParse(block);
+  return parsed.success ? parsed.data : undefined;
 }
 
 // ============ Template Substitution ============
@@ -282,11 +361,16 @@ async function executeCommandHook(hook: HookDefinition, context: HookContext): P
           duration,
         });
       } else {
-        resolve({
+        const result: HookResult = {
           success: true,
           output: stdout,
           duration,
-        });
+        };
+        const hso = parseHookSpecificOutput(stdout);
+        if (hso) {
+          result.hookSpecificOutput = hso;
+        }
+        resolve(result);
       }
     });
 
@@ -353,11 +437,16 @@ async function executeHttpHook(hook: HookDefinition, context: HookContext): Prom
       };
     }
 
-    return {
+    const result: HookResult = {
       success: true,
       output: responseText,
       duration,
     };
+    const hso = parseHookSpecificOutput(responseText);
+    if (hso) {
+      result.hookSpecificOutput = hso;
+    }
+    return result;
   } catch (err) {
     const duration = Date.now() - startTime;
     const error = err instanceof Error ? err.message : String(err);
@@ -427,14 +516,20 @@ async function executeScriptHook(hook: HookDefinition, context: HookContext): Pr
       return hookFn(context);
     })();
 
-    const result = await Promise.race([executePromise, timeoutPromise]);
+    const scriptReturn = await Promise.race([executePromise, timeoutPromise]);
     const duration = Date.now() - startTime;
 
-    return {
+    const hookResult: HookResult = {
       success: true,
-      output: result !== undefined ? JSON.stringify(result) : undefined,
+      output: scriptReturn !== undefined ? JSON.stringify(scriptReturn) : undefined,
       duration,
     };
+    // Script return values are objects, not strings — pass through directly.
+    const hso = parseHookSpecificOutput(scriptReturn);
+    if (hso) {
+      hookResult.hookSpecificOutput = hso;
+    }
+    return hookResult;
   } catch (err) {
     const duration = Date.now() - startTime;
     const error = err instanceof Error ? err.message : String(err);
@@ -444,6 +539,32 @@ async function executeScriptHook(hook: HookDefinition, context: HookContext): Pr
       error: `Script execution failed: ${error}`,
       duration,
     };
+  }
+}
+
+// ============ SessionStart Side-Effects ============
+
+/**
+ * Inspect SessionStart hook results and, if any successful result requested a
+ * skill reload, perform exactly one reload of the active skill registry.
+ *
+ * The skill module is imported lazily so the hooks module stays usable in
+ * environments that don't load skills (and to avoid an import cycle).
+ */
+async function maybeReloadSkillsFromResults(results: HookResult[]): Promise<void> {
+  const wantsReload = results.some((r) => r.success && r.hookSpecificOutput?.reloadSkills === true);
+  if (!wantsReload) {
+    return;
+  }
+
+  try {
+    const skillModule = await import('../skill/index.js');
+    const counts = skillModule.reloadSkills(process.cwd());
+    logger.info(
+      `Skills reloaded by SessionStart hook: +${counts.added} -${counts.removed} (total ${counts.total})`
+    );
+  } catch (err) {
+    logger.warn(`Skill reload failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
@@ -607,6 +728,12 @@ export class HookManagerImpl implements HookManager {
           timestamp: Date.now(),
         });
       }
+    }
+
+    // SessionStart hooks may request a skill registry refresh. Honor it once
+    // per execute() call regardless of how many hooks asked.
+    if (event === 'SessionStart') {
+      await maybeReloadSkillsFromResults(results);
     }
 
     return results;

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -9,6 +9,23 @@ import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
 import { getGlobalPaths } from '../utils/global.js';
+import { defineEvent } from '../bus/index.js';
+
+// ============ Events ============
+
+/**
+ * Emitted whenever the skill registry is re-scanned and replaced via
+ * {@link reloadSkills}.
+ */
+export const SkillReloaded = defineEvent(
+  'skill.reloaded',
+  z.object({
+    added: z.number(),
+    removed: z.number(),
+    total: z.number(),
+    timestamp: z.number(),
+  })
+);
 
 // Skill definition schema
 export const SkillSchema = z.object({
@@ -419,6 +436,88 @@ export function getSkill(idOrAlias: string): Skill | undefined {
 
 export function listSkills(): Skill[] {
   return getSkillRegistry().list();
+}
+
+/**
+ * Re-scan all skill directories and replace the file-sourced entries in the
+ * active registry.
+ *
+ * - Built-in skills (anything not loaded from a file) are preserved verbatim.
+ * - File-sourced skills that no longer appear on disk are removed.
+ * - New on-disk skills are added.
+ * - Existing on-disk skills are refreshed in case their content changed.
+ *
+ * Publishes a `skill.reloaded` event with `{ added, removed, total }` counts.
+ */
+export function reloadSkills(projectRoot: string): {
+  added: number;
+  removed: number;
+  total: number;
+} {
+  const registry = getSkillRegistry();
+
+  // Snapshot the current file-sourced skills before re-scanning.
+  const previousFileIds = new Set<string>();
+  for (const skill of registry.list()) {
+    if (skill.source === 'file') {
+      previousFileIds.add(skill.id);
+    }
+  }
+
+  // Re-scan all configured skill directories with a fresh visited set so a
+  // call after a directory was newly created actually picks up the entries.
+  const directories = skillDirectories(projectRoot);
+  const seen = new Set<string>();
+  const discovered: Skill[] = [];
+  for (const dir of directories) {
+    discovered.push(...loadSkillsFromDirectory(dir, seen));
+  }
+
+  // Deduplicate by id; first occurrence wins (project before global because
+  // skillDirectories returns them in precedence order).
+  const discoveredById = new Map<string, Skill>();
+  for (const skill of discovered) {
+    if (!discoveredById.has(skill.id)) {
+      discoveredById.set(skill.id, skill);
+    }
+  }
+
+  // Remove file-sourced skills that have disappeared. Built-ins (any non-file
+  // source) are never touched here. We also defensively skip ids in the
+  // BUILTIN_SKILLS set in case a built-in was somehow loaded as a file.
+  let removed = 0;
+  for (const id of previousFileIds) {
+    if (discoveredById.has(id)) {
+      continue;
+    }
+    if (isBuiltinSkill(id)) {
+      continue;
+    }
+    if (registry.remove(id)) {
+      removed++;
+    }
+  }
+
+  // Register / refresh discovered skills. Track adds (skills that weren't
+  // present as file-sourced before this reload).
+  let added = 0;
+  for (const skill of discoveredById.values()) {
+    if (!previousFileIds.has(skill.id)) {
+      added++;
+    }
+    registry.register(skill);
+  }
+
+  const total = registry.list().length;
+
+  SkillReloaded.publish({
+    added,
+    removed,
+    total,
+    timestamp: Date.now(),
+  });
+
+  return { added, removed, total };
 }
 
 // Re-export

--- a/src/skill/reload.test.ts
+++ b/src/skill/reload.test.ts
@@ -1,0 +1,180 @@
+/**
+ * `reloadSkills` registry-refresh tests.
+ *
+ * Verifies that re-scanning skill directories:
+ * - Picks up newly added skills on a second call.
+ * - Removes file-sourced skills that have disappeared.
+ * - Preserves built-in skills (source !== 'file') across reloads.
+ * - Publishes the `skill.reloaded` event with correct counts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const globalSkillsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reload-skills-global-'));
+
+vi.mock('../utils/global.js', () => ({
+  getGlobalPaths: () => ({
+    config: path.dirname(globalSkillsDir),
+    skills: globalSkillsDir,
+    cache: path.join(path.dirname(globalSkillsDir), 'cache'),
+  }),
+}));
+
+import {
+  reloadSkills,
+  getSkillRegistry,
+  defineSkill,
+  registerSkill,
+  SkillReloaded,
+  type Skill,
+} from './index.js';
+
+const SKILL_BODY = (id: string): string => `---
+id: ${id}
+name: ${id}
+description: ${id} from disk
+---
+
+Prompt for ${id}.
+`;
+
+describe('reloadSkills', () => {
+  let projectRoot: string;
+  let tempRoots: string[];
+
+  beforeEach(() => {
+    tempRoots = [];
+    projectRoot = mkTempDir('reload-skills-project-');
+    // Reset the registry to a clean baseline so tests don't interact.
+    getSkillRegistry().clear();
+  });
+
+  afterEach(() => {
+    for (const dir of tempRoots) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    // Empty the controlled global skills dir between tests.
+    if (fs.existsSync(globalSkillsDir)) {
+      for (const entry of fs.readdirSync(globalSkillsDir)) {
+        fs.rmSync(path.join(globalSkillsDir, entry), { recursive: true, force: true });
+      }
+    }
+    getSkillRegistry().clear();
+  });
+
+  function mkTempDir(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    const resolved = fs.realpathSync(dir);
+    tempRoots.push(resolved);
+    return resolved;
+  }
+
+  function writeSkill(dir: string, id: string): string {
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `${id}.md`);
+    fs.writeFileSync(file, SKILL_BODY(id));
+    return file;
+  }
+
+  it('discovers new on-disk skills on a subsequent reload', () => {
+    const projectSkillsDir = path.join(projectRoot, '.alexi', 'skills');
+    writeSkill(projectSkillsDir, 'first-skill');
+    writeSkill(globalSkillsDir, 'second-skill');
+
+    const first = reloadSkills(projectRoot);
+    expect(first.added).toBe(2);
+    expect(first.removed).toBe(0);
+    expect(first.total).toBe(2);
+
+    // Verify registry contents.
+    const ids1 = getSkillRegistry()
+      .list()
+      .map((s) => s.id)
+      .sort();
+    expect(ids1).toEqual(['first-skill', 'second-skill']);
+
+    // Add a third on-disk skill and reload again.
+    writeSkill(projectSkillsDir, 'third-skill');
+
+    const second = reloadSkills(projectRoot);
+    expect(second.added).toBe(1);
+    expect(second.removed).toBe(0);
+    expect(second.total).toBe(3);
+
+    const ids2 = getSkillRegistry()
+      .list()
+      .map((s) => s.id)
+      .sort();
+    expect(ids2).toContain('third-skill');
+    expect(ids2).toHaveLength(3);
+  });
+
+  it('removes file-sourced skills that have disappeared', () => {
+    const projectSkillsDir = path.join(projectRoot, '.alexi', 'skills');
+    const file = writeSkill(projectSkillsDir, 'doomed-skill');
+
+    const first = reloadSkills(projectRoot);
+    expect(first.added).toBe(1);
+    expect(getSkillRegistry().has('doomed-skill')).toBe(true);
+
+    // Delete the file and reload.
+    fs.unlinkSync(file);
+
+    const second = reloadSkills(projectRoot);
+    expect(second.removed).toBe(1);
+    expect(second.added).toBe(0);
+    expect(getSkillRegistry().has('doomed-skill')).toBe(false);
+  });
+
+  it('preserves built-in skills across reloads', () => {
+    // Register a built-in (non-file) skill before any reload.
+    const builtin: Skill = defineSkill({
+      id: 'alexi-config',
+      name: 'Alexi Config (test)',
+      description: 'Built-in protected skill',
+      prompt: 'built-in',
+    });
+    registerSkill(builtin);
+
+    const projectSkillsDir = path.join(projectRoot, '.alexi', 'skills');
+    writeSkill(projectSkillsDir, 'project-skill');
+
+    const first = reloadSkills(projectRoot);
+    expect(first.total).toBe(2);
+    expect(getSkillRegistry().has('alexi-config')).toBe(true);
+
+    // Second reload — built-in must still be present even when file-sourced
+    // skills disappear.
+    fs.rmSync(projectSkillsDir, { recursive: true, force: true });
+    const second = reloadSkills(projectRoot);
+    expect(getSkillRegistry().has('alexi-config')).toBe(true);
+    expect(getSkillRegistry().has('project-skill')).toBe(false);
+    expect(second.total).toBe(1);
+  });
+
+  it('publishes a skill.reloaded event with the count summary', () => {
+    const events: Array<{ added: number; removed: number; total: number }> = [];
+    const unsubscribe = SkillReloaded.subscribe((payload) => {
+      events.push({ added: payload.added, removed: payload.removed, total: payload.total });
+    });
+
+    try {
+      const projectSkillsDir = path.join(projectRoot, '.alexi', 'skills');
+      writeSkill(projectSkillsDir, 'evt-skill');
+
+      const counts = reloadSkills(projectRoot);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        added: counts.added,
+        removed: counts.removed,
+        total: counts.total,
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation of #534 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 9
- **Branch**: `auto/534-hook-sessionstart-reloadskills-output-and-reload-s`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #534
