### PR TITLE
feat: [B003] Extend the rule-contribution Zod schema in (#633) [plugin] (#650)

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -298,6 +298,85 @@ export const PLUGIN_RULE_TRUNCATION_MARKER =
   '\n\n[... truncated: rule content exceeded 32 KB cap ...]';
 
 /**
+ * Default timeout (in ms) for `source: 'command'` rules when none is specified.
+ */
+export const PLUGIN_RULE_COMMAND_DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Maximum permitted value for a `source: 'command'` rule's `timeoutMs`. Keeps
+ * a misbehaving plugin from stalling system-prompt assembly indefinitely.
+ */
+export const PLUGIN_RULE_COMMAND_MAX_TIMEOUT_MS = 30_000;
+
+/**
+ * Zod schema for an `inline` rule declaration. Content lives directly in
+ * `plugin.json` via the `content` field.
+ *
+ * Inline rules are mutually exclusive with `file` and `command` rules — a
+ * single rule entry must declare exactly one source. The discriminator is
+ * the `source` literal, which keeps the union variants statically distinct.
+ */
+const InlineRuleSchema = z
+  .object({
+    name: z.string().min(1),
+    scope: z.enum(['session', 'always']).default('always'),
+    source: z.literal('inline'),
+    content: z.string(),
+  })
+  .strict();
+
+/**
+ * Zod schema for a `file` rule declaration. Content is read from `path`,
+ * resolved against the plugin root with a `..` escape guard at load time.
+ */
+const FileRuleSchema = z
+  .object({
+    name: z.string().min(1),
+    scope: z.enum(['session', 'always']).default('always'),
+    source: z.literal('file'),
+    path: z.string().min(1),
+  })
+  .strict();
+
+/**
+ * Zod schema for a `command` rule declaration. Content is produced by
+ * spawning `argv` (shell-free) inside the plugin root, with strict
+ * timeout, stdout-cap, and env-scrub bounds.
+ *
+ * Defaults (per parent tracker #633 / B003):
+ *   - `scope` defaults to `'session'` so a freshly-spawned command rule
+ *     observes session-scoped state, but is re-evaluated for each new
+ *     session unless a plugin opts into `'always'` for process-lifetime
+ *     caching.
+ *   - `timeoutMs` defaults to 5_000 ms and is capped at 30_000 ms.
+ *
+ * Mutual exclusion with `inline`/`file` is enforced by the discriminated
+ * union: a `command` rule cannot carry `content` or `path` fields and a
+ * non-`command` rule cannot carry `argv` / `timeoutMs` / `maxBytes`.
+ */
+const CommandRuleSchema = z
+  .object({
+    name: z.string().min(1),
+    scope: z.enum(['session', 'always']).default('session'),
+    source: z.literal('command'),
+    /** Argv array. `argv[0]` is the binary, `argv.slice(1)` are arguments. */
+    argv: z.array(z.string()).min(1),
+    /**
+     * Optional per-rule timeout override. Bounded at 30_000 ms so a misbehaving
+     * plugin can't stall system-prompt assembly indefinitely.
+     */
+    timeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .max(PLUGIN_RULE_COMMAND_MAX_TIMEOUT_MS)
+      .default(PLUGIN_RULE_COMMAND_DEFAULT_TIMEOUT_MS),
+    /** Optional override of the per-rule 32 KB stdout cap (in bytes). */
+    maxBytes: z.number().int().positive().optional(),
+  })
+  .strict();
+
+/**
  * Zod schema for a `PluginRule` declaration in `plugin.json`.
  *
  * A rule ships markdown that gets injected into the agent's system prompt
@@ -305,37 +384,18 @@ export const PLUGIN_RULE_TRUNCATION_MARKER =
  *
  *   - `inline`:  content lives inline in `plugin.json` (`content` field).
  *   - `file`:    content is read from `path` resolved against the plugin root.
- *   - `command`: content is produced by spawning `command` (no shell) inside
+ *   - `command`: content is produced by spawning `argv` (no shell) inside
  *                the plugin root. See `runRuleCommand` for safety bounds.
  *
- * For `command` sources, `command` may be either a single string (parsed via
- * a small whitespace + quote tokeniser) or a pre-tokenised string array. In
- * both cases the spawn is shell-free.
+ * Variants are a Zod discriminated union over `source` — fields from one
+ * source cannot be mixed with another (e.g. a `command` rule cannot carry
+ * `content` / `path`, and inline/file rules cannot carry `argv`).
  */
-export const PluginRuleSchema = z
-  .object({
-    name: z.string().min(1),
-    scope: z.enum(['session', 'always']).default('always'),
-    source: z.enum(['inline', 'file', 'command']),
-    content: z.string().optional(),
-    path: z.string().optional(),
-    /** Command line for `source: 'command'` rules. */
-    command: z.union([z.string(), z.array(z.string())]).optional(),
-    /** Optional override of the per-rule 5s spawn timeout (in milliseconds). */
-    timeoutMs: z.number().int().positive().optional(),
-    /** Optional override of the per-rule 32 KB stdout cap (in bytes). */
-    maxBytes: z.number().int().positive().optional(),
-  })
-  .refine(
-    (r) =>
-      (r.source === 'inline' && r.content !== undefined) ||
-      (r.source === 'file' && r.path !== undefined) ||
-      (r.source === 'command' && r.command !== undefined),
-    {
-      message:
-        "rule must have 'content' for inline source, 'path' for file source, or 'command' for command source",
-    }
-  );
+export const PluginRuleSchema = z.discriminatedUnion('source', [
+  InlineRuleSchema,
+  FileRuleSchema,
+  CommandRuleSchema,
+]);
 
 export type PluginRule = z.infer<typeof PluginRuleSchema>;
 
@@ -370,9 +430,9 @@ export interface ResolvedPluginRule {
   command?: {
     /** Working directory for the spawn (typically the plugin root). */
     pluginRoot: string;
-    /** Command line — either a single string or pre-tokenised argv. */
-    command: string | string[];
-    /** Per-rule timeout override (defaults to 5000 ms). */
+    /** Argv array. `argv[0]` is the binary, `argv.slice(1)` are arguments. */
+    argv: string[];
+    /** Per-rule timeout override (defaults to 5000 ms, capped at 30_000 ms). */
     timeoutMs?: number;
     /** Per-rule stdout cap override (defaults to 32 KB). */
     maxBytes?: number;
@@ -434,11 +494,6 @@ export function resolvePluginRule(
   rule: PluginRule
 ): { ok: true; rule: ResolvedPluginRule } | { ok: false; error: string } {
   if (rule.source === 'inline') {
-    if (rule.content === undefined) {
-      // Should be unreachable thanks to the schema refine, but keep the guard
-      // so callers don't have to reason about partially-validated input.
-      return { ok: false, error: `rule '${rule.name}' missing 'content' for inline source` };
-    }
     return {
       ok: true,
       rule: {
@@ -452,10 +507,6 @@ export function resolvePluginRule(
   }
 
   if (rule.source === 'file') {
-    if (rule.path === undefined) {
-      return { ok: false, error: `rule '${rule.name}' missing 'path' for file source` };
-    }
-
     const resolved = path.resolve(pluginRoot, rule.path);
     const rel = path.relative(pluginRoot, resolved);
     if (rel.startsWith('..') || path.isAbsolute(rel)) {
@@ -486,12 +537,9 @@ export function resolvePluginRule(
   }
 
   // source === 'command'
-  if (rule.command === undefined) {
-    return { ok: false, error: `rule '${rule.name}' missing 'command' for command source` };
-  }
   // Defer execution to prompt-assembly time so we can apply per-session
   // caching. The descriptor is carried verbatim — `runRuleCommand` does the
-  // tokenisation / env-scrub / spawn-bounding.
+  // env-scrub / spawn-bounding.
   return {
     ok: true,
     rule: {
@@ -502,7 +550,7 @@ export function resolvePluginRule(
       content: '',
       command: {
         pluginRoot,
-        command: rule.command,
+        argv: rule.argv,
         timeoutMs: rule.timeoutMs,
         maxBytes: rule.maxBytes,
       },
@@ -585,7 +633,7 @@ export async function materializeCommandRule(
 
   const result = await runRuleCommandLenient({
     pluginRoot: rule.command.pluginRoot,
-    command: rule.command.command,
+    command: rule.command.argv,
     timeoutMs: rule.command.timeoutMs,
     maxBytes: rule.command.maxBytes,
   });

--- a/tests/plugin/ruleCommand.test.ts
+++ b/tests/plugin/ruleCommand.test.ts
@@ -46,28 +46,120 @@ function writeScript(pluginRoot: string, name: string, body: string): string {
 }
 
 describe('PluginRuleSchema — command source', () => {
-  it('accepts a command rule with string command', () => {
+  it('accepts a command rule with argv array and applies session/timeout defaults', () => {
     const r = PluginRuleSchema.parse({
       name: 'todos',
       source: 'command',
-      command: 'echo hi',
+      argv: ['echo', 'hi'],
     });
-    expect(r.scope).toBe('always');
+    // Default scope for command rules is 'session' (vs 'always' for inline/file).
+    expect(r.scope).toBe('session');
     expect(r.source).toBe('command');
-    expect(r.command).toBe('echo hi');
+    if (r.source === 'command') {
+      expect(r.argv).toEqual(['echo', 'hi']);
+      // Default timeoutMs is 5_000.
+      expect(r.timeoutMs).toBe(5_000);
+    }
   });
 
-  it('accepts a command rule with array command', () => {
+  it('accepts an explicit timeoutMs within the 30_000 cap', () => {
     const r = PluginRuleSchema.parse({
       name: 'todos',
       source: 'command',
-      command: ['node', '-e', 'console.log("x")'],
+      argv: ['node', '-e', 'console.log("x")'],
+      timeoutMs: 10_000,
     });
-    expect(r.command).toEqual(['node', '-e', 'console.log("x")']);
+    if (r.source === 'command') {
+      expect(r.timeoutMs).toBe(10_000);
+    }
   });
 
-  it('rejects a command rule missing the command field', () => {
+  it('rejects a timeoutMs above the 30_000 cap', () => {
+    const result = PluginRuleSchema.safeParse({
+      name: 'todos',
+      source: 'command',
+      argv: ['echo'],
+      timeoutMs: 60_000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-positive timeoutMs', () => {
+    const result = PluginRuleSchema.safeParse({
+      name: 'todos',
+      source: 'command',
+      argv: ['echo'],
+      timeoutMs: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-integer timeoutMs', () => {
+    const result = PluginRuleSchema.safeParse({
+      name: 'todos',
+      source: 'command',
+      argv: ['echo'],
+      timeoutMs: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a command rule missing argv', () => {
     expect(() => PluginRuleSchema.parse({ name: 'todos', source: 'command' })).toThrow();
+  });
+
+  it('rejects a command rule with an empty argv array', () => {
+    const result = PluginRuleSchema.safeParse({
+      name: 'todos',
+      source: 'command',
+      argv: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a command rule that mixes inline `content`', () => {
+    const result = PluginRuleSchema.safeParse({
+      name: 'todos',
+      source: 'command',
+      argv: ['echo', 'hi'],
+      content: 'inline body',
+    });
+    // Strict-mode discriminated union: foreign fields are an error, not stripped.
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.map((i) => i.message).join(';');
+      expect(msg.toLowerCase()).toMatch(/unrecognized|unknown/);
+    }
+  });
+
+  it('rejects a command rule that mixes file-source `path`', () => {
+    const result = PluginRuleSchema.safeParse({
+      name: 'todos',
+      source: 'command',
+      argv: ['echo', 'hi'],
+      path: 'rules/x.md',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an inline rule that carries command-source `argv`', () => {
+    const result = PluginRuleSchema.safeParse({
+      name: 'todos',
+      source: 'inline',
+      content: 'rule body',
+      argv: ['echo', 'hi'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a file rule that carries command-source `argv`', () => {
+    const result = PluginRuleSchema.safeParse({
+      name: 'todos',
+      source: 'file',
+      path: 'rules/x.md',
+      argv: ['echo', 'hi'],
+    });
+    expect(result.success).toBe(false);
   });
 });
 
@@ -249,7 +341,7 @@ describe('materializeCommandRule + cache', () => {
       content: '',
       command: {
         pluginRoot: tmpdir,
-        command: [NODE, '-e', script],
+        argv: [NODE, '-e', script],
       },
     };
   }
@@ -310,7 +402,7 @@ describe('materializeCommandRule + cache', () => {
       content: '',
       command: {
         pluginRoot: tmpdir,
-        command: [NODE, '-e', 'process.stdout.write("x".repeat(64*1024))'],
+        argv: [NODE, '-e', 'process.stdout.write("x".repeat(64*1024))'],
         maxBytes: 8192,
       },
     };
@@ -329,7 +421,7 @@ describe('materializeCommandRule + cache', () => {
       content: '',
       command: {
         pluginRoot: tmpdir,
-        command: [NODE, '-e', 'process.stdout.write("partial");setTimeout(()=>{},1000)'],
+        argv: [NODE, '-e', 'process.stdout.write("partial");setTimeout(()=>{},1000)'],
         timeoutMs: 200,
       },
     };
@@ -347,7 +439,7 @@ describe('materializeCommandRule + cache', () => {
       content: '',
       command: {
         pluginRoot: tmpdir,
-        command: [
+        argv: [
           NODE,
           '-e',
           'process.stdout.write("partial");process.stderr.write("oops");process.exit(3)',
@@ -373,27 +465,19 @@ describe('resolvePluginRule (command source)', () => {
   it('returns a deferred descriptor with empty content', () => {
     const result = resolvePluginRule(tmpdir, 'p1', {
       name: 'r1',
-      scope: 'always',
+      scope: 'session',
       source: 'command',
-      command: ['echo', 'ok'],
+      argv: ['echo', 'ok'],
+      timeoutMs: 5_000,
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.rule.source).toBe('command');
       expect(result.rule.content).toBe('');
-      expect(result.rule.command?.command).toEqual(['echo', 'ok']);
+      expect(result.rule.command?.argv).toEqual(['echo', 'ok']);
       expect(result.rule.command?.pluginRoot).toBe(tmpdir);
+      expect(result.rule.command?.timeoutMs).toBe(5_000);
     }
-  });
-
-  it('rejects when command is missing', () => {
-    // Bypass schema (which would normally catch this) to exercise the guard.
-    const result = resolvePluginRule(tmpdir, 'p1', {
-      name: 'r1',
-      scope: 'always',
-      source: 'command',
-    } as unknown as Parameters<typeof resolvePluginRule>[2]);
-    expect(result.ok).toBe(false);
   });
 });
 
@@ -423,7 +507,7 @@ describe('resolvePluginRulesForPrompt — manifest end-to-end', () => {
         {
           name: 'todos',
           source: 'command',
-          command: [NODE, '-e', 'process.stdout.write("# Today\\n- ship it")'],
+          argv: [NODE, '-e', 'process.stdout.write("# Today\\n- ship it")'],
         },
       ],
     });

--- a/tests/plugin/rules.test.ts
+++ b/tests/plugin/rules.test.ts
@@ -88,15 +88,18 @@ describe('Plugin rule contributions', () => {
       expect(parsed.path).toBe('rules/x.md');
     });
 
-    it('rejects inline source without content with a useful error', () => {
+    it('rejects inline source without content', () => {
       const result = PluginRuleSchema.safeParse({
         name: 'r3',
         source: 'inline',
       });
       expect(result.success).toBe(false);
       if (!result.success) {
-        const msg = result.error.issues.map((i) => i.message).join(';');
-        expect(msg).toContain("'content' for inline source");
+        // The discriminated-union branch for `source: 'inline'` requires
+        // `content: z.string()` — the resulting issue should reference the
+        // `content` path (not the legacy refine message text).
+        const paths = result.error.issues.map((i) => i.path.join('.'));
+        expect(paths.some((p) => p.includes('content'))).toBe(true);
       }
     });
 
@@ -111,8 +114,19 @@ describe('Plugin rule contributions', () => {
     it('rejects unknown source values', () => {
       const result = PluginRuleSchema.safeParse({
         name: 'r5',
-        source: 'command',
+        source: 'shell',
         content: 'echo hi',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects mixing command source `argv` with inline `content`', () => {
+      // Strict-mode discriminated union: foreign fields fail at parse time.
+      const result = PluginRuleSchema.safeParse({
+        name: 'mix',
+        source: 'command',
+        argv: ['echo', 'hi'],
+        content: 'inline body',
       });
       expect(result.success).toBe(false);
     });
@@ -405,7 +419,10 @@ describe('Plugin rule contributions', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/Invalid plugin\.json/);
-      expect(result.error).toMatch(/'content' for inline source/);
+      // The discriminated-union branch surfaces a Zod issue on the
+      // `rules.0.content` path — we just need a message that mentions
+      // the missing required field, not a hand-rolled refine string.
+      expect(result.error?.toLowerCase()).toMatch(/required|invalid|content/);
       expect(manager.get('bad-rule')).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Summary

Automated implementation of #650 by **Kilo CLI** using SAP AI Core.

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 3
- **Branch**: `auto/650-b003-extend-the-rule-contribution-zod-schema-in-63`
- **Model**: `sap-ai-core/anthropic--claude-4.7-opus`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #650
