### PR TITLE
feat: [config] Honor agent field in user config as default agent (#531)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -114,11 +114,18 @@ User configuration is stored in `~/.alexi/config.json` and persists settings acr
 ```typescript
 interface UserConfig {
   defaultModel?: string;          // Persistent default model
+  agent?: string;                 // Default agent slug for `alexi agent` / `alexi chat`
+                                  //   (overridden per-invocation by `--agent <name>`)
   soundEnabled?: boolean;         // Enable notification sounds
   autoRoute?: boolean;            // Auto-routing preference
   [key: string]: unknown;         // Extensible for custom settings
 }
 ```
+
+The `agent` field accepts any built-in agent slug (`code`, `debug`, `plan`,
+`explore`, `orchestrator`) or a custom agent slug loaded from
+`~/.alexi/agents/*.md` or `<project>/.alexi/agents/*.md`. Unknown slugs log
+a warning and fall back to the default agent (no crash).
 
 ### Managing Configuration
 

--- a/src/agent/defaultAgent.test.ts
+++ b/src/agent/defaultAgent.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { pickAgentSlug, resolveDefaultAgent } from './defaultAgent.js';
+import * as logger from '../utils/logger.js';
+
+// pickAgentSlug — pure precedence logic
+describe('pickAgentSlug', () => {
+  it('returns CLI flag when both CLI and config are set (CLI > config)', () => {
+    expect(pickAgentSlug({ cliFlag: 'debug', configValue: 'plan' })).toBe('debug');
+  });
+
+  it('returns config value when CLI flag is absent', () => {
+    expect(pickAgentSlug({ configValue: 'plan' })).toBe('plan');
+  });
+
+  it('returns undefined when neither is set', () => {
+    expect(pickAgentSlug({})).toBeUndefined();
+  });
+
+  it('treats empty CLI flag as absent and falls through to config', () => {
+    expect(pickAgentSlug({ cliFlag: '', configValue: 'debug' })).toBe('debug');
+  });
+
+  it('treats whitespace-only CLI flag as absent and falls through to config', () => {
+    expect(pickAgentSlug({ cliFlag: '   ', configValue: 'debug' })).toBe('debug');
+  });
+
+  it('treats whitespace-only config value as absent', () => {
+    expect(pickAgentSlug({ configValue: '   ' })).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace from the resolved slug', () => {
+    expect(pickAgentSlug({ cliFlag: '  debug  ' })).toBe('debug');
+    expect(pickAgentSlug({ configValue: '  plan  ' })).toBe('plan');
+  });
+});
+
+// resolveDefaultAgent — registry validation
+describe('resolveDefaultAgent', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger.logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns undefined when no slug is provided (no warning)', async () => {
+    const result = await resolveDefaultAgent({});
+    expect(result).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the canonical agent id when CLI flag matches a built-in agent', async () => {
+    const result = await resolveDefaultAgent({ cliFlag: 'debug' });
+    expect(result).toBe('debug');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('resolves an alias to the canonical agent id', async () => {
+    // 'fix' is an alias of the 'debug' agent
+    const result = await resolveDefaultAgent({ cliFlag: 'fix' });
+    expect(result).toBe('debug');
+  });
+
+  it('honors config value when CLI flag is absent', async () => {
+    const result = await resolveDefaultAgent({ configValue: 'plan' });
+    expect(result).toBe('plan');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('CLI flag overrides config value', async () => {
+    const result = await resolveDefaultAgent({ cliFlag: 'debug', configValue: 'plan' });
+    expect(result).toBe('debug');
+  });
+
+  it('logs a warning and returns undefined for an unknown slug (no throw)', async () => {
+    const result = await resolveDefaultAgent({ cliFlag: 'this-agent-does-not-exist' });
+    expect(result).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('this-agent-does-not-exist');
+  });
+});

--- a/src/agent/defaultAgent.ts
+++ b/src/agent/defaultAgent.ts
@@ -1,0 +1,96 @@
+/**
+ * Default Agent Resolution
+ *
+ * Determines which agent slug to use for a given CLI invocation.
+ *
+ * Precedence (highest → lowest):
+ *   1. `--agent <name>` CLI flag (per-invocation override)
+ *   2. `agent` field in ~/.alexi/config.json (user default)
+ *   3. `undefined` — caller falls through to its own default
+ *
+ * If a slug is resolved but does not exist in the agent registry,
+ * a warning is logged and `undefined` is returned (no throw).
+ */
+
+import { getAgentRegistry } from './index.js';
+import { logger } from '../utils/logger.js';
+
+export interface ResolveDefaultAgentInput {
+  /** Slug supplied via CLI flag (e.g. `--agent debug`) */
+  cliFlag?: string;
+  /** Slug persisted in user config (`agent` key in config.json) */
+  configValue?: string;
+  /**
+   * Working directory used to discover project-local custom agents.
+   * Defaults to `process.cwd()` when omitted.
+   */
+  workdir?: string;
+}
+
+/**
+ * Pure precedence resolver — picks the slug to use without validating
+ * that it exists in the registry.
+ *
+ * Trims values and treats empty/whitespace-only strings as absent.
+ *
+ * Exported for unit testing.
+ */
+export function pickAgentSlug(input: ResolveDefaultAgentInput): string | undefined {
+  const cli = input.cliFlag?.trim();
+  if (cli && cli.length > 0) {
+    return cli;
+  }
+
+  const cfg = input.configValue?.trim();
+  if (cfg && cfg.length > 0) {
+    return cfg;
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve the default agent slug for an invocation, validating against
+ * the agent registry.
+ *
+ * Returns `undefined` when no slug is set at any level, or when the
+ * resolved slug does not match any registered agent (built-in or
+ * custom) — in which case a warning is logged via the shared logger.
+ *
+ * Custom agents are loaded lazily from `~/.alexi/agents/` and
+ * `<workdir>/.alexi/agents/` before validation so user-defined slugs
+ * are recognized.
+ *
+ * Callers should pass the result as the `agentId` option to
+ * `agenticChat()`.
+ */
+export async function resolveDefaultAgent(
+  input: ResolveDefaultAgentInput
+): Promise<string | undefined> {
+  const slug = pickAgentSlug(input);
+  if (!slug) {
+    return undefined;
+  }
+
+  const registry = getAgentRegistry();
+
+  // Load custom agents on demand so user-defined slugs are resolvable.
+  // Failures here are non-fatal: built-in agents remain available.
+  if (!registry.get(slug)) {
+    try {
+      await registry.loadCustomAgents(input.workdir);
+    } catch (err) {
+      logger.warn(
+        `Failed to load custom agents while resolving '${slug}': ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  const agent = registry.get(slug);
+  if (!agent) {
+    logger.warn(`Unknown agent '${slug}' — falling back to default agent`);
+    return undefined;
+  }
+
+  return agent.id;
+}

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -18,6 +18,8 @@ import { commitDirtyFiles } from '../../git/dirtyFiles.js';
 import { RepoMapManager } from '../../context/repoMap.js';
 import { parseEffortLevel, type EffortLevel } from '../../core/effortLevel.js';
 import { createWorktree } from '../../utils/gitWorktree.js';
+import { resolveDefaultAgent } from '../../agent/defaultAgent.js';
+import { getConfigDefaultAgent } from '../../config/userConfig.js';
 
 interface AgentOptions {
   message?: string;
@@ -43,6 +45,8 @@ interface AgentOptions {
   mapTokens?: string;
   // Effort level
   effort?: string;
+  // Custom agent slug (overrides config default)
+  agent?: string;
 }
 
 export function registerAgentCommand(program: Command): void {
@@ -72,6 +76,10 @@ export function registerAgentCommand(program: Command): void {
     .option('--map-tokens <n>', 'Repo map token budget (default: 2000; set to 0 to disable)')
     // Effort level
     .option('--effort <level>', 'Effort level: low, medium, high (default: medium)')
+    .option(
+      '--agent <name>',
+      'Custom agent slug to dispatch (overrides `agent` field in user config)'
+    )
     .action(async (opts: AgentOptions) => {
       let worktreeCleanup: (() => Promise<void>) | undefined;
       try {
@@ -210,6 +218,14 @@ export function registerAgentCommand(program: Command): void {
               }
             : undefined;
 
+        // Resolve agent: --agent flag > config `agent` field > undefined.
+        // Unknown slugs log a warning and fall back to the default agent.
+        const agentId = await resolveDefaultAgent({
+          cliFlag: opts.agent,
+          configValue: getConfigDefaultAgent(),
+          workdir,
+        });
+
         const res = await agenticChat(message, {
           modelOverride: opts.model,
           autoRoute: opts.autoRoute,
@@ -223,6 +239,7 @@ export function registerAgentCommand(program: Command): void {
           gitManager,
           repoMapManager,
           effort,
+          agentId,
         });
 
         // Flush any pending auto-commits

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -6,6 +6,9 @@ import { readFileSync } from 'node:fs';
 import type { Command } from 'commander';
 import { sendChat } from '../../core/orchestrator.js';
 import { SessionManager } from '../../core/sessionManager.js';
+import { resolveDefaultAgent } from '../../agent/defaultAgent.js';
+import { getConfigDefaultAgent } from '../../config/userConfig.js';
+import { getAgentRegistry } from '../../agent/index.js';
 
 interface ChatOptions {
   message?: string;
@@ -15,6 +18,7 @@ interface ChatOptions {
   preferCheap?: boolean;
   session?: string;
   system?: string;
+  agent?: string;
 }
 
 export function registerChatCommand(program: Command): void {
@@ -27,6 +31,10 @@ export function registerChatCommand(program: Command): void {
     .option('--prefer-cheap', 'Prefer cheaper models when auto-routing')
     .option('--session <id>', 'Continue existing session')
     .option('--system <prompt>', 'System prompt for the conversation')
+    .option(
+      '--agent <name>',
+      'Agent slug whose system prompt and model become defaults (overrides `agent` field in user config). Tools are not enabled in chat mode, so agent tool restrictions are ignored.'
+    )
     .action(async (opts: ChatOptions) => {
       try {
         // Get message from either --message or --message-file
@@ -52,12 +60,36 @@ export function registerChatCommand(program: Command): void {
           console.log(`[Continuing session: ${session.metadata.title || opts.session}]`);
         }
 
+        // Resolve agent: --agent flag > config `agent` field > undefined.
+        // Unknown slugs log a warning and fall back to defaults.
+        const agentId = await resolveDefaultAgent({
+          cliFlag: opts.agent,
+          configValue: getConfigDefaultAgent(),
+        });
+
+        // For chat, the agent's system prompt and model become defaults.
+        // Tools are not enabled on this path, so `tools`/`disabledTools`
+        // on the agent are intentionally ignored.
+        let effectiveSystemPrompt = opts.system;
+        let effectiveModel = opts.model;
+        if (agentId) {
+          const agent = getAgentRegistry().get(agentId);
+          if (agent) {
+            if (!effectiveSystemPrompt) {
+              effectiveSystemPrompt = agent.systemPrompt;
+            }
+            if (!effectiveModel && agent.preferredModel) {
+              effectiveModel = agent.preferredModel;
+            }
+          }
+        }
+
         const res = await sendChat(message, {
-          modelOverride: opts.model,
+          modelOverride: effectiveModel,
           autoRoute: opts.autoRoute,
           preferCheap: opts.preferCheap,
           sessionManager,
-          systemPrompt: opts.system,
+          systemPrompt: effectiveSystemPrompt,
         });
 
         console.log(res.text);

--- a/src/config/userConfig.ts
+++ b/src/config/userConfig.ts
@@ -183,6 +183,35 @@ export function setConfigDefaultModel(modelId: string): void {
   setConfigValue('defaultModel', modelId);
 }
 
+/**
+ * Get the user's persisted default agent slug, or undefined if not set.
+ * Read from the `agent` top-level key in ~/.alexi/config.json.
+ *
+ * Returns `undefined` for non-string values, empty strings, or
+ * whitespace-only strings.
+ */
+export function getConfigDefaultAgent(): string | undefined {
+  const value = getConfigValue('agent');
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Persist the user's chosen default agent slug.
+ */
+export function setConfigDefaultAgent(slug: string): void {
+  setConfigValue('agent', slug);
+}
+
+/**
+ * Clear the user's default agent setting.
+ */
+export function clearConfigDefaultAgent(): void {
+  deleteConfigValue('agent');
+}
+
 // ============ Batch update with options ============
 
 export interface UpdateGlobalOptions {

--- a/tests/config/userConfig.test.ts
+++ b/tests/config/userConfig.test.ts
@@ -14,6 +14,9 @@ import {
   deleteConfigValue,
   getConfigDefaultModel,
   setConfigDefaultModel,
+  getConfigDefaultAgent,
+  setConfigDefaultAgent,
+  clearConfigDefaultAgent,
 } from '../../src/config/userConfig.js';
 
 describe('userConfig', () => {
@@ -169,6 +172,66 @@ describe('userConfig', () => {
       expect(config.defaultModel).toBe('gpt-4.1');
       expect(config.theme).toBe('dark');
       expect(config.sounds).toEqual({ enabled: true });
+    });
+  });
+
+  describe('getConfigDefaultAgent / setConfigDefaultAgent / clearConfigDefaultAgent', () => {
+    it('should return undefined when no agent is set', () => {
+      saveFullConfig({});
+      expect(getConfigDefaultAgent()).toBeUndefined();
+    });
+
+    it('should return undefined for empty string', () => {
+      saveFullConfig({ agent: '' });
+      expect(getConfigDefaultAgent()).toBeUndefined();
+    });
+
+    it('should return undefined for whitespace-only string', () => {
+      saveFullConfig({ agent: '   ' });
+      expect(getConfigDefaultAgent()).toBeUndefined();
+    });
+
+    it('should return undefined for non-string values', () => {
+      saveFullConfig({ agent: 42 });
+      expect(getConfigDefaultAgent()).toBeUndefined();
+    });
+
+    it('should return trimmed agent slug', () => {
+      saveFullConfig({ agent: '  debug  ' });
+      expect(getConfigDefaultAgent()).toBe('debug');
+    });
+
+    it('should persist agent via setConfigDefaultAgent', () => {
+      saveFullConfig({});
+      setConfigDefaultAgent('debug');
+      expect(getConfigDefaultAgent()).toBe('debug');
+    });
+
+    it('should preserve other config keys when setting default agent', () => {
+      saveFullConfig({ defaultModel: 'gpt-4.1', theme: 'dark' });
+      setConfigDefaultAgent('plan');
+
+      const config = loadFullConfig();
+      expect(config.agent).toBe('plan');
+      expect(config.defaultModel).toBe('gpt-4.1');
+      expect(config.theme).toBe('dark');
+    });
+
+    it('should clear the agent key via clearConfigDefaultAgent', () => {
+      saveFullConfig({ agent: 'debug', defaultModel: 'gpt-4.1' });
+      clearConfigDefaultAgent();
+
+      const config = loadFullConfig();
+      expect(config.agent).toBeUndefined();
+      expect(config.defaultModel).toBe('gpt-4.1');
+      expect(getConfigDefaultAgent()).toBeUndefined();
+    });
+
+    it('should be a no-op when clearing an unset agent', () => {
+      saveFullConfig({ defaultModel: 'gpt-4.1' });
+      expect(() => clearConfigDefaultAgent()).not.toThrow();
+      expect(getConfigDefaultAgent()).toBeUndefined();
+      expect(loadFullConfig().defaultModel).toBe('gpt-4.1');
     });
   });
 });


### PR DESCRIPTION
## Summary

Automated implementation of #531 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 7
- **Branch**: `auto/531-config-honor-agent-field-in-user-config-as-default`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #531
