### PR TITLE
feat: [config] workdir field on SessionMetadata + --here / --workdir / --all filter for alexi sessions (#594)

### DIFF
--- a/src/cli/commands/__tests__/sessions.test.ts
+++ b/src/cli/commands/__tests__/sessions.test.ts
@@ -34,6 +34,7 @@ const FIXTURE_SESSIONS: SessionMetadata[] = [
     totalTokens: 1234,
     messageCount: 7,
     title: 'Refactor router',
+    workdir: '/repo/alexi',
   },
   {
     id: 'sess-002',
@@ -43,6 +44,7 @@ const FIXTURE_SESSIONS: SessionMetadata[] = [
     totalTokens: 0,
     messageCount: 0,
     // title intentionally omitted to exercise the null fallback
+    // workdir intentionally omitted (legacy session)
   },
 ];
 
@@ -88,9 +90,10 @@ describe('alexi sessions command', () => {
         updatedAt: 1_700_000_500_000,
         messageCount: 7,
         totalTokens: 1234,
+        workdir: '/repo/alexi',
       });
 
-      // Second session exercises the null fallbacks for title and model.
+      // Second session exercises the null fallbacks for title, model, and workdir.
       expect(arr[1]).toEqual({
         id: 'sess-002',
         title: null,
@@ -98,10 +101,19 @@ describe('alexi sessions command', () => {
         updatedAt: 1_700_001_500_000,
         messageCount: 0,
         totalTokens: 0,
+        workdir: null,
       });
 
       // Each entry must have exactly the documented set of keys.
-      const expectedKeys = ['id', 'title', 'model', 'updatedAt', 'messageCount', 'totalTokens'];
+      const expectedKeys = [
+        'id',
+        'title',
+        'model',
+        'updatedAt',
+        'messageCount',
+        'totalTokens',
+        'workdir',
+      ];
       for (const entry of arr) {
         expect(Object.keys(entry).sort()).toEqual([...expectedKeys].sort());
       }
@@ -136,6 +148,8 @@ describe('alexi sessions command', () => {
       expect(output).toContain('Messages: 7, Tokens: 1234');
       expect(output).toContain('Model: sap-ai-core/anthropic--claude-4.7-opus');
       expect(output).toContain('Model: N/A');
+      expect(output).toContain('Workdir: /repo/alexi');
+      expect(output).toContain('Workdir: N/A');
     });
 
     it('prints "No sessions found" when there are no sessions', async () => {
@@ -147,6 +161,65 @@ describe('alexi sessions command', () => {
       const output = (logSpy.mock.calls as unknown[][]).map((c) => c.join(' ')).join('\n');
       expect(output).toContain('No sessions found');
       expect(output).not.toContain('=== Saved Sessions ===');
+    });
+  });
+
+  describe('--here / --workdir / --all flags', () => {
+    it('passes { workdir: process.cwd() } to listSessions when --here is set', async () => {
+      listSessionsMock.mockReturnValue([]);
+
+      const program = buildProgram();
+      await program.parseAsync(['node', 'alexi', 'sessions', '--here']);
+
+      expect(listSessionsMock).toHaveBeenCalledTimes(1);
+      expect(listSessionsMock).toHaveBeenCalledWith({ workdir: process.cwd() });
+    });
+
+    it('passes { workdir: <dir> } to listSessions when --workdir is set', async () => {
+      listSessionsMock.mockReturnValue([]);
+
+      const program = buildProgram();
+      await program.parseAsync(['node', 'alexi', 'sessions', '--workdir', '/some/explicit/path']);
+
+      expect(listSessionsMock).toHaveBeenCalledWith({ workdir: '/some/explicit/path' });
+    });
+
+    it('passes no filter to listSessions when no flag is set (default)', async () => {
+      listSessionsMock.mockReturnValue([]);
+
+      const program = buildProgram();
+      await program.parseAsync(['node', 'alexi', 'sessions']);
+
+      expect(listSessionsMock).toHaveBeenCalledWith(undefined);
+    });
+
+    it('passes no filter to listSessions when --all is set', async () => {
+      listSessionsMock.mockReturnValue([]);
+
+      const program = buildProgram();
+      await program.parseAsync(['node', 'alexi', 'sessions', '--all']);
+
+      expect(listSessionsMock).toHaveBeenCalledWith(undefined);
+    });
+
+    it('errors out when --here and --workdir are both set', async () => {
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+        throw new Error('process.exit called');
+      }) as never);
+
+      const program = buildProgram();
+
+      await expect(
+        program.parseAsync(['node', 'alexi', 'sessions', '--here', '--workdir', '/some/path'])
+      ).rejects.toThrow('process.exit called');
+
+      expect(listSessionsMock).not.toHaveBeenCalled();
+      expect(errSpy).toHaveBeenCalledWith('Error: --here and --workdir are mutually exclusive');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
     });
   });
 });

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -13,7 +13,8 @@ import { SessionManager } from '../../core/sessionManager.js';
  *     model: string | null,
  *     updatedAt: number,   // unix epoch milliseconds
  *     messageCount: number,
