### PR TITLE
feat: [tool] Extend per-directory AGENTS.md system-reminders to write/edit/multiedit/grep (#632)

### DIFF
--- a/src/agent/agentsMdReminders.ts
+++ b/src/agent/agentsMdReminders.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared helper for attaching per-directory AGENTS.md system-reminders to
+ * file-touching tool results.
+ *
+ * Used by `read`, `edit`, `multiedit`, `write`, and `grep` so the relevant
+ * `apps/<x>/AGENTS.md` rules reach the agent even when it edits a file
+ * without reading it first.
+ */
+
+import * as path from 'path';
+import type { ToolResult } from '../tool/index.js';
+import { instructionsForPath } from './system.js';
+
+/**
+ * If `context.agentsMdSeen` is provided, walk parent directories of `absPath`
+ * looking for AGENTS.md files and attach any new finds to
+ * `result.metadata.systemReminders` as workdir-relative `source` entries.
+ *
+ * No-op when `context.agentsMdSeen` is absent (e.g. test harnesses, one-shot
+ * CLI commands). The shared `agentsMdSeen` set is mutated by
+ * `instructionsForPath` so subsequent calls in the same session won't
+ * re-emit the same AGENTS.md.
+ */
+export function attachAgentsMdReminders<T>(
+  result: ToolResult<T>,
+  absPath: string,
+  context: { workdir: string; agentsMdSeen?: Set<string> }
+): void {
+  if (!context.agentsMdSeen) {
+    return;
+  }
+
+  const reminders = instructionsForPath(absPath, context.workdir, context.agentsMdSeen);
+  if (reminders.length === 0) {
+    return;
+  }
+
+  result.metadata = {
+    ...(result.metadata ?? {}),
+    systemReminders: reminders.map((r) => ({
+      source: path.relative(context.workdir, r.path),
+      content: r.content,
+    })),
+  };
+}
+
+/**
+ * Multi-path variant for tools like `grep` that touch many files in a single
+ * call. Walks the unique parent directories of `absPaths` and attaches any
+ * newly-discovered AGENTS.md to `result.metadata.systemReminders`. Dedup is
+ * handled by the shared `context.agentsMdSeen` set across paths.
+ */
+export function attachAgentsMdRemindersForPaths<T>(
+  result: ToolResult<T>,
+  absPaths: Iterable<string>,
+  context: { workdir: string; agentsMdSeen?: Set<string> }
+): void {
+  if (!context.agentsMdSeen) {
+    return;
+  }
+
+  const collected: Array<{ source: string; content: string }> = [];
+  const visitedDirs = new Set<string>();
+
+  for (const absPath of absPaths) {
+    const dir = path.dirname(path.resolve(absPath));
+    if (visitedDirs.has(dir)) {
+      continue;
+    }
+    visitedDirs.add(dir);
+
+    const reminders = instructionsForPath(absPath, context.workdir, context.agentsMdSeen);
+    for (const r of reminders) {
+      collected.push({
+        source: path.relative(context.workdir, r.path),
+        content: r.content,
+      });
+    }
+  }
+
+  if (collected.length === 0) {
+    return;
+  }
+
+  result.metadata = {
+    ...(result.metadata ?? {}),
+    systemReminders: [...(result.metadata?.systemReminders ?? []), ...collected],
+  };
+}

--- a/src/tool/tools/__tests__/edit.agentsmd.test.ts
+++ b/src/tool/tools/__tests__/edit.agentsmd.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { editTool } from '../edit.js';
+import type { ToolContext } from '../../index.js';
+
+describe('edit tool — per-directory AGENTS.md reminders', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'edit-agentsmd-')));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('emits metadata.systemReminders when editing a file under a subdir AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_EDIT');
+    const target = path.join(srcDir, 'foo.ts');
+    fs.writeFileSync(target, 'export const value = 1;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await editTool.executeUnsafe(
+      { filePath: target, oldString: 'value = 1', newString: 'value = 2' },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    const reminders = result.metadata?.systemReminders;
+    expect(reminders).toBeDefined();
+    expect(reminders).toHaveLength(1);
+    if (reminders) {
+      expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+      expect(reminders[0].content).toBe('API_TEAM_RULES_EDIT');
+    }
+  });
+
+  it('does not re-emit a reminder for an already-seen AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_EDIT');
+    const first = path.join(srcDir, 'a.ts');
+    const second = path.join(srcDir, 'b.ts');
+    fs.writeFileSync(first, 'export const x = 1;\n');
+    fs.writeFileSync(second, 'export const y = 2;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const firstResult = await editTool.executeUnsafe(
+      { filePath: first, oldString: 'x = 1', newString: 'x = 11' },
+      context
+    );
+    const secondResult = await editTool.executeUnsafe(
+      { filePath: second, oldString: 'y = 2', newString: 'y = 22' },
+      context
+    );
+
+    expect(firstResult.metadata?.systemReminders).toHaveLength(1);
+    expect(secondResult.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('stays silent when context.agentsMdSeen is omitted', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_EDIT');
+    const target = path.join(srcDir, 'foo.ts');
+    fs.writeFileSync(target, 'export const value = 1;\n');
+
+    const context: ToolContext = { workdir };
+
+    const result = await editTool.executeUnsafe(
+      { filePath: target, oldString: 'value = 1', newString: 'value = 2' },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+});

--- a/src/tool/tools/__tests__/grep.agentsmd.test.ts
+++ b/src/tool/tools/__tests__/grep.agentsmd.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { grepTool, _resetRgDetectionForTests } from '../grep.js';
+import type { ToolContext } from '../../index.js';
+
+describe('grep tool — per-directory AGENTS.md reminders', () => {
+  let workdir: string;
+  const prevDisableRg = process.env.ALEXI_DISABLE_RG;
+
+  beforeEach(() => {
+    // Force the JS path so the test is deterministic regardless of host rg.
+    process.env.ALEXI_DISABLE_RG = '1';
+    _resetRgDetectionForTests();
+    workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'grep-agentsmd-')));
+  });
+
+  afterEach(() => {
+    if (prevDisableRg === undefined) {
+      delete process.env.ALEXI_DISABLE_RG;
+    } else {
+      process.env.ALEXI_DISABLE_RG = prevDisableRg;
+    }
+    _resetRgDetectionForTests();
+    try {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('emits metadata.systemReminders for AGENTS.md above matched files', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_GREP');
+    fs.writeFileSync(path.join(srcDir, 'foo.ts'), 'const SENTINEL_TOKEN = 1;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await grepTool.executeUnsafe(
+      { pattern: 'SENTINEL_TOKEN', path: workdir },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data?.matches.length).toBeGreaterThan(0);
+    const reminders = result.metadata?.systemReminders;
+    expect(reminders).toBeDefined();
+    expect(reminders).toHaveLength(1);
+    if (reminders) {
+      expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+      expect(reminders[0].content).toBe('API_TEAM_RULES_GREP');
+    }
+  });
+
+  it('does not re-emit a reminder for an already-seen AGENTS.md across calls', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_GREP');
+    fs.writeFileSync(path.join(srcDir, 'foo.ts'), 'const SENTINEL_TOKEN = 1;\n');
+    fs.writeFileSync(path.join(srcDir, 'bar.ts'), 'const SENTINEL_TOKEN = 2;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const firstResult = await grepTool.executeUnsafe(
+      { pattern: 'SENTINEL_TOKEN', path: workdir },
+      context
+    );
+    const secondResult = await grepTool.executeUnsafe(
+      { pattern: 'SENTINEL_TOKEN', path: workdir },
+      context
+    );
+
+    expect(firstResult.metadata?.systemReminders).toHaveLength(1);
+    expect(secondResult.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('stays silent when context.agentsMdSeen is omitted', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_GREP');
+    fs.writeFileSync(path.join(srcDir, 'foo.ts'), 'const SENTINEL_TOKEN = 1;\n');
+
+    const context: ToolContext = { workdir };
+
+    const result = await grepTool.executeUnsafe(
+      { pattern: 'SENTINEL_TOKEN', path: workdir },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('emits no reminders when there are zero matches', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_GREP');
+    fs.writeFileSync(path.join(srcDir, 'foo.ts'), 'const value = 1;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await grepTool.executeUnsafe(
+      { pattern: 'NO_SUCH_TOKEN_FOO', path: workdir },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data?.matches).toHaveLength(0);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+});

--- a/src/tool/tools/__tests__/multiedit.agentsmd.test.ts
+++ b/src/tool/tools/__tests__/multiedit.agentsmd.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { multieditTool } from '../multiedit.js';
+import type { ToolContext } from '../../index.js';
+
+describe('multiedit tool — per-directory AGENTS.md reminders', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'multiedit-agentsmd-')));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('emits metadata.systemReminders when multiediting a file under a subdir AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_MULTIEDIT');
+    const target = path.join(srcDir, 'foo.ts');
+    fs.writeFileSync(target, 'export const a = 1;\nexport const b = 2;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await multieditTool.executeUnsafe(
+      {
+        filePath: target,
+        edits: [
+          { oldString: 'a = 1', newString: 'a = 10' },
+          { oldString: 'b = 2', newString: 'b = 20' },
+        ],
+      },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    const reminders = result.metadata?.systemReminders;
+    expect(reminders).toBeDefined();
+    expect(reminders).toHaveLength(1);
+    if (reminders) {
+      expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+      expect(reminders[0].content).toBe('API_TEAM_RULES_MULTIEDIT');
+    }
+  });
+
+  it('does not re-emit a reminder for an already-seen AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_MULTIEDIT');
+    const first = path.join(srcDir, 'a.ts');
+    const second = path.join(srcDir, 'b.ts');
+    fs.writeFileSync(first, 'export const x = 1;\n');
+    fs.writeFileSync(second, 'export const y = 2;\n');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const firstResult = await multieditTool.executeUnsafe(
+      { filePath: first, edits: [{ oldString: 'x = 1', newString: 'x = 11' }] },
+      context
+    );
+    const secondResult = await multieditTool.executeUnsafe(
+      { filePath: second, edits: [{ oldString: 'y = 2', newString: 'y = 22' }] },
+      context
+    );
+
+    expect(firstResult.metadata?.systemReminders).toHaveLength(1);
+    expect(secondResult.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('stays silent when context.agentsMdSeen is omitted', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_MULTIEDIT');
+    const target = path.join(srcDir, 'foo.ts');
+    fs.writeFileSync(target, 'export const a = 1;\n');
+
+    const context: ToolContext = { workdir };
+
+    const result = await multieditTool.executeUnsafe(
+      { filePath: target, edits: [{ oldString: 'a = 1', newString: 'a = 10' }] },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+});

--- a/src/tool/tools/__tests__/write.agentsmd.test.ts
+++ b/src/tool/tools/__tests__/write.agentsmd.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { writeTool } from '../write.js';
+import type { ToolContext } from '../../index.js';
+
+describe('write tool — per-directory AGENTS.md reminders', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'write-agentsmd-')));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(workdir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('emits metadata.systemReminders when writing a file under a subdir AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_WRITE');
+    const target = path.join(srcDir, 'foo.ts');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const result = await writeTool.executeUnsafe(
+      { filePath: target, content: 'export const v = 1;\n' },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    const reminders = result.metadata?.systemReminders;
+    expect(reminders).toBeDefined();
+    expect(reminders).toHaveLength(1);
+    if (reminders) {
+      expect(reminders[0].source).toBe(path.join('apps', 'api', 'AGENTS.md'));
+      expect(reminders[0].content).toBe('API_TEAM_RULES_WRITE');
+    }
+  });
+
+  it('does not re-emit a reminder for an already-seen AGENTS.md', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_WRITE');
+    const first = path.join(srcDir, 'a.ts');
+    const second = path.join(srcDir, 'b.ts');
+
+    const agentsMdSeen = new Set<string>();
+    const context: ToolContext = { workdir, agentsMdSeen };
+
+    const firstResult = await writeTool.executeUnsafe(
+      { filePath: first, content: 'export const x = 1;\n' },
+      context
+    );
+    const secondResult = await writeTool.executeUnsafe(
+      { filePath: second, content: 'export const y = 2;\n' },
+      context
+    );
+
+    expect(firstResult.metadata?.systemReminders).toHaveLength(1);
+    expect(secondResult.metadata?.systemReminders).toBeUndefined();
+  });
+
+  it('stays silent when context.agentsMdSeen is omitted', async () => {
+    const apiDir = path.join(workdir, 'apps', 'api');
+    const srcDir = path.join(apiDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(apiDir, 'AGENTS.md'), 'API_TEAM_RULES_WRITE');
+    const target = path.join(srcDir, 'foo.ts');
+
+    const context: ToolContext = { workdir };
+
+    const result = await writeTool.executeUnsafe(
+      { filePath: target, content: 'export const v = 1;\n' },
+      context
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.systemReminders).toBeUndefined();
+  });
+});

