### PR TITLE
feat: [mcp] Inject ALEXI_SESSION_ID and ALEXICODE=1 into stdio MCP server env (#596)

### DIFF
--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -1077,7 +1077,8 @@ async function handleCommand(input: string, state: ReplState): Promise<boolean> 
           if (!serverConfig) {
             console.log(c('red', `  Server '${serverName}' not found in config\n`));
           } else {
-            const result = await mcpManager.connect(serverConfig);
+            const sessionId = state.sessionManager.getCurrentSession()?.metadata.id;
+            const result = await mcpManager.connect(serverConfig, { sessionId });
             if (result.status === 'connected') {
               console.log(
                 c('green', `  Connected to ${serverName} (${result.tools.length} tools)\n`)

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -44,6 +44,8 @@ export interface McpConnection {
 export interface McpConnectOptions {
   /** Project working directory to pass as ALEXI_PROJECT_DIR */
   workdir?: string;
+  /** Active Alexi session id to pass as ALEXI_SESSION_ID */
+  sessionId?: string;
 }
 
 interface ToolCache {
@@ -167,10 +169,13 @@ export class McpClientManager {
     }
 
     // Resolve environment variables
-    // ALEXI_PROJECT_DIR is injected before user config.env so users can override it
+    // ALEXI_PROJECT_DIR, ALEXI_SESSION_ID and ALEXICODE are injected before user
+    // config.env so users can override them (last-write semantics).
     const env = {
       ...process.env,
       ALEXI_PROJECT_DIR: options?.workdir ?? process.cwd(),
+      ALEXI_SESSION_ID: options?.sessionId ?? '',
+      ALEXICODE: '1',
       ...resolveEnvVars(config.env),
     };
 

--- a/tests/mcp/client.test.ts
+++ b/tests/mcp/client.test.ts
@@ -140,4 +140,94 @@ describe('McpClientManager', () => {
       );
     });
   });
+
+  describe('ALEXI_SESSION_ID and ALEXICODE injection', () => {
+    it('should set ALEXI_SESSION_ID from options.sessionId and ALEXICODE=1', async () => {
+      await manager.connect(stdioConfig, { sessionId: 'test-session-123' });
+
+      expect(StdioClientTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: expect.objectContaining({
+            ALEXI_SESSION_ID: 'test-session-123',
+            ALEXICODE: '1',
+          }),
+        })
+      );
+    });
+
+    it('should default ALEXI_SESSION_ID to empty string when no sessionId is provided', async () => {
+      await manager.connect(stdioConfig);
+
+      expect(StdioClientTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: expect.objectContaining({
+            ALEXI_SESSION_ID: '',
+            ALEXICODE: '1',
+          }),
+        })
+      );
+    });
+
+    it('should pass ALEXI_SESSION_ID and ALEXICODE to spawn env as well', async () => {
+      const { resolveEnvVars } = await import('../../src/mcp/config.js');
+      vi.mocked(resolveEnvVars).mockReturnValue({});
+
+      await manager.connect(stdioConfig, { sessionId: 'spawn-session-456' });
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'node',
+        ['server.js'],
+        expect.objectContaining({
+          env: expect.objectContaining({
+            ALEXI_SESSION_ID: 'spawn-session-456',
+            ALEXICODE: '1',
+          }),
+        })
+      );
+    });
+
+    it('should allow user-configured env to override ALEXI_SESSION_ID and ALEXICODE', async () => {
+      const { resolveEnvVars } = await import('../../src/mcp/config.js');
+      vi.mocked(resolveEnvVars).mockReturnValue({
+        ALEXI_SESSION_ID: 'user-override-session',
+        ALEXICODE: '0',
+      });
+
+      const configWithEnv: McpServerConfig = {
+        ...stdioConfig,
+        env: { ALEXI_SESSION_ID: 'user-override-session', ALEXICODE: '0' },
+      };
+
+      await manager.connect(configWithEnv, { sessionId: 'alexi-internal-id' });
+
+      expect(StdioClientTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: expect.objectContaining({
+            ALEXI_SESSION_ID: 'user-override-session',
+            ALEXICODE: '0',
+          }),
+        })
+      );
+    });
+
+    it('should preserve ALEXI_PROJECT_DIR alongside ALEXI_SESSION_ID and ALEXICODE', async () => {
+      const { resolveEnvVars } = await import('../../src/mcp/config.js');
+      vi.mocked(resolveEnvVars).mockReturnValue({});
+
+      await manager.connect(stdioConfig, {
+        workdir: '/proj/dir',
+        sessionId: 'sess-789',
+      });
+
+      expect(StdioClientTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: expect.objectContaining({
+            ALEXI_PROJECT_DIR: '/proj/dir',
+            ALEXI_SESSION_ID: 'sess-789',
+            ALEXICODE: '1',
+          }),
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Automated implementation of #596 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 3
- **Branch**: `auto/596-mcp-inject-alexi-session-id-and-alexicode-1-into-s`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #596
