### PR TITLE
feat: [tool] Walk parent directories for nearby AGENTS.md and inject as <system-reminder> after file reads (#578)

### DIFF
--- a/src/agent/system.test.ts
+++ b/src/agent/system.test.ts
@@ -9,6 +9,7 @@ import {
   getModelPrompt,
   getSoulPrompt,
   getModelPromptKey,
+  instructionsForPath,
 } from './system.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -298,6 +299,162 @@ describe('Prompt System', () => {
       expect(matches.length).toBe(1);
       // No global block when it would point at the same file.
       expect(prompt).not.toContain('<global-agents-md');
+    });
+  });
+
+  describe('instructionsForPath', () => {
+    let workdir: string;
+
+    beforeEach(() => {
+      workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'agents-walk-')));
+    });
+
+    afterEach(() => {
+      try {
+        fs.rmSync(workdir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    });
+
+    it('returns [] when no AGENTS.md exists between workdir and the file', () => {
+      const file = path.join(workdir, 'apps', 'api', 'src', 'index.ts');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, 'export {}');
+
+      const seen = new Set<string>();
+      const result = instructionsForPath(file, workdir, seen);
+
+      expect(result).toEqual([]);
+      expect(seen.size).toBe(0);
+    });
+
+    it('returns reminders for apps/api/AGENTS.md when reading apps/api/src/index.ts', () => {
+      const file = path.join(workdir, 'apps', 'api', 'src', 'index.ts');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, 'export {}');
+      const agentsPath = path.join(workdir, 'apps', 'api', 'AGENTS.md');
+      fs.writeFileSync(agentsPath, 'API_RULES_TOKEN');
+
+      const seen = new Set<string>();
+      const result = instructionsForPath(file, workdir, seen);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].path).toBe(fs.realpathSync(agentsPath));
+      expect(result[0].content).toBe('API_RULES_TOKEN');
+      expect(seen.has(fs.realpathSync(agentsPath))).toBe(true);
+    });
+
+    it('returns nearest-first when multiple AGENTS.md exist on the path', () => {
+      const file = path.join(workdir, 'apps', 'api', 'src', 'index.ts');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, 'export {}');
+      const apiAgents = path.join(workdir, 'apps', 'api', 'AGENTS.md');
+      const srcAgents = path.join(workdir, 'apps', 'api', 'src', 'AGENTS.md');
+      fs.writeFileSync(apiAgents, 'API_RULES');
+      fs.writeFileSync(srcAgents, 'SRC_RULES');
+
+      const seen = new Set<string>();
+      const result = instructionsForPath(file, workdir, seen);
+
+      expect(result).toHaveLength(2);
+      // Nearest first: src/AGENTS.md before api/AGENTS.md.
+      expect(result[0].content).toBe('SRC_RULES');
+      expect(result[1].content).toBe('API_RULES');
+    });
+
+    it('excludes the project-root AGENTS.md', () => {
+      const file = path.join(workdir, 'apps', 'api', 'index.ts');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, 'export {}');
+      fs.writeFileSync(path.join(workdir, 'AGENTS.md'), 'ROOT_RULES');
+
+      const seen = new Set<string>();
+      const result = instructionsForPath(file, workdir, seen);
+
+      expect(result).toEqual([]);
+    });
+
+    it('de-dupes when the same file is read twice with a shared seen set', () => {
+      const file = path.join(workdir, 'apps', 'api', 'src', 'index.ts');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, 'export {}');
+      fs.writeFileSync(path.join(workdir, 'apps', 'api', 'AGENTS.md'), 'API_RULES');
+
+      const seen = new Set<string>();
+      const first = instructionsForPath(file, workdir, seen);
+      const second = instructionsForPath(file, workdir, seen);
+
+      expect(first).toHaveLength(1);
+      expect(second).toEqual([]);
+    });
+
+    it('refuses paths outside workdir', () => {
+      const outside = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'outside-')));
+      try {
+        const file = path.join(outside, 'apps', 'index.ts');
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, 'export {}');
+        fs.writeFileSync(path.join(outside, 'apps', 'AGENTS.md'), 'OUTSIDE_RULES');
+
+        const seen = new Set<string>();
+        const result = instructionsForPath(file, workdir, seen);
+
+        expect(result).toEqual([]);
+        expect(seen.size).toBe(0);
+      } finally {
+        fs.rmSync(outside, { recursive: true, force: true });
+      }
+    });
+
+    it('symlinked AGENTS.md de-dupes via realpath', () => {
+      // Two sibling subtrees whose AGENTS.md both point to the same target.
+      const target = path.join(workdir, 'shared-rules.md');
+      fs.writeFileSync(target, 'SHARED_RULES_TOKEN');
+
+      const fileA = path.join(workdir, 'apps', 'a', 'index.ts');
+      const fileB = path.join(workdir, 'apps', 'b', 'index.ts');
+      fs.mkdirSync(path.dirname(fileA), { recursive: true });
+      fs.mkdirSync(path.dirname(fileB), { recursive: true });
+      fs.writeFileSync(fileA, 'export {}');
+      fs.writeFileSync(fileB, 'export {}');
+
+      const linkA = path.join(workdir, 'apps', 'a', 'AGENTS.md');
+      const linkB = path.join(workdir, 'apps', 'b', 'AGENTS.md');
+      fs.symlinkSync(target, linkA);
+      fs.symlinkSync(target, linkB);
+
+      const seen = new Set<string>();
+      const firstResult = instructionsForPath(fileA, workdir, seen);
+      const secondResult = instructionsForPath(fileB, workdir, seen);
+
+      expect(firstResult).toHaveLength(1);
+      expect(firstResult[0].content).toBe('SHARED_RULES_TOKEN');
+      // Second call hits the same realpath via the symlink and is skipped.
+      expect(secondResult).toEqual([]);
+    });
+
+    it('caps walk depth at 32', () => {
+      // Build a deeply nested path: workdir/d1/d2/.../d40/leaf.ts
+      // and place AGENTS.md at every level. The cap should keep us from
+      // walking the full chain.
+      let cur = workdir;
+      const totalLevels = 40;
+      for (let i = 0; i < totalLevels; i++) {
+        cur = path.join(cur, `d${i}`);
+        fs.mkdirSync(cur);
+        fs.writeFileSync(path.join(cur, 'AGENTS.md'), `RULES_${i}`);
+      }
+      const file = path.join(cur, 'leaf.ts');
+      fs.writeFileSync(file, 'export {}');
+
+      const seen = new Set<string>();
+      const result = instructionsForPath(file, workdir, seen);
+
+      // Cap is 32; the walker may visit up to 32 directories upward,
+      // never the workdir itself nor anything beyond it.
+      expect(result.length).toBeLessThanOrEqual(32);
+      expect(result.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/agent/system.ts
+++ b/src/agent/system.ts
@@ -247,6 +247,85 @@ function loadInstructionFiles(workdir: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Per-directory AGENTS.md discovery (used by file-touching tools at runtime)
+// ---------------------------------------------------------------------------
+
+/** A single per-directory AGENTS.md discovered during a tool call. */
+export interface InstructionFile {
+  /** Absolute realpath of the AGENTS.md file. */
+  path: string;
+  /** Trimmed contents of the file. */
+  content: string;
+}
+
+/** Hard cap on the number of upward iterations to defend against cycles/symlink loops. */
+const MAX_INSTRUCTION_WALK_DEPTH = 32;
+
+/**
+ * Walk from `path.dirname(absPath)` upward toward `workdir` (exclusive),
+ * collecting any AGENTS.md found at each level. Skips files whose
+ * realpath is already in `seen`. Mutates `seen` to add freshly emitted
+ * paths. Returns nearest-first.
+ *
+ * Refuses to walk above `workdir`: if `absPath` is not inside `workdir`,
+ * returns []. The project root AGENTS.md is intentionally excluded
+ * because `loadInstructionFiles()` already injects it once per session.
+ */
+export function instructionsForPath(
+  absPath: string,
+  workdir: string,
+  seen: Set<string>
+): InstructionFile[] {
+  const resolvedWorkdir = path.resolve(workdir);
+  const resolvedAbs = path.resolve(absPath);
+
+  // Refuse paths outside the workdir.
+  const rel = path.relative(resolvedWorkdir, resolvedAbs);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return [];
+  }
+
+  const collected: InstructionFile[] = [];
+  let dir = path.dirname(resolvedAbs);
+  let iterations = 0;
+
+  while (iterations < MAX_INSTRUCTION_WALK_DEPTH) {
+    iterations++;
+
+    // Stop when we hit the workdir (exclusive) or filesystem root.
+    if (dir === resolvedWorkdir) {
+      break;
+    }
+    // Confirm dir is still strictly inside workdir.
+    const dirRel = path.relative(resolvedWorkdir, dir);
+    if (dirRel.startsWith('..') || path.isAbsolute(dirRel) || dirRel === '') {
+      break;
+    }
+
+    const candidate = path.join(dir, 'AGENTS.md');
+    if (fs.existsSync(candidate)) {
+      const realpath = safeRealpath(candidate);
+      if (!seen.has(realpath)) {
+        seen.add(realpath);
+        const content = loadTextFile(candidate);
+        if (content) {
+          collected.push({ path: realpath, content });
+        }
+      }
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      // Reached filesystem root.
+      break;
+    }
+    dir = parent;
+  }
+
+  return collected;
+}
+
+// ---------------------------------------------------------------------------
 // Assembly
 // ---------------------------------------------------------------------------
 

--- a/src/core/agenticChat.ts
+++ b/src/core/agenticChat.ts
@@ -487,11 +487,16 @@ export async function agenticChat(
   };
 
   // Tool context
+  // `agentsMdSeen` is per-execute: file-touching tools (e.g. `read`) walk
+  // parent dirs for AGENTS.md and emit them as `<system-reminder>` blocks the
+  // first time each one is encountered during this execution.
+  const agentsMdSeen = new Set<string>();
   const toolContext: ToolContext = {
     workdir,
     signal: options?.signal,
     sessionId: options?.sessionManager?.getCurrentSession()?.metadata.id,
     gitManager: options?.gitManager,
+    agentsMdSeen,
   };
 
   // Agent loop
@@ -637,6 +642,17 @@ export async function agenticChat(
           tool_call_id: id,
           content: JSON.stringify(toolResult),
         });
+
+        // If the tool surfaced any per-directory AGENTS.md reminders, inject
+        // them as a single synthetic user-role message so the model sees
+        // them on the next turn. Mirrors upstream kilocode #10707.
+        const reminders = (toolResult as ToolResult).metadata?.systemReminders;
+        if (reminders && reminders.length > 0) {
+          const body = reminders
+            .map((r) => `<system-reminder source="${r.source}">\n${r.content}\n</system-reminder>`)
+            .join('\n\n');
+          messages.push({ role: 'user', content: body });
+        }
 
         // Execute PostToolUse hooks and handle rejection feedback
         const hookContext = createHookContext('PostToolUse', {

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -20,6 +20,26 @@ export interface ToolContext {
   sessionId?: string;
   /** Optional git auto-commit manager — injected by agenticChat when enabled */
   gitManager?: AutoCommitManager;
+  /**
+   * Per-session set of realpath()ed AGENTS.md files that have already been
+   * surfaced to the agent as system-reminders. File-touching tools use this
+   * to de-duplicate per-directory AGENTS.md emissions across a single
+   * orchestrator execution.
+   */
+  agentsMdSeen?: Set<string>;
+}
+
+/**
+ * A single per-directory AGENTS.md the agent should be reminded of after a
+ * file-touching tool call. Emitted via `ToolResult.metadata.systemReminders`
+ * and re-injected by the orchestrator as a synthetic user-role message
+ * containing one or more `<system-reminder source="...">` blocks.
+ */
+export interface ToolSystemReminder {
+  /** Workdir-relative path of the AGENTS.md, used as `source="..."`. */
+  source: string;
+  /** Trimmed contents of the AGENTS.md. */
+  content: string;
 }
 
 // Tool result
@@ -29,7 +49,15 @@ export interface ToolResult<T = unknown> {
   error?: string;
   truncated?: boolean;
   hint?: string;
-  metadata?: Record<string, unknown>;
+  metadata?: {
+    /**
+     * Per-directory AGENTS.md reminders discovered by this tool call.
+     * Re-emitted by the orchestrator as `<system-reminder source="...">`
+     * blocks in a synthetic user message before the next assistant turn.
+     */
+    systemReminders?: ToolSystemReminder[];
+    [k: string]: unknown;
+  };
 }
 
 // Tool definition options

--- a/src/tool/tools/__tests__/read.agentsmd.test.ts
+++ b/src/tool/tools/__tests__/read.agentsmd.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { readTool } from '../read.js';
+import type { ToolContext } from '../../index.js';
+
+describe('read tool — per-directory AGENTS.md reminders', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'read-agentsmd-')));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('emits metadata.systemReminders when reading a file under a subdir AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(srcDir, 'index.ts');
+    fs.writeFileSync(target, 'export const hello = 1;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await readTool.executeUnsafe({ filePath: target }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.metadata).toBeDefined();
+    const reminders = result.metadata?.systemReminders;
+    expect(reminders).toBeDefined();
+    expect(reminders).toHaveLength(1);
+    if (reminders) {
+      expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+      expect(reminders[0].content).toBe('API_TEAM_RULES');
+    }
+  });
+
+  it('does not re-emit a reminder for an already-seen AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const first = path.join(srcDir, 'index.ts');
+    const second = path.join(srcDir, 'util.ts');
+    fs.writeFileSync(first, 'export {}\n');
+    fs.writeFileSync(second, 'export {}\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const firstResult = await readTool.executeUnsafe({ filePath: first }, context);
+    const secondResult = await readTool.executeUnsafe({ filePath: second }, context);
+
+    expect(firstResult.metadata?.systemReminders).toHaveLength(1);
+    expect(secondResult.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('stays silent when context.agentsMdSeen is omitted', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(srcDir, 'index.ts');
+    fs.writeFileSync(target, 'export {}\n');
+
+    const context: ToolContext = { workdir };
+
+    const result = await readTool.executeUnsafe({ filePath: target }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+});

--- a/src/tool/tools/read.ts
+++ b/src/tool/tools/read.ts
@@ -14,6 +14,7 @@ import {
   type EncodingInfo,
 } from '../encoded-io.js';
 import { getReferenceService } from '../../reference/reference.js';
+import { instructionsForPath } from '../../agent/system.js';
 
 const ReadParamsSchema = z.object({
   filePath: z.string().describe('Absolute path to the file or directory to read'),
@@ -41,6 +42,37 @@ type ReadResult = ReadFileResult | ReadDirResult;
 
 // Store encoding info for later write operations
 const fileEncodings = new Map<string, EncodingInfo>();
+
+/**
+ * If `context.agentsMdSeen` is provided, walk parent directories of `absPath`
+ * looking for AGENTS.md files and attach any new finds to
+ * `result.metadata.systemReminders` as workdir-relative `source` entries.
+ *
+ * No-op when `context.agentsMdSeen` is absent (e.g. test harnesses, one-shot
+ * CLI commands) — the read tool stays a pure read in that case.
+ */
+function attachAgentsMdReminders(
+  result: ToolResult<ReadResult>,
+  absPath: string,
+  context: { workdir: string; agentsMdSeen?: Set<string> }
+): void {
+  if (!context.agentsMdSeen) {
+    return;
+  }
+
+  const reminders = instructionsForPath(absPath, context.workdir, context.agentsMdSeen);
+  if (reminders.length === 0) {
+    return;
+  }
+
+  result.metadata = {
+    ...(result.metadata ?? {}),
+    systemReminders: reminders.map((r) => ({
+      source: path.relative(context.workdir, r.path),
+      content: r.content,
+    })),
+  };
+}
 
 export function getFileEncoding(filePath: string): EncodingInfo | undefined {
   return fileEncodings.get(filePath);
@@ -140,7 +172,7 @@ Usage:
           .sort()
           .join('\n');
 
-        return {
+        const dirResult: ToolResult<ReadResult> = {
           success: true,
           data: {
             type: 'directory',
@@ -148,6 +180,8 @@ Usage:
             entries: formatted,
           },
         };
+        attachAgentsMdReminders(dirResult, filePath, context);
+        return dirResult;
       }
 
       // Read file
@@ -203,7 +237,7 @@ Usage:
         hint = `Output truncated. Use offset=${nextOffset} to continue reading.`;
       }
 
-      return {
+      const fileResult: ToolResult<ReadResult> = {
         success: true,
         data: {
           type: 'file',
@@ -217,6 +251,8 @@ Usage:
         truncated: wasTruncated,
         hint,
       };
+      attachAgentsMdReminders(fileResult, filePath, context);
+      return fileResult;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
 


### PR DESCRIPTION
## Summary

Automated implementation of #578 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 6
- **Branch**: `auto/578-tool-walk-parent-directories-for-nearby-agents-md-`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #578