- *     totalTokens: number
+ *     totalTokens: number,
+ *     workdir: string | null
  *   }
  */
 export function registerSessionCommands(program: Command): void {
@@ -22,13 +23,31 @@ export function registerSessionCommands(program: Command): void {
     .command('sessions')
     .description(
       'List all saved sessions. Use --json to emit a stable JSON array ' +
-        '({ id, title, model, updatedAt, messageCount, totalTokens }) for scripting.'
+        '({ id, title, model, updatedAt, messageCount, totalTokens, workdir }) for scripting. ' +
+        'Use --here to filter to sessions created in the current directory, ' +
+        '--workdir <dir> to filter to a specific directory, or --all (default) ' +
+        'to list every saved session including legacy ones with no recorded workdir.'
     )
     .option('--json', 'Output sessions as JSON array')
-    .action(async (opts: { json?: boolean }) => {
+    .option('--here', 'Only list sessions created in the current working directory')
+    .option('--workdir <dir>', 'Only list sessions created in the specified directory')
+    .option('--all', 'List all sessions (default behavior; explicit no-filter form)')
+    .action(async (opts: { json?: boolean; here?: boolean; workdir?: string; all?: boolean }) => {
       try {
+        if (opts.here && opts.workdir !== undefined) {
+          console.error('Error: --here and --workdir are mutually exclusive');
+          process.exit(1);
+        }
+
+        let filter: { workdir?: string } | undefined;
+        if (opts.here) {
+          filter = { workdir: process.cwd() };
+        } else if (opts.workdir !== undefined) {
+          filter = { workdir: opts.workdir };
+        }
+
         const sessionManager = new SessionManager();
-        const sessions = sessionManager.listSessions();
+        const sessions = sessionManager.listSessions(filter);
 
         if (opts.json) {
           const out = sessions.map((s) => ({
@@ -38,6 +57,7 @@ export function registerSessionCommands(program: Command): void {
             updatedAt: s.updated,
             messageCount: s.messageCount,
             totalTokens: s.totalTokens,
+            workdir: s.workdir ?? null,
           }));
           console.log(JSON.stringify(out, null, 2));
           return;
@@ -57,6 +77,7 @@ export function registerSessionCommands(program: Command): void {
           console.log(`  Updated: ${date}`);
           console.log(`  Messages: ${session.messageCount}, Tokens: ${session.totalTokens}`);
           console.log(`  Model: ${session.modelId || 'N/A'}`);
+          console.log(`  Workdir: ${session.workdir || 'N/A'}`);
           console.log();
         });
       } catch (e) {

--- a/src/core/__tests__/sessionManager.test.ts
+++ b/src/core/__tests__/sessionManager.test.ts
@@ -109,6 +109,13 @@ describe('SessionManager', () => {
 
       expect(session.metadata.modelId).toBe('gpt-4');
     });
+
+    it('should populate workdir from process.cwd() at creation time', () => {
+      const manager = new SessionManager(tempDir);
+      const session = manager.createSession();
+
+      expect(session.metadata.workdir).toBe(process.cwd());
+    });
   });
 
   // ========== 3. loadSession ==========
@@ -355,6 +362,97 @@ describe('SessionManager', () => {
       const manager = new SessionManager(emptyDir);
 
       expect(manager.listSessions()).toEqual([]);
+    });
+
+    describe('workdir filter', () => {
+      function writeRawSession(
+        sessionsDir: string,
+        id: string,
+        workdir: string | undefined,
+        updated: number
+      ): void {
+        const meta: Record<string, unknown> = {
+          id,
+          created: updated,
+          updated,
+          totalTokens: 0,
+          messageCount: 0,
+        };
+        if (workdir !== undefined) {
+          meta.workdir = workdir;
+        }
+        const session = { metadata: meta, messages: [] };
+        fs.writeFileSync(
+          path.join(sessionsDir, `${id}.json`),
+          JSON.stringify(session, null, 2),
+          'utf-8'
+        );
+      }
+
+      it('should return all sessions when no opts are passed (unchanged behavior)', () => {
+        const dir = path.join(tempDir, 'filter-default');
+        fs.mkdirSync(dir, { recursive: true });
+        writeRawSession(dir, 'a', '/foo', 1000);
+        writeRawSession(dir, 'b', '/bar', 2000);
+        writeRawSession(dir, 'c', undefined, 3000);
+
+        const manager = new SessionManager(dir);
+        const sessions = manager.listSessions();
+
+        expect(sessions.map((s) => s.id).sort()).toEqual(['a', 'b', 'c']);
+      });
+
+      it('should filter to only sessions with matching workdir', () => {
+        const dir = path.join(tempDir, 'filter-match');
+        fs.mkdirSync(dir, { recursive: true });
+        writeRawSession(dir, 'match1', '/foo', 1000);
+        writeRawSession(dir, 'nomatch', '/bar', 2000);
+        writeRawSession(dir, 'match2', '/foo', 3000);
+
+        const manager = new SessionManager(dir);
+        const sessions = manager.listSessions({ workdir: '/foo' });
+
+        expect(sessions.map((s) => s.id).sort()).toEqual(['match1', 'match2']);
+      });
+
+      it('should exclude sessions with undefined workdir from filtered listings', () => {
+        const dir = path.join(tempDir, 'filter-exclude-legacy');
+        fs.mkdirSync(dir, { recursive: true });
+        writeRawSession(dir, 'legacy', undefined, 1000);
+        writeRawSession(dir, 'matching', '/foo', 2000);
+
+        const manager = new SessionManager(dir);
+        const sessions = manager.listSessions({ workdir: '/foo' });
+
+        expect(sessions.map((s) => s.id)).toEqual(['matching']);
+      });
+
+      it('should resolve paths so /foo, /foo/, and /foo/. all match', () => {
+        const dir = path.join(tempDir, 'filter-resolve');
+        fs.mkdirSync(dir, { recursive: true });
+        writeRawSession(dir, 's1', '/foo', 1000);
+        writeRawSession(dir, 's2', '/foo/', 2000);
+        writeRawSession(dir, 's3', '/foo/.', 3000);
+
+        const manager = new SessionManager(dir);
+
+        for (const target of ['/foo', '/foo/', '/foo/.']) {
+          const sessions = manager.listSessions({ workdir: target });
+          expect(sessions.map((s) => s.id).sort()).toEqual(['s1', 's2', 's3']);
+        }
+      });
+
+      it('should return an empty array when no sessions match the workdir', () => {
+        const dir = path.join(tempDir, 'filter-empty');
+        fs.mkdirSync(dir, { recursive: true });
+        writeRawSession(dir, 'a', '/foo', 1000);
+        writeRawSession(dir, 'b', undefined, 2000);
+
+        const manager = new SessionManager(dir);
+        const sessions = manager.listSessions({ workdir: '/nope' });
+
+        expect(sessions).toEqual([]);
+      });
     });
   });
 

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -9,6 +9,16 @@ import { randomUUID } from 'crypto';
 import { shouldCompact, compactConversation, estimateMessagesTokens } from './compaction.js';
 import { closeSession } from './sessionClose.js';
 
+/**
+ * Normalize a workdir for comparison. Resolves `.`, `..`, and trailing
+ * separators, and lowercases on Windows where filesystem paths are
+ * case-insensitive.
+ */
+function normalizeWorkdir(p: string): string {
+  const resolved = path.resolve(p);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
 export interface Message {
   role: 'user' | 'assistant' | 'system';
   content: string;
@@ -27,6 +37,12 @@ export interface SessionMetadata {
   totalTokens: number;
   messageCount: number;
   title?: string;
+  /**
+   * Working directory where the session was created (typically `process.cwd()`
+   * at session-creation time). Optional because sessions created before this
+   * field was introduced have no recorded workdir.
+   */
+  workdir?: string;
 }
 
 export interface Session {
@@ -72,6 +88,7 @@ export class SessionManager {
         modelId,
         totalTokens: 0,
         messageCount: 0,
+        workdir: process.cwd(),
       },
       messages: [],
     };
@@ -183,15 +200,23 @@ export class SessionManager {
   }
 
   /**
-   * List all sessions
+   * List all sessions.
+   *
+   * @param opts.workdir When set, only sessions whose recorded `workdir`
+   *   resolves to the same path are returned. Sessions with no recorded
+   *   workdir (legacy sessions created before the field was introduced) are
+   *   excluded from filtered results — they have no opinion. Path comparison
+   *   is performed via `path.resolve` and is case-insensitive on Windows.
    */
-  listSessions(): SessionMetadata[] {
+  listSessions(opts?: { workdir?: string }): SessionMetadata[] {
     try {
       const files = fs.readdirSync(this.sessionsDir);
       const sessions: SessionMetadata[] = [];
 
       for (const file of files) {
-        if (!file.endsWith('.json')) continue;
+        if (!file.endsWith('.json')) {
+          continue;
+        }
 
         const sessionPath = path.join(this.sessionsDir, file);
         const content = fs.readFileSync(sessionPath, 'utf-8');
@@ -202,6 +227,16 @@ export class SessionManager {
 
       // Sort by updated time (newest first)
       sessions.sort((a, b) => b.updated - a.updated);
+
+      if (opts?.workdir !== undefined) {
+        const target = normalizeWorkdir(opts.workdir);
+        return sessions.filter((s) => {
+          if (s.workdir === undefined) {
+            return false;
+          }
+          return normalizeWorkdir(s.workdir) === target;
+        });
+      }
 
       return sessions;
     } catch (error) {


### PR DESCRIPTION
## Summary

Automated implementation of #594 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 4
- **Branch**: `auto/594-config-workdir-field-on-sessionmetadata-here-workd`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #594