--- a/src/tool/tools/edit.ts
+++ b/src/tool/tools/edit.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { defineTool, type ToolResult } from '../index.js';
+import { attachAgentsMdReminders } from '../../agent/agentsMdReminders.js';
 
 const EditParamsSchema = z.object({
   filePath: z
@@ -136,7 +137,7 @@ Usage:
         }
       }
 
-      const toolResult = {
+      const toolResult: ToolResult<EditResult> = {
         success: true,
         data: {
           path: filePath,
@@ -148,6 +149,8 @@ Usage:
       };
 
       context.gitManager?.onFileChanged(filePath, 'edit', `${replacements} replacement(s)`);
+
+      attachAgentsMdReminders(toolResult, filePath, context);
 
       return toolResult;
     } catch (err) {

--- a/src/tool/tools/grep.ts
+++ b/src/tool/tools/grep.ts
@@ -16,6 +16,7 @@ import { spawn } from 'child_process';
 import { defineTool, type ToolResult } from '../index.js';
 import { getReferenceService } from '../../reference/reference.js';
 import { logger } from '../../utils/logger.js';
+import { attachAgentsMdRemindersForPaths } from '../../agent/agentsMdReminders.js';
 
 const GrepParamsSchema = z.object({
   pattern: z.string().describe('Regex pattern to search for'),
@@ -579,7 +580,7 @@ Usage:
           );
           // Apply the same 1000-match cap as the JS path.
           const limited = value.matches.slice(0, 1000);
-          return {
+          const rgResult: ToolResult<GrepResult> = {
             success: true,
             data: {
               matches: limited,
@@ -592,6 +593,14 @@ Usage:
                 ? `Showing first 1000 of ${value.totalMatches} matches. Narrow your search.`
                 : undefined,
           };
+          if (limited.length > 0) {
+            attachAgentsMdRemindersForPaths(
+              rgResult,
+              limited.map((m) => path.join(searchPath, m.file)),
+              context
+            );
+          }
+          return rgResult;
         } catch (err) {
           // Aborted searches should surface as aborted, not silently fall
           // through to the JS path.
@@ -669,7 +678,7 @@ Usage:
       // Limit total matches
       const limitedMatches = matches.slice(0, 1000);
 
-      return {
+      const jsResult: ToolResult<GrepResult> = {
         success: true,
         data: {
           matches: limitedMatches,
@@ -682,6 +691,14 @@ Usage:
             ? `Showing first 1000 of ${matches.length} matches. Narrow your search.`
             : undefined,
       };
+      if (limitedMatches.length > 0) {
+        attachAgentsMdRemindersForPaths(
+          jsResult,
+          limitedMatches.map((m) => path.join(searchPath, m.file)),
+          context
+        );
+      }
+      return jsResult;
     } catch (err) {
       if (err instanceof SyntaxError) {
         return {

--- a/src/tool/tools/multiedit.ts
+++ b/src/tool/tools/multiedit.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { defineTool, type ToolResult } from '../index.js';
+import { attachAgentsMdReminders } from '../../agent/agentsMdReminders.js';
 
 const EditItemSchema = z.object({
   oldString: z.string().describe('The text to replace'),
@@ -148,6 +149,8 @@ Usage:
       }
 
       context.gitManager?.onFileChanged(filePath, 'multiedit', `${changes.length} edit(s) applied`);
+
+      attachAgentsMdReminders(result, filePath, context);
 
       return result;
     } catch (err) {

--- a/src/tool/tools/read.ts
+++ b/src/tool/tools/read.ts
@@ -15,7 +15,7 @@ import {
 } from '../encoded-io.js';
 import { getReferenceService } from '../../reference/reference.js';
 import { extractDocxText, extractXlsxText, isOfficeDocument } from './read-office.js';
-import { instructionsForPath } from '../../agent/system.js';
+import { attachAgentsMdReminders } from '../../agent/agentsMdReminders.js';
 
 const ReadParamsSchema = z.object({
   filePath: z.string().describe('Absolute path to the file or directory to read'),
@@ -43,37 +43,6 @@ type ReadResult = ReadFileResult | ReadDirResult;
 
 // Store encoding info for later write operations
 const fileEncodings = new Map<string, EncodingInfo>();
-
-/**
- * If `context.agentsMdSeen` is provided, walk parent directories of `absPath`
- * looking for AGENTS.md files and attach any new finds to
- * `result.metadata.systemReminders` as workdir-relative `source` entries.
- *
- * No-op when `context.agentsMdSeen` is absent (e.g. test harnesses, one-shot
- * CLI commands) — the read tool stays a pure read in that case.
- */
-function attachAgentsMdReminders(
-  result: ToolResult<ReadResult>,
-  absPath: string,
-  context: { workdir: string; agentsMdSeen?: Set<string> }
-): void {
-  if (!context.agentsMdSeen) {
-    return;
-  }
-
-  const reminders = instructionsForPath(absPath, context.workdir, context.agentsMdSeen);
-  if (reminders.length === 0) {
-    return;
-  }
-
-  result.metadata = {
-    ...(result.metadata ?? {}),
-    systemReminders: reminders.map((r) => ({
-      source: path.relative(context.workdir, r.path),
-      content: r.content,
-    })),
-  };
-}
 
 export function getFileEncoding(filePath: string): EncodingInfo | undefined {
   return fileEncodings.get(filePath);

--- a/src/tool/tools/write.ts
+++ b/src/tool/tools/write.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { defineTool, type ToolResult } from '../index.js';
 import { encodeWithEncoding, type EncodingInfo } from '../encoded-io.js';
 import { getFileEncoding } from './read.js';
+import { attachAgentsMdReminders } from '../../agent/agentsMdReminders.js';
 
 const WriteParamsSchema = z.object({
   filePath: z.string().describe('Absolute path to the file to write'),
@@ -86,7 +87,7 @@ Usage:
       await fs.writeFile(filePath, buffer);
       const bytesWritten = buffer.length;
 
-      const toolResult = {
+      const toolResult: ToolResult<WriteResult> = {
         success: true,
         data: {
           path: filePath,
@@ -100,6 +101,8 @@ Usage:
         'write',
         !exists ? 'created file' : 'overwrote file'
       );
+
+      attachAgentsMdReminders(toolResult, filePath, context);
 
       return toolResult;
     } catch (err) {


### PR DESCRIPTION
## Summary

Automated implementation of #632 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 10
- **Branch**: `auto/632-tool-extend-per-directory-agents-md-system-reminde`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #632
