### PR TITLE
feat(tools): add ALEXI_PLUGIN_RULE_TIMEOUT_MS env override (#711)

### DIFF
--- a/src/plugin/__tests__/ruleCommandRunner.test.ts
+++ b/src/plugin/__tests__/ruleCommandRunner.test.ts
@@ -18,7 +18,7 @@
  * The legacy lenient API and its helpers (`tokenizeCommand`, `scrubEnv`)
  * are exercised separately in `tests/plugin/ruleCommand.test.ts`.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -251,5 +251,108 @@ describe('runRuleCommand (strict)', () => {
     // Either SPAWN_ERROR (ENOENT path) or EXIT (some platforms surface it as
     // exit-with-code on the child). Both are acceptable failure modes here.
     expect(['SPAWN_ERROR', 'EXIT']).toContain(caught?.code);
+  });
+});
+
+/**
+ * Tests for the `ALEXI_PLUGIN_RULE_TIMEOUT_MS` env override (issue #711).
+ *
+ * The override is resolved exactly once at module load, so each test must
+ * call `vi.resetModules()` after stubbing the env var and then dynamically
+ * import the runner so the `ENV_TIMEOUT_MS` constant picks up the test value.
+ *
+ * Precedence asserted here (highest to lowest):
+ *   1. `opts.timeoutMs` (per-rule / per-call override)
+ *   2. `ALEXI_PLUGIN_RULE_TIMEOUT_MS`
+ *   3. 5000 ms hardcoded default
+ */
+describe('runRuleCommand — ALEXI_PLUGIN_RULE_TIMEOUT_MS env override', () => {
+  let tmpdir: string;
+
+  beforeEach(() => {
+    tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-rule-cmd-env-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpdir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses ALEXI_PLUGIN_RULE_TIMEOUT_MS as the timeout when no per-call override is given', async () => {
+    vi.stubEnv('ALEXI_PLUGIN_RULE_TIMEOUT_MS', '150');
+    vi.resetModules();
+    const { runRuleCommand: runFresh } = await import('../ruleCommandRunner.js');
+
+    const start = Date.now();
+    let caught: RunRuleCommandError | undefined;
+    try {
+      await runFresh({
+        // ~1000ms sleep — well past the 150ms env-derived budget but well
+        // under the 5000ms hardcoded default.
+        argv: [NODE, '-e', 'setTimeout(() => {}, 1000)'],
+        cwd: tmpdir,
+      });
+    } catch (err) {
+      caught = err as RunRuleCommandError;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.code).toBe('TIMEOUT');
+    // Should reject in roughly the env-derived budget, definitely well under
+    // the 5000ms default.
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  it('per-call timeoutMs wins over ALEXI_PLUGIN_RULE_TIMEOUT_MS', async () => {
+    // Env says 150ms; per-call says 2000ms; child sleeps 400ms then exits 0.
+    // If per-call did NOT win, this would reject with TIMEOUT at ~150ms.
+    vi.stubEnv('ALEXI_PLUGIN_RULE_TIMEOUT_MS', '150');
+    vi.resetModules();
+    const { runRuleCommand: runFresh } = await import('../ruleCommandRunner.js');
+
+    const result = await runFresh({
+      argv: [NODE, '-e', 'setTimeout(() => process.stdout.write("ok"), 400)'],
+      cwd: tmpdir,
+      timeoutMs: 2000,
+    });
+    expect(result.stdout).toBe('ok');
+    expect(result.truncated).toBe(false);
+  });
+
+  it('falls back to the 5000 ms default when ALEXI_PLUGIN_RULE_TIMEOUT_MS is invalid', async () => {
+    // 'abc' is not a positive integer — the override must be ignored and the
+    // 5000 ms default re-applied. A short sleep finishes well under that.
+    vi.stubEnv('ALEXI_PLUGIN_RULE_TIMEOUT_MS', 'abc');
+    vi.resetModules();
+    const { runRuleCommand: runFresh } = await import('../ruleCommandRunner.js');
+
+    const start = Date.now();
+    const result = await runFresh({
+      argv: [NODE, '-e', 'setTimeout(() => process.stdout.write("ok"), 200)'],
+      cwd: tmpdir,
+    });
+    expect(result.stdout).toBe('ok');
+    expect(result.truncated).toBe(false);
+    // No early timeout — 200ms sleep should not be cut short by a misread
+    // env value, and we should be nowhere near the 5000ms default ceiling.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(150);
+    expect(Date.now() - start).toBeLessThan(5000);
+  });
+
+  it('also ignores zero and negative values (keeps 5000 ms default)', async () => {
+    // Zero / negative values would degenerate to instant timeouts if applied
+    // verbatim, so the runner must reject them at parse time and keep the
+    // 5000 ms default.
+    for (const bogus of ['0', '-1']) {
+      vi.stubEnv('ALEXI_PLUGIN_RULE_TIMEOUT_MS', bogus);
+      vi.resetModules();
+      const { runRuleCommand: runFresh } = await import('../ruleCommandRunner.js');
+      const result = await runFresh({
+        argv: [NODE, '-e', 'process.stdout.write("ok")'],
+        cwd: tmpdir,
+      });
+      expect(result.stdout).toBe('ok');
+      expect(result.truncated).toBe(false);
+    }
   });
 });

--- a/src/plugin/ruleCommandRunner.ts
+++ b/src/plugin/ruleCommandRunner.ts
@@ -33,6 +33,45 @@
 
 import { execFile, spawn } from 'child_process';
 
+import logger from '../utils/logger.js';
+
+// ---------------------------------------------------------------------------
+// Env override (issue #711)
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional process-wide override for the default 5000 ms rule-command timeout,
+ * sourced from `ALEXI_PLUGIN_RULE_TIMEOUT_MS`. Resolved exactly once at module
+ * load to keep behaviour predictable across long-running sessions and child
+ * forks; runtime mutations to `process.env` are intentionally ignored.
+ *
+ * Precedence (highest to lowest), applied by both
+ * {@link runRuleCommand} and {@link runRuleCommandLenient}:
+ *
+ *   1. `opts.timeoutMs` (per-call / per-rule override)
+ *   2. `ENV_TIMEOUT_MS` (this value)
+ *   3. `DEFAULT_TIMEOUT_MS` / `STRICT_DEFAULT_TIMEOUT_MS` (5000 ms)
+ *
+ * Mirrors the precedent set by cline's `CLINE_PLUGIN_IMPORT_TIMEOUT_MS`
+ * escape hatch: an unset var stays silent; an *invalid* value (non-numeric,
+ * zero, negative, NaN) emits a single warning at module load and falls back
+ * to the hardcoded default.
+ */
+export const ENV_TIMEOUT_MS: number | undefined = (() => {
+  const raw = process.env.ALEXI_PLUGIN_RULE_TIMEOUT_MS;
+  if (raw === undefined || raw === '') {
+    return undefined;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (Number.isFinite(n) && n > 0) {
+    return n;
+  }
+  logger.warn(
+    `ALEXI_PLUGIN_RULE_TIMEOUT_MS=${JSON.stringify(raw)} is not a positive integer; ignoring (using 5000 ms default).`
+  );
+  return undefined;
+})();
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -49,7 +88,11 @@ export interface RunRuleCommandOptions {
    * passed as-is to the child program (i.e. they have no meaning).
    */
   command: string | string[];
-  /** Optional override for the default 5000 ms timeout. */
+  /**
+   * Optional override for the default 5000 ms timeout. When omitted, the
+   * `ALEXI_PLUGIN_RULE_TIMEOUT_MS` env var (resolved once at module load)
+   * is consulted before falling back to the 5000 ms default.
+   */
   timeoutMs?: number;
   /** Optional override for the default 32 KB stdout cap. */
   maxBytes?: number;
@@ -230,7 +273,7 @@ export function tokenizeCommand(input: string): string[] {
 export async function runRuleCommandLenient(
   opts: RunRuleCommandOptions
 ): Promise<RunRuleCommandResult> {
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = opts.timeoutMs ?? ENV_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS;
   const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
 
   let argv: string[];
@@ -378,7 +421,11 @@ export interface RunRuleCommandStrictOptions {
    * is used as the source.
    */
   env?: NodeJS.ProcessEnv;
-  /** Timeout in milliseconds. Defaults to 5000. */
+  /**
+   * Timeout in milliseconds. Defaults to 5000. When omitted, the
+   * `ALEXI_PLUGIN_RULE_TIMEOUT_MS` env var (resolved once at module load)
+   * is consulted before falling back to the 5000 ms default.
+   */
   timeoutMs?: number;
   /** Stdout cap in bytes. Defaults to 32 KB (32 768 bytes). */
   maxBytes?: number;
@@ -477,7 +524,7 @@ export function runRuleCommand(
       return;
     }
 
-    const timeoutMs = opts.timeoutMs ?? STRICT_DEFAULT_TIMEOUT_MS;
+    const timeoutMs = opts.timeoutMs ?? ENV_TIMEOUT_MS ?? STRICT_DEFAULT_TIMEOUT_MS;
     const maxBytes = opts.maxBytes ?? STRICT_DEFAULT_MAX_BYTES;
     const baseEnv = opts.env ?? process.env;
     const childEnv = scrubEnvDeny(baseEnv);


### PR DESCRIPTION
## Summary

- Adds opt-in `ALEXI_PLUGIN_RULE_TIMEOUT_MS` env var that overrides the hardcoded 5000 ms default in `runRuleCommand` / `runRuleCommandLenient`, with per-rule `rule.command.timeoutMs` still winning.
- Resolved exactly once at module load (predictable across long-running sessions and forks); invalid values (non-numeric, zero, negative) emit a single warning and fall back to 5000 ms; unset values are silent.
- Mirrors cline/cline#11084 (`CLINE_PLUGIN_IMPORT_TIMEOUT_MS`) - smallest possible escape hatch for slow-starting rule commands without changing defaults, CLI surface, or schema.

## Precedence

1. `opts.timeoutMs` (per-call / per-rule)
2. `ALEXI_PLUGIN_RULE_TIMEOUT_MS`
3. `5000` ms hardcoded default

## Tests

Four new tests in `src/plugin/__tests__/ruleCommandRunner.test.ts`:

- env value used when no per-call override is supplied
- per-call `timeoutMs` wins over the env value
- invalid env value (`"abc"`) falls back to 5000 ms default
- zero / negative env values also fall back (no degenerate instant timeouts)

Tests use `vi.stubEnv` + `vi.resetModules()` + dynamic import so the
once-at-module-load constant picks up each scenario's value.

## Verification

- `npm run lint` (0 errors)
- `npm run typecheck`
- `npm run format:check`
- `npm test` (175 files, 2511 passed)
- `npm run build`

## Scope

Changes are limited to `src/plugin/ruleCommandRunner.ts` and its `__tests__/`,
as required by the issue. No `.github/`, no schema, no CLI surface, no default
change.

Closes #711