### PR TITLE
feat(cli): add /plugins and /skills slash commands to interactive REPL

### DIFF
--- a/src/cli/__tests__/_pluginTestHelpers.ts
+++ b/src/cli/__tests__/_pluginTestHelpers.ts
@@ -1,0 +1,15 @@
+/**
+ * Tiny re-export shim for `interactive.commands.test.ts`. Centralises the
+ * plugin-manager interactions used by the test (load, clear, isEnabled) so
+ * the test file itself stays focused on the slash-command surface.
+ */
+export { getPluginManager, loadPlugin, type Plugin, type LoadResult } from '../../plugin/index.js';
+import { getPluginManager } from '../../plugin/index.js';
+
+/**
+ * Convenience wrapper around `getPluginManager().isEnabled(name)` used by
+ * the slash-command tests.
+ */
+export function isEnabledHelper(name: string): boolean {
+  return getPluginManager().isEnabled(name);
+}

--- a/src/cli/__tests__/interactive.commands.test.ts
+++ b/src/cli/__tests__/interactive.commands.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the `/plugins` and `/skills` interactive REPL slash commands.
+ *
+ * The interactive REPL imports plugin and skill modules dynamically inside
+ * `handleCommand`, so we drive the real global managers rather than mocking
+ * the dynamic-import target. Each test resets the singletons up front so
+ * registrations don't leak between cases.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleCommand, printHelp, type ReplState } from '../interactive.js';
+import {
+  getPluginManager,
+  loadPlugin,
+  isEnabledHelper,
+  type Plugin,
+} from './_pluginTestHelpers.js';
+import { getSkillRegistry, registerSkill, isSkillEnabled } from '../../skill/index.js';
+
+/**
+ * Build a minimal `ReplState` for tests. The `/plugins` and `/skills` paths
+ * never touch `sessionManager`, so we cast a stub through `ReplState` to
+ * avoid spinning up the real `SessionManager` (which would create files
+ * under `~/.alexi/sessions/`).
+ */
+function makeState(): ReplState {
+  return {
+    sessionManager: {} as ReplState['sessionManager'],
+    currentModel: 'test-model',
+    autoRoute: false,
+    preferCheap: false,
+    isStreaming: false,
+  };
+}
+
+function makePlugin(overrides: Partial<Plugin> = {}): Plugin {
+  return {
+    name: 'demo-plugin',
+    version: '1.2.3',
+    description: 'A test plugin',
+    ...overrides,
+  };
+}
+
+describe('interactive /plugins command', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    await getPluginManager().clear();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    await getPluginManager().clear();
+  });
+
+  it('lists each loaded plugin with name, version, and enabled state', async () => {
+    await loadPlugin(makePlugin({ name: 'alpha', version: '0.1.0' }));
+    await loadPlugin(makePlugin({ name: 'beta', version: '2.0.0' }));
+
+    const handled = await handleCommand('/plugins', makeState());
+    expect(handled).toBe(true);
+
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toContain('alpha');
+    expect(output).toContain('0.1.0');
+    expect(output).toContain('beta');
+    expect(output).toContain('2.0.0');
+    expect(output).toContain('enabled');
+  });
+
+  it('prints a friendly notice when no plugins are loaded', async () => {
+    const handled = await handleCommand('/plugins', makeState());
+    expect(handled).toBe(true);
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toContain('No plugins loaded');
+  });
+
+  it('toggles a plugin from enabled to disabled and back', async () => {
+    await loadPlugin(makePlugin({ name: 'toggleable' }));
+    expect(isEnabledHelper('toggleable')).toBe(true);
+
+    await handleCommand('/plugins toggle toggleable', makeState());
+    expect(isEnabledHelper('toggleable')).toBe(false);
+    let output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toMatch(/toggleable/);
+    expect(output).toMatch(/disabled/);
+
+    logSpy.mockClear();
+    await handleCommand('/plugins toggle toggleable', makeState());
+    expect(isEnabledHelper('toggleable')).toBe(true);
+    output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toMatch(/enabled/);
+  });
+
+  it('reports an error when toggling an unknown plugin', async () => {
+    const handled = await handleCommand('/plugins toggle does-not-exist', makeState());
+    expect(handled).toBe(true);
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toMatch(/not loaded/i);
+  });
+
+  it('falls back to the list view for an unknown subcommand', async () => {
+    await loadPlugin(makePlugin({ name: 'visible' }));
+    const handled = await handleCommand('/plugins bogus', makeState());
+    expect(handled).toBe(true);
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toContain('visible');
+    // Default branch must not have surfaced a toggle error
+    expect(output).not.toMatch(/Toggle failed/);
+  });
+});
+
+describe('interactive /skills command', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getSkillRegistry().clear();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    getSkillRegistry().clear();
+  });
+
+  it('lists each registered skill with id and enabled state', async () => {
+    registerSkill({
+      id: 'reviewer',
+      name: 'Reviewer',
+      description: 'Reviews code',
+      prompt: 'be thorough',
+    });
+    registerSkill({
+      id: 'planner',
+      name: 'Planner',
+      description: 'Plans tasks',
+      prompt: 'be deliberate',
+    });
+
+    const handled = await handleCommand('/skills', makeState());
+    expect(handled).toBe(true);
+
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toContain('reviewer');
+    expect(output).toContain('planner');
+    expect(output).toContain('enabled');
+  });
+
+  it('prints a friendly notice when no skills are loaded', async () => {
+    const handled = await handleCommand('/skills', makeState());
+    expect(handled).toBe(true);
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toContain('No skills loaded');
+  });
+
+  it('toggles a skill from enabled to disabled and back', async () => {
+    registerSkill({
+      id: 'flippable',
+      name: 'Flippable',
+      description: 'A test skill',
+      prompt: '...',
+    });
+    expect(isSkillEnabled('flippable')).toBe(true);
+
+    await handleCommand('/skills toggle flippable', makeState());
+    expect(isSkillEnabled('flippable')).toBe(false);
+    let output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toMatch(/flippable/);
+    expect(output).toMatch(/disabled/);
+
+    logSpy.mockClear();
+    await handleCommand('/skills toggle flippable', makeState());
+    expect(isSkillEnabled('flippable')).toBe(true);
+    output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toMatch(/enabled/);
+  });
+
+  it('reports an error when toggling an unknown skill', async () => {
+    const handled = await handleCommand('/skills toggle missing', makeState());
+    expect(handled).toBe(true);
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toMatch(/not found/i);
+  });
+
+  it('falls back to the list view for an unknown subcommand', async () => {
+    registerSkill({
+      id: 'shown',
+      name: 'Shown',
+      description: 'A test skill',
+      prompt: '...',
+    });
+    const handled = await handleCommand('/skills bogus', makeState());
+    expect(handled).toBe(true);
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(output).toContain('shown');
+  });
+});
+
+describe('interactive /help output', () => {
+  it('lists /plugins and /skills among the available commands', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      printHelp();
+      const output = logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+      expect(output).toContain('/plugins');
+      expect(output).toContain('/skills');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -75,7 +75,7 @@ export interface InteractiveOptions {
   repoMapManager?: RepoMapManager;
 }
 
-interface ReplState {
+export interface ReplState {
   sessionManager: SessionManager;
   currentModel: string;
   autoRoute: boolean;
@@ -128,8 +128,11 @@ function printHeader(state: ReplState): void {
 
 /**
  * Print help message
+ *
+ * Exported so unit tests can capture the rendered help text without booting
+ * the full REPL.
  */
-function printHelp(): void {
+export function printHelp(): void {
   console.log();
   console.log(c('cyan', '  Available Commands:'));
   console.log();
@@ -233,6 +236,14 @@ function printHelp(): void {
   console.log(
     c('yellow', '  /reload-skills') + c('gray', '     - Re-scan skill directories without restart')
   );
+  console.log(
+    c('yellow', '  /plugins') +
+      c('gray', '           - List loaded plugins (or /plugins toggle <name>)')
+  );
+  console.log(
+    c('yellow', '  /skills') +
+      c('gray', '            - List loaded skills (or /skills toggle <id>)')
+  );
   console.log(c('yellow', '  /clear-history') + c('gray', '     - Clear conversation history'));
   console.log(c('yellow', '  /bug, /feedback') + c('gray', '    - Report issues and feedback'));
   console.log();
@@ -301,8 +312,13 @@ function printHelp(): void {
 
 /**
  * Handle slash commands
+ *
+ * Exported so unit tests can drive `/plugins`, `/skills`, and other slash
+ * commands without booting the full REPL. The `state` parameter is mutable
+ * by design — commands such as `/agent`, `/effort`, and `/think` flip flags
+ * on it in place, so tests should pass a fresh `ReplState` per case.
  */
-async function handleCommand(input: string, state: ReplState): Promise<boolean> {
+export async function handleCommand(input: string, state: ReplState): Promise<boolean> {
   // Resolve aliases first
   const aliasManager = getAliasManager();
   const resolvedInput = aliasManager.resolve(input);
@@ -2093,6 +2109,92 @@ async function handleCommand(input: string, state: ReplState): Promise<boolean> 
           c('red', `\n  Skill reload failed: ${err instanceof Error ? err.message : String(err)}\n`)
         );
       }
+      return true;
+    }
+
+    case 'plugins': {
+      const pluginManager = await import('../plugin/index.js');
+      if (args[0] === 'toggle' && args[1]) {
+        const target = args[1];
+        const result = pluginManager.togglePlugin(target);
+        if (result.success) {
+          const stateLabel = result.enabled ? c('green', 'enabled') : c('yellow', 'disabled');
+          console.log(c('green', `\n  Plugin '${result.pluginName}' ${stateLabel}\n`));
+          if (result.enabledDependencies && result.enabledDependencies.length > 0) {
+            console.log(
+              c('gray', `  Also enabled dependencies: ${result.enabledDependencies.join(', ')}\n`)
+            );
+          }
+        } else {
+          console.log(c('red', `\n  ${result.error || 'Toggle failed'}\n`));
+        }
+        return true;
+      }
+
+      const plugins = pluginManager.listPlugins();
+      if (plugins.length === 0) {
+        console.log(c('yellow', '\n  No plugins loaded\n'));
+        return true;
+      }
+      console.log(c('cyan', '\n  Loaded Plugins:\n'));
+      for (const info of plugins) {
+        const statusIcon = info.enabled ? c('green', '●') : c('red', '○');
+        const enabledLabel = info.enabled ? c('green', 'enabled') : c('yellow', 'disabled');
+        console.log(
+          c('gray', `    ${statusIcon} ${info.name} v${info.version} `) +
+            `(${enabledLabel}` +
+            c(
+              'gray',
+              `, tools: ${info.toolCount}, skills: ${info.skillCount}, commands: ${info.commandCount}, hooks: ${info.hookCount})`
+            )
+        );
+        if (info.description) {
+          console.log(c('dim', `        ${info.description}`));
+        }
+      }
+      console.log();
+      console.log(c('dim', '  Usage: /plugins toggle <name>'));
+      console.log();
+      return true;
+    }
+
+    case 'skills': {
+      const skillModule = await import('../skill/index.js');
+      if (args[0] === 'toggle' && args[1]) {
+        const target = args[1];
+        const result = skillModule.toggleSkill(target);
+        if (result.success) {
+          const stateLabel = result.enabled ? c('green', 'enabled') : c('yellow', 'disabled');
+          console.log(c('green', `\n  Skill '${result.skillId}' ${stateLabel}\n`));
+        } else {
+          console.log(c('red', `\n  ${result.error || 'Toggle failed'}\n`));
+        }
+        return true;
+      }
+
+      const skills = skillModule.listSkills();
+      if (skills.length === 0) {
+        console.log(c('yellow', '\n  No skills loaded\n'));
+        return true;
+      }
+      console.log(c('cyan', '\n  Loaded Skills:\n'));
+      for (const skill of skills) {
+        const enabled = skillModule.isSkillEnabled(skill.id);
+        const statusIcon = enabled ? c('green', '●') : c('red', '○');
+        const enabledLabel = enabled ? c('green', 'enabled') : c('yellow', 'disabled');
+        const sourceLabel = skill.source ? ` [${skill.source}]` : '';
+        console.log(
+          c('gray', `    ${statusIcon} ${skill.id} `) +
+            `(${enabledLabel}` +
+            c('gray', `${sourceLabel})`)
+        );
+        if (skill.description) {
+          console.log(c('dim', `        ${skill.description}`));
+        }
+      }
+      console.log();
+      console.log(c('dim', '  Usage: /skills toggle <id>'));
+      console.log();
       return true;
     }
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1818,6 +1818,57 @@ export function disablePlugin(name: string, options?: { force?: boolean }): Disa
 }
 
 /**
+ * Result of {@link togglePlugin}: reports the post-toggle `enabled` state and
+ * whether the operation succeeded. On failure (plugin not loaded, dependents
+ * preventing disable, etc.) `enabled` reflects the unchanged current state.
+ */
+export interface TogglePluginResult {
+  success: boolean;
+  pluginName: string;
+  enabled: boolean;
+  error?: string;
+  enabledDependencies?: string[];
+}
+
+/**
+ * Toggle a plugin's enabled flag in the global manager. If currently enabled
+ * the plugin is disabled (refusing if dependents would break, unless `force`
+ * is set); if currently disabled it is enabled, recursively enabling its
+ * dependencies.
+ */
+export function togglePlugin(name: string, options?: { force?: boolean }): TogglePluginResult {
+  const manager = getPluginManager();
+  if (!manager.get(name)) {
+    return {
+      success: false,
+      pluginName: name,
+      enabled: false,
+      error: `Plugin '${name}' is not loaded`,
+    };
+  }
+
+  const currentlyEnabled = manager.isEnabled(name);
+  if (currentlyEnabled) {
+    const result = manager.disable(name, options);
+    return {
+      success: result.success,
+      pluginName: name,
+      enabled: result.success ? false : true,
+      error: result.error,
+    };
+  }
+
+  const result = manager.enable(name);
+  return {
+    success: result.success,
+    pluginName: name,
+    enabled: result.success ? true : false,
+    error: result.error,
+    enabledDependencies: result.enabledDependencies,
+  };
+}
+
+/**
  * Return resolved rule contributions from all enabled plugins in the global
  * manager. Used by the system-prompt assembler to layer plugin rules after
  * AGENTS.md.

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -311,6 +311,50 @@ export function removeSkill(skillId: string): { success: boolean; error?: string
 class SkillRegistry {
   private skills: Map<string, Skill> = new Map();
   private aliasMap: Map<string, string> = new Map();
+  /**
+   * In-memory set of skill ids that the user has explicitly disabled via the
+   * interactive REPL or the public {@link toggleSkill} helper. Disabling does
+   * not remove the skill from the registry; it just opts it out of the
+   * default activation surface (see {@link isSkillEnabled}). Persistence to
+   * disk is intentionally deferred until a follow-up issue.
+   */
+  private disabledSkillIds: Set<string> = new Set();
+
+  /**
+   * Mark a skill as disabled (opted out of activation). Idempotent.
+   */
+  disable(idOrAlias: string): boolean {
+    const skill = this.get(idOrAlias);
+    if (!skill) {
+      return false;
+    }
+    this.disabledSkillIds.add(skill.id);
+    return true;
+  }
+
+  /**
+   * Re-enable a previously disabled skill. Idempotent.
+   */
+  enable(idOrAlias: string): boolean {
+    const skill = this.get(idOrAlias);
+    if (!skill) {
+      return false;
+    }
+    this.disabledSkillIds.delete(skill.id);
+    return true;
+  }
+
+  /**
+   * Whether a skill is currently considered enabled. Skills default to
+   * enabled; only explicit `disable()` calls flip the flag.
+   */
+  isEnabled(idOrAlias: string): boolean {
+    const skill = this.get(idOrAlias);
+    if (!skill) {
+      return false;
+    }
+    return !this.disabledSkillIds.has(skill.id);
+  }
 
   /**
    * Register a skill
@@ -404,6 +448,7 @@ class SkillRegistry {
       }
     }
 
+    this.disabledSkillIds.delete(id);
     return this.skills.delete(id);
   }
 
@@ -413,6 +458,7 @@ class SkillRegistry {
   clear(): void {
     this.skills.clear();
     this.aliasMap.clear();
+    this.disabledSkillIds.clear();
   }
 }
 
@@ -436,6 +482,51 @@ export function getSkill(idOrAlias: string): Skill | undefined {
 
 export function listSkills(): Skill[] {
   return getSkillRegistry().list();
+}
+
+/**
+ * Result of {@link toggleSkill}. Mirrors the shape of `TogglePluginResult` so
+ * UI callers can format both with the same helper.
+ */
+export interface ToggleSkillResult {
+  success: boolean;
+  skillId: string;
+  enabled: boolean;
+  error?: string;
+}
+
+/**
+ * Whether a skill (by id or alias) is currently enabled. Skills default to
+ * enabled; only explicit `toggleSkill` calls or registry `disable()` flip
+ * the flag.
+ */
+export function isSkillEnabled(idOrAlias: string): boolean {
+  return getSkillRegistry().isEnabled(idOrAlias);
+}
+
+/**
+ * Toggle a skill's in-memory enabled flag. Built-in skills can be toggled
+ * (they remain registered either way); the only failure mode is the skill
+ * not being registered at all.
+ */
+export function toggleSkill(idOrAlias: string): ToggleSkillResult {
+  const registry = getSkillRegistry();
+  const skill = registry.get(idOrAlias);
+  if (!skill) {
+    return {
+      success: false,
+      skillId: idOrAlias,
+      enabled: false,
+      error: `Skill not found: ${idOrAlias}`,
+    };
+  }
+  const currentlyEnabled = registry.isEnabled(skill.id);
+  if (currentlyEnabled) {
+    registry.disable(skill.id);
+    return { success: true, skillId: skill.id, enabled: false };
+  }
+  registry.enable(skill.id);
+  return { success: true, skillId: skill.id, enabled: true };
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds `/plugins` and `/skills` slash commands to the interactive REPL so plugin and skill state is discoverable from where users actually live, without dropping out to a CLI subcommand.

- **`/plugins`** lists every loaded plugin with name, version, enabled state, and per-feature counts (tools/skills/commands/hooks).
- **`/plugins toggle <name>`** flips the enabled flag, routing through the existing `enable` / `disable` pipeline on the plugin manager (so dependent-plugin guards and recursive enables still apply).
- **`/skills`** lists registered skills with id, source, and enabled state.
- **`/skills toggle <id>`** flips an in-memory disabled-set on the skill registry. Persistence to disk is intentionally deferred to a follow-up.
- `/help` now surfaces both new commands.

## Implementation

- `src/plugin/index.ts`: new `togglePlugin(name, opts?)` helper + `TogglePluginResult` type.
- `src/skill/index.ts`: new `toggleSkill(idOrAlias)` helper, `ToggleSkillResult`, and `isSkillEnabled` plus enable/disable/isEnabled methods on the `SkillRegistry`.
- `src/cli/interactive.ts`: two new `case 'plugins'` / `case 'skills'` branches in `handleCommand` and corresponding `/help` lines. `handleCommand`, `printHelp`, and `ReplState` are now exported so unit tests can drive them without booting the full REPL.
- `src/cli/__tests__/interactive.commands.test.ts`: covers list, toggle (round-trip), unknown-target, unknown-subcommand fall-through, and `/help` lines for both commands. 11 new tests, all passing.

## Verification

- `npm run lint` — 0 errors (only pre-existing warnings).
- `npm run typecheck` — clean.
- `npm run format:check` — clean.
- `npm test` — 175 files / 2507 passed (including the 11 new tests).
- `npm run build` — clean.

Closes #704