### PR TITLE
feat: [tool] Extend per-directory AGENTS.md system-reminders to write/edit/multiedit/grep (#598)

### DIFF
--- a/src/tool/tools/__tests__/edit.agentsmd.test.ts
+++ b/src/tool/tools/__tests__/edit.agentsmd.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { editTool } from '../edit.js';
+import type { ToolContext } from '../../index.js';
+
+describe('edit tool — per-directory AGENTS.md reminders', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'edit-agentsmd-')));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('emits metadata.systemReminders when editing a file under a subdir AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(srcDir, 'index.ts');
+    fs.writeFileSync(target, 'export const hello = 1;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await editTool.executeUnsafe(
+      {
+        filePath: target,
+        oldString: 'export const hello = 1;',
+        newString: 'export const hello = 2;',
+      },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata).toBeDefined();
+    const reminders = result.metadata?.systemReminders;
+    expect(reminders).toBeDefined();
+    expect(reminders).toHaveLength(1);
+    if (reminders) {
+      expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+      expect(reminders[0].content).toBe('API_TEAM_RULES');
+    }
+  });
+
+  it('does not re-emit a reminder for an already-seen AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const first = path.join(srcDir, 'index.ts');
+    const second = path.join(srcDir, 'util.ts');
+    fs.writeFileSync(first, 'export const a = 1;\n');
+    fs.writeFileSync(second, 'export const b = 1;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const firstResult = await editTool.executeUnsafe(
+      { filePath: first, oldString: 'const a = 1', newString: 'const a = 2' },
+      context
+    );
+    const secondResult = await editTool.executeUnsafe(
+      { filePath: second, oldString: 'const b = 1', newString: 'const b = 2' },
+      context
+    );
+
+    expect(firstResult.metadata?.systemReminders).toHaveLength(1);
+    expect(secondResult.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('does not include the project-root AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(workdir, 'AGENTS.md'), 'ROOT_RULES');
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(apiDir, 'index.ts');
+    fs.writeFileSync(target, 'export const x = 1;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await editTool.executeUnsafe(
+      { filePath: target, oldString: 'const x = 1', newString: 'const x = 2' },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    const reminders = result.metadata?.systemReminders ?? [];
+    expect(reminders.map((r) => r.source)).toEqual([path.join('apps', 'api', 'AGENTS.md')]);
+  });
+
+  it('stays silent when context.agentsMdSeen is omitted', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(apiDir, 'index.ts');
+    fs.writeFileSync(target, 'export const x = 1;\n');
+
+    const context: ToolContext = { workdir };
+
+    const result = await editTool.executeUnsafe(
+      { filePath: target, oldString: 'const x = 1', newString: 'const x = 2' },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+});

--- a/src/tool/tools/__tests__/grep.agentsmd.test.ts
+++ b/src/tool/tools/__tests__/grep.agentsmd.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { grepTool } from '../grep.js';
+import type { ToolContext } from '../../index.js';
+
+describe('grep tool — per-directory AGENTS.md reminders', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'grep-agentsmd-')));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('emits metadata.systemReminders for files whose subtree contains AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    fs.writeFileSync(path.join(srcDir, 'a.ts'), 'NEEDLE in a\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await grepTool.executeUnsafe({ pattern: 'NEEDLE', path: workdir }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.matches.length).toBeGreaterThan(0);
+    const reminders = result.metadata?.systemReminders;
+    expect(reminders).toBeDefined();
+    expect(reminders).toHaveLength(1);
+    if (reminders) {
+      expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+      expect(reminders[0].content).toBe('API_TEAM_RULES');
+    }
+  });
+
+  it('emits only one reminder when many matches share the same subtree', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    const nested = path.join(srcDir, 'nested');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    fs.writeFileSync(path.join(srcDir, 'a.ts'), 'NEEDLE one\n');
+    fs.writeFileSync(path.join(srcDir, 'b.ts'), 'NEEDLE two\n');
+    fs.writeFileSync(path.join(nested, 'c.ts'), 'NEEDLE three\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await grepTool.executeUnsafe({ pattern: 'NEEDLE', path: workdir }, context);
+
+    expect(result.success).toBe(true);
+    const reminders = result.metadata?.systemReminders ?? [];
+    expect(reminders).toHaveLength(1);
+    expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+  });
+
+  it('does not re-emit a reminder for an already-seen AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    fs.writeFileSync(path.join(srcDir, 'a.ts'), 'NEEDLE in a\n');
+    fs.writeFileSync(path.join(srcDir, 'b.ts'), 'NEEDLE in b\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const firstResult = await grepTool.executeUnsafe(
+      { pattern: 'NEEDLE in a', path: workdir },
+      context
+    );
+    const secondResult = await grepTool.executeUnsafe(
+      { pattern: 'NEEDLE in b', path: workdir },
+      context
+    );
+
+    expect(firstResult.metadata?.systemReminders).toHaveLength(1);
+    expect(secondResult.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('does not include the project-root AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(workdir, 'AGENTS.md'), 'ROOT_RULES');
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    fs.writeFileSync(path.join(apiDir, 'a.ts'), 'NEEDLE here\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await grepTool.executeUnsafe({ pattern: 'NEEDLE', path: workdir }, context);
+
+    expect(result.success).toBe(true);
+    const reminders = result.metadata?.systemReminders ?? [];
+    expect(reminders.map((r) => r.source)).toEqual([path.join('apps', 'api', 'AGENTS.md')]);
+  });
+
+  it('stays silent when context.agentsMdSeen is omitted', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    fs.writeFileSync(path.join(apiDir, 'a.ts'), 'NEEDLE here\n');
+
+    const context: ToolContext = { workdir };
+
+    const result = await grepTool.executeUnsafe({ pattern: 'NEEDLE', path: workdir }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+});

--- a/src/tool/tools/__tests__/multiedit.agentsmd.test.ts
+++ b/src/tool/tools/__tests__/multiedit.agentsmd.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { multieditTool } from '../multiedit.js';
+import type { ToolContext } from '../../index.js';
+
+describe('multiedit tool — per-directory AGENTS.md reminders', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'multiedit-agentsmd-')));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('emits metadata.systemReminders when editing a file under a subdir AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(srcDir, 'index.ts');
+    fs.writeFileSync(target, 'const a = 1;\nconst b = 2;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await multieditTool.executeUnsafe(
+      {
+        filePath: target,
+        edits: [
+          { oldString: 'const a = 1', newString: 'const a = 10' },
+          { oldString: 'const b = 2', newString: 'const b = 20' },
+        ],
+      },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    const reminders = result.metadata?.systemReminders;
+    expect(reminders).toBeDefined();
+    expect(reminders).toHaveLength(1);
+    if (reminders) {
+      expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+      expect(reminders[0].content).toBe('API_TEAM_RULES');
+    }
+  });
+
+  it('emits at most one reminder per AGENTS.md per call (file-level dedup)', async () => {
+    // multiedit operates on a single file. Even with many edits in the same
+    // call, only one reminder should fire for the nearest AGENTS.md.
+    const apiDir = path.join(workdir, 'apps', 'api');
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(apiDir, 'index.ts');
+    fs.writeFileSync(target, 'const a = 1;\nconst b = 2;\nconst c = 3;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await multieditTool.executeUnsafe(
+      {
+        filePath: target,
+        edits: [
+          { oldString: 'const a = 1', newString: 'const a = 10' },
+          { oldString: 'const b = 2', newString: 'const b = 20' },
+          { oldString: 'const c = 3', newString: 'const c = 30' },
+        ],
+      },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toHaveLength(1);
+  });
+
+  it('does not re-emit a reminder when called twice on the same subtree', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const first = path.join(srcDir, 'a.ts');
+    const second = path.join(srcDir, 'b.ts');
+    fs.writeFileSync(first, 'const x = 1;\n');
+    fs.writeFileSync(second, 'const y = 1;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const firstResult = await multieditTool.executeUnsafe(
+      {
+        filePath: first,
+        edits: [{ oldString: 'const x = 1', newString: 'const x = 2' }],
+      },
+      context
+    );
+    const secondResult = await multieditTool.executeUnsafe(
+      {
+        filePath: second,
+        edits: [{ oldString: 'const y = 1', newString: 'const y = 2' }],
+      },
+      context
+    );
+
+    expect(firstResult.metadata?.systemReminders).toHaveLength(1);
+    expect(secondResult.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('does not include the project-root AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(workdir, 'AGENTS.md'), 'ROOT_RULES');
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(apiDir, 'index.ts');
+    fs.writeFileSync(target, 'const x = 1;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await multieditTool.executeUnsafe(
+      {
+        filePath: target,
+        edits: [{ oldString: 'const x = 1', newString: 'const x = 2' }],
+      },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    const reminders = result.metadata?.systemReminders ?? [];
+    expect(reminders.map((r) => r.source)).toEqual([path.join('apps', 'api', 'AGENTS.md')]);
+  });
+
+  it('stays silent when context.agentsMdSeen is omitted', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(apiDir, 'index.ts');
+    fs.writeFileSync(target, 'const x = 1;\n');
+
+    const context: ToolContext = { workdir };
+
+    const result = await multieditTool.executeUnsafe(
+      {
+        filePath: target,
+        edits: [{ oldString: 'const x = 1', newString: 'const x = 2' }],
+      },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+});

--- a/src/tool/tools/__tests__/write.agentsmd.test.ts
+++ b/src/tool/tools/__tests__/write.agentsmd.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { writeTool } from '../write.js';
+import type { ToolContext } from '../../index.js';
+
+describe('write tool — per-directory AGENTS.md reminders', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'write-agentsmd-')));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('emits metadata.systemReminders when writing a file under a subdir AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(srcDir, 'index.ts');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await writeTool.executeUnsafe(
+      { filePath: target, content: 'export const hello = 1;\n' },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata).toBeDefined();
+    const reminders = result.metadata?.systemReminders;
+    expect(reminders).toBeDefined();
+    expect(reminders).toHaveLength(1);
+    if (reminders) {
+      expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+      expect(reminders[0].content).toBe('API_TEAM_RULES');
+    }
+  });
+
+  it('does not re-emit a reminder for an already-seen AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const first = path.join(srcDir, 'index.ts');
+    const second = path.join(srcDir, 'util.ts');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const firstResult = await writeTool.executeUnsafe(
+      { filePath: first, content: 'export {};\n' },
+      context
+    );
+    const secondResult = await writeTool.executeUnsafe(
+      { filePath: second, content: 'export {};\n' },
+      context
+    );
+
+    expect(firstResult.metadata?.systemReminders).toHaveLength(1);
+    expect(secondResult.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('does not include the project-root AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(workdir, 'AGENTS.md'), 'ROOT_RULES');
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(apiDir, 'index.ts');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await writeTool.executeUnsafe(
+      { filePath: target, content: 'export const x = 1;\n' },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    const reminders = result.metadata?.systemReminders ?? [];
+    expect(reminders.map((r) => r.source)).toEqual([path.join('apps', 'api', 'AGENTS.md')]);
+  });
+
+  it('stays silent when context.agentsMdSeen is omitted', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES');
+    const target = path.join(apiDir, 'index.ts');
+
+    const context: ToolContext = { workdir };
+
+    const result = await writeTool.executeUnsafe(
+      { filePath: target, content: 'export const x = 1;\n' },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+});

--- a/src/tool/tools/edit.ts
+++ b/src/tool/tools/edit.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { defineTool, type ToolResult } from '../index.js';
+import { instructionsForPath } from '../../agent/system.js';
 
 const EditParamsSchema = z.object({
   filePath: z
@@ -136,7 +137,7 @@ Usage:
         }
       }
 
-      const toolResult = {
+      const toolResult: ToolResult<EditResult> = {
         success: true,
         data: {
           path: filePath,
@@ -148,6 +149,20 @@ Usage:
       };
 
       context.gitManager?.onFileChanged(filePath, 'edit', `${replacements} replacement(s)`);
+
+      // Per-directory AGENTS.md reminders — mirror read.ts:55-76
+      if (context.agentsMdSeen) {
+        const reminders = instructionsForPath(filePath, context.workdir, context.agentsMdSeen);
+        if (reminders.length > 0) {
+          toolResult.metadata = {
+            ...(toolResult.metadata ?? {}),
+            systemReminders: reminders.map((r) => ({
+              source: path.relative(context.workdir, r.path),
+              content: r.content,
+            })),
+          };
+        }
+      }
 
       return toolResult;
     } catch (err) {

--- a/src/tool/tools/grep.ts
+++ b/src/tool/tools/grep.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { defineTool, type ToolResult } from '../index.js';
 import { getReferenceService } from '../../reference/reference.js';
+import { instructionsForPath } from '../../agent/system.js';
 
 const GrepParamsSchema = z.object({
   pattern: z.string().describe('Regex pattern to search for'),
@@ -205,7 +206,7 @@ Usage:
       // Limit total matches
       const limitedMatches = matches.slice(0, 1000);
 
-      return {
+      const grepResult: ToolResult<GrepResult> = {
         success: true,
         data: {
           matches: limitedMatches,
@@ -218,6 +219,37 @@ Usage:
             ? `Showing first 1000 of ${matches.length} matches. Narrow your search.`
             : undefined,
       };
+
+      // Per-directory AGENTS.md reminders — for each unique file in the
+      // returned matches, walk parent directories looking for AGENTS.md.
+      // The shared `agentsMdSeen` set guarantees one reminder per unique
+      // AGENTS.md per session, even if many matches live under the same
+      // subtree. Mirror read.ts:55-76.
+      if (context.agentsMdSeen) {
+        const uniqueFiles = new Set<string>();
+        for (const m of limitedMatches) {
+          // m.file is relative to searchPath; rebuild absolute path.
+          uniqueFiles.add(path.join(searchPath, m.file));
+        }
+        const allReminders: { source: string; content: string }[] = [];
+        for (const absFile of uniqueFiles) {
+          const reminders = instructionsForPath(absFile, context.workdir, context.agentsMdSeen);
+          for (const r of reminders) {
+            allReminders.push({
+              source: path.relative(context.workdir, r.path),
+              content: r.content,
+            });
+          }
+        }
+        if (allReminders.length > 0) {
+          grepResult.metadata = {
+            ...(grepResult.metadata ?? {}),
+            systemReminders: allReminders,
+          };
+        }
+      }
+
+      return grepResult;
     } catch (err) {
       if (err instanceof SyntaxError) {
         return {

--- a/src/tool/tools/multiedit.ts
+++ b/src/tool/tools/multiedit.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { defineTool, type ToolResult } from '../index.js';
+import { instructionsForPath } from '../../agent/system.js';
 
 const EditItemSchema = z.object({
   oldString: z.string().describe('The text to replace'),
@@ -148,6 +149,23 @@ Usage:
       }
 
       context.gitManager?.onFileChanged(filePath, 'multiedit', `${changes.length} edit(s) applied`);
+
+      // Per-directory AGENTS.md reminders — mirror read.ts:55-76.
+      // multiedit operates on a single file, so a single instructionsForPath
+      // walk is sufficient; the shared `agentsMdSeen` set guarantees one
+      // emission per AGENTS.md per session across calls.
+      if (context.agentsMdSeen) {
+        const reminders = instructionsForPath(filePath, context.workdir, context.agentsMdSeen);
+        if (reminders.length > 0) {
+          result.metadata = {
+            ...(result.metadata ?? {}),
+            systemReminders: reminders.map((r) => ({
+              source: path.relative(context.workdir, r.path),
+              content: r.content,
+            })),
+          };
+        }
+      }
 
       return result;
     } catch (err) {

--- a/src/tool/tools/write.ts
+++ b/src/tool/tools/write.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { defineTool, type ToolResult } from '../index.js';
 import { encodeWithEncoding, type EncodingInfo } from '../encoded-io.js';
 import { getFileEncoding } from './read.js';
+import { instructionsForPath } from '../../agent/system.js';
 
 const WriteParamsSchema = z.object({
   filePath: z.string().describe('Absolute path to the file to write'),
@@ -86,7 +87,7 @@ Usage:
       await fs.writeFile(filePath, buffer);
       const bytesWritten = buffer.length;
 
-      const toolResult = {
+      const toolResult: ToolResult<WriteResult> = {
         success: true,
         data: {
           path: filePath,
@@ -100,6 +101,20 @@ Usage:
         'write',
         !exists ? 'created file' : 'overwrote file'
       );
+
+      // Per-directory AGENTS.md reminders — mirror read.ts:55-76
+      if (context.agentsMdSeen) {
+        const reminders = instructionsForPath(filePath, context.workdir, context.agentsMdSeen);
+        if (reminders.length > 0) {
+          toolResult.metadata = {
+            ...(toolResult.metadata ?? {}),
+            systemReminders: reminders.map((r) => ({
+              source: path.relative(context.workdir, r.path),
+              content: r.content,
+            })),
+          };
+        }
+      }
 
       return toolResult;
     } catch (err) {


### PR DESCRIPTION
## Summary

Automated implementation of #598 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 8
- **Branch**: `auto/598-tool-extend-per-directory-agents-md-system-reminde`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #598
