### PR TITLE
feat(tools): permission deny-rule glob warnings + asymmetric allow-rule guard

### DIFF
--- a/src/permission/__tests__/wildcard-tools.test.ts
+++ b/src/permission/__tests__/wildcard-tools.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
+
+import {
+  PermissionManager,
+  PermissionRuleSchema,
+  type PermissionContext,
+  type PermissionRule,
+} from '../index.js';
+import { getToolRegistry } from '../../tool/index.js';
+import { registerBuiltInTools } from '../../tool/tools/index.js';
+
+/**
+ * Tests for issue #713: deny-rule glob warnings + asymmetric allow-rule
+ * guard around `PermissionRule.tools` glob handling.
+ *
+ * Covers:
+ *   1. `tools: ['*']` + decision: 'deny' denies every registered tool name.
+ *   2. `tools: ['Bsah']` (typo) + decision: 'deny' produces a `logger.warn`
+ *      at PermissionManager construction and is otherwise a no-op.
+ *   3. `tools: ['*']` + decision: 'allow' is rejected by Zod schema parse.
+ *   4. `tools: ['mcp__server__*']` + decision: 'allow' is accepted (MCP
+ *      namespace exemption).
+ */
+
+function ctx(toolName: string, action: PermissionContext['action'] = 'read'): PermissionContext {
+  return {
+    toolName,
+    action,
+    resource: '/tmp/wildcard-tools-test/file.txt',
+  };
+}
+
+describe('PermissionRule.tools wildcard guards (issue #713)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  function getWarnLines(): string[] {
+    const calls = warnSpy.mock.calls as unknown as unknown[][];
+    return calls.map((call) => call.map((part) => String(part)).join(' '));
+  }
+
+  beforeAll(() => {
+    // Ensure built-in tools are registered so the warning logic and
+    // wildcard-deny tests have a real registry to consult. registerTool
+    // is idempotent on the global registry (Map.set semantics).
+    registerBuiltInTools();
+  });
+
+  beforeEach(() => {
+    // Silence and capture logger.warn output (logger.warn -> console.warn).
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('schema validation: asymmetric allow-rule glob guard', () => {
+    it("rejects allow rules with a literal '*' tool pattern", () => {
+      const rule = {
+        id: 'bad-allow-wildcard',
+        tools: ['*'],
+        decision: 'allow',
+      };
+      expect(() => PermissionRuleSchema.parse(rule)).toThrow();
+    });
+
+    it("rejects allow rules with a '?' tool pattern", () => {
+      const rule = {
+        id: 'bad-allow-question-mark',
+        tools: ['rea?'],
+        decision: 'allow',
+      };
+      expect(() => PermissionRuleSchema.parse(rule)).toThrow();
+    });
+
+    it("accepts allow rules with an 'mcp__'-prefixed glob (MCP namespace exemption)", () => {
+      const rule = {
+        id: 'allow-mcp-namespace',
+        tools: ['mcp__server__*'],
+        decision: 'allow',
+      };
+      const parsed = PermissionRuleSchema.parse(rule);
+      expect(parsed.tools).toEqual(['mcp__server__*']);
+      expect(parsed.decision).toBe('allow');
+    });
+
+    it('accepts allow rules with literal tool names (no glob chars)', () => {
+      const rule = {
+        id: 'allow-literal',
+        tools: ['read', 'write'],
+        decision: 'allow',
+      };
+      const parsed = PermissionRuleSchema.parse(rule);
+      expect(parsed.tools).toEqual(['read', 'write']);
+    });
+
+    it("permits 'deny' rules to use globs without restriction", () => {
+      const rule = {
+        id: 'deny-wildcard',
+        tools: ['*'],
+        decision: 'deny',
+      };
+      const parsed = PermissionRuleSchema.parse(rule);
+      expect(parsed.decision).toBe('deny');
+      expect(parsed.tools).toEqual(['*']);
+    });
+  });
+
+  describe("rule evaluation: tools: ['*'] + deny denies every tool", () => {
+    it('matches every registered tool name for a wildcard deny rule', () => {
+      // Sanity check: registry must contain at least the built-in tools so
+      // the assertion below is not vacuously true.
+      const registeredNames = getToolRegistry()
+        .list()
+        .map((t) => t.name);
+      expect(registeredNames.length).toBeGreaterThan(0);
+
+      const wildcardDeny: PermissionRule = {
+        id: 'wildcard-deny',
+        tools: ['*'],
+        decision: 'deny',
+        priority: 100,
+      };
+
+      const manager = new PermissionManager([wildcardDeny]);
+
+      for (const name of registeredNames) {
+        const result = manager.evaluate(ctx(name));
+        expect(result.decision).toBe('deny');
+        expect(result.rule?.id).toBe('wildcard-deny');
+      }
+    });
+
+    it('also denies arbitrary unknown tool names (matching engine treats * literally)', () => {
+      const wildcardDeny: PermissionRule = {
+        id: 'wildcard-deny-2',
+        tools: ['*'],
+        decision: 'deny',
+        priority: 0,
+      };
+      const manager = new PermissionManager([wildcardDeny]);
+
+      expect(manager.evaluate(ctx('definitely-not-a-real-tool')).decision).toBe('deny');
+    });
+  });
+
+  describe('startup warnings for unknown deny-rule tool names', () => {
+    it('warns once per typo when constructing a PermissionManager', () => {
+      const typoRule: PermissionRule = {
+        id: 'deny-typo',
+        tools: ['Bsah'], // intentional typo of 'bash'
+        decision: 'deny',
+        priority: 0,
+      };
+
+      const manager = new PermissionManager([typoRule]);
+
+      // The warning should mention the rule label and the unknown tool name.
+      const matched = getWarnLines().find(
+        (line) => line.includes("'deny-typo'") && line.includes("'Bsah'")
+      );
+      expect(matched).toBeDefined();
+
+      // The rule still parses and is stored, but does not match anything
+      // because the wildcard matcher will not equate 'Bsah' with 'bash'.
+      const result = manager.evaluate(ctx('bash'));
+      expect(result.decision).not.toBe('deny');
+    });
+
+    it('does not warn for deny rules whose tool entries contain glob chars', () => {
+      const rule: PermissionRule = {
+        id: 'deny-glob',
+        tools: ['*'],
+        decision: 'deny',
+        priority: 0,
+      };
+      const manager = new PermissionManager([rule]);
+      expect(manager.getRules()).toHaveLength(1);
+
+      const offending = getWarnLines().find((line) => line.includes("'deny-glob'"));
+      expect(offending).toBeUndefined();
+    });
+
+    it('does not warn for deny rules referencing real registered tools', () => {
+      const known = getToolRegistry()
+        .list()
+        .map((t) => t.name)[0];
+      // Skip if no tools are registered in this test environment - the
+      // wildcard deny test above would also be vacuous in that case.
+      if (!known) {
+        return;
+      }
+
+      const rule: PermissionRule = {
+        id: 'deny-known-tool',
+        tools: [known],
+        decision: 'deny',
+        priority: 0,
+      };
+      const manager = new PermissionManager([rule]);
+      expect(manager.getRules()).toHaveLength(1);
+
+      const offending = getWarnLines().find((line) => line.includes("'deny-known-tool'"));
+      expect(offending).toBeUndefined();
+    });
+  });
+});

--- a/src/permission/index.ts
+++ b/src/permission/index.ts
@@ -22,6 +22,20 @@ import {
 } from '../bus/index.js';
 import { ConfigProtection } from './config-paths.js';
 import { containsPath, safePathCheck } from '../utils/filesystem.js';
+import { logger } from '../utils/logger.js';
+import { getAllToolNames } from '../tool/registry.js';
+
+// Glob characters that flag a tool entry as a pattern rather than a literal name.
+const GLOB_CHARS = /[*?]/;
+
+// MCP-namespaced tools follow the cline/claude convention of "mcp__server__tool".
+// Allow rules with globs in this namespace are an explicit, well-understood
+// exemption to the asymmetric allow-rule guard.
+const MCP_TOOL_PREFIX = 'mcp__';
+
+function hasGlobChars(value: string): boolean {
+  return GLOB_CHARS.test(value);
+}
 
 // Permission action types
 export type PermissionAction = 'read' | 'write' | 'execute' | 'network' | 'admin';
@@ -48,25 +62,53 @@ interface OperationAttempt {
   firstAttempt: number;
 }
 
-// Rule schema - enhanced with external path and home expansion options
-export const PermissionRuleSchema = z.object({
-  id: z.string().optional(),
-  name: z.string().optional(),
-  description: z.string().optional(),
-  // Matching criteria
-  tools: z.array(z.string()).optional(), // Tool name patterns
-  actions: z.array(z.enum(['read', 'write', 'execute', 'network', 'admin'])).optional(),
-  paths: z.array(z.string()).optional(), // File path patterns
-  commands: z.array(z.string()).optional(), // Command patterns
-  hosts: z.array(z.string()).optional(), // Network host patterns
-  // Decision
-  decision: z.enum(['allow', 'deny', 'ask']),
-  // Priority (higher = evaluated later in last-match-wins)
-  priority: z.number().default(0),
-  // Enhanced options
-  externalPaths: z.boolean().optional(), // Whether rule applies to external paths
-  homeExpansion: z.boolean().optional(), // Expand ~/ to home directory in paths
-});
+// Rule schema - enhanced with external path and home expansion options.
+//
+// Asymmetric allow-rule guard: glob patterns ('*' / '?') in `tools` are
+// rejected for `decision: 'allow'` rules unless the tool name is prefixed
+// with `mcp__` (cline/claude MCP-namespaced tools). Deny rules may freely
+// use globs since wildcard denies are intentional. This mirrors the
+// behaviour shipped in claude-code v2.1.166.
+export const PermissionRuleSchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    description: z.string().optional(),
+    // Matching criteria
+    tools: z.array(z.string()).optional(), // Tool name patterns
+    actions: z.array(z.enum(['read', 'write', 'execute', 'network', 'admin'])).optional(),
+    paths: z.array(z.string()).optional(), // File path patterns
+    commands: z.array(z.string()).optional(), // Command patterns
+    hosts: z.array(z.string()).optional(), // Network host patterns
+    // Decision
+    decision: z.enum(['allow', 'deny', 'ask']),
+    // Priority (higher = evaluated later in last-match-wins)
+    priority: z.number().default(0),
+    // Enhanced options
+    externalPaths: z.boolean().optional(), // Whether rule applies to external paths
+    homeExpansion: z.boolean().optional(), // Expand ~/ to home directory in paths
+  })
+  .superRefine((rule, ctx) => {
+    if (rule.decision !== 'allow' || !rule.tools) {
+      return;
+    }
+    rule.tools.forEach((entry, idx) => {
+      if (!hasGlobChars(entry)) {
+        return;
+      }
+      if (entry.startsWith(MCP_TOOL_PREFIX)) {
+        return;
+      }
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['tools', idx],
+        message:
+          `Allow rules may not use glob patterns ('*' / '?') in 'tools' ` +
+          `(found '${entry}'). Use literal tool names, or an 'mcp__'-prefixed ` +
+          `pattern for MCP-namespaced tools.`,
+      });
+    });
+  });
 
 export type PermissionRule = z.infer<typeof PermissionRuleSchema>;
 
@@ -126,6 +168,7 @@ export class PermissionManager {
 
   constructor(rules: PermissionRule[] = []) {
     this.rules = this.sortRules(rules);
+    this.warnOnUnknownDenyToolNames();
   }
 
   /**
@@ -133,6 +176,51 @@ export class PermissionManager {
    */
   private sortRules(rules: PermissionRule[]): PermissionRule[] {
     return [...rules].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+  }
+
+  /**
+   * Emit a one-line warning for every deny-rule `tools` entry that is a
+   * literal name (no glob chars) and does not match any registered tool.
+   * This catches typos like `tools: ['Bsah']` which would otherwise be a
+   * silent no-op. Skipped when the registry has no tools registered (e.g.
+   * during early bootstrap or in isolated unit tests) to avoid spurious
+   * warnings.
+   */
+  private warnOnUnknownDenyToolNames(): void {
+    const denyRules = this.rules.filter((r) => r.decision === 'deny' && r.tools?.length);
+    if (denyRules.length === 0) {
+      return;
+    }
+
+    let knownNames: Set<string>;
+    try {
+      // The tool registry import is part of an existing circular module
+      // graph (permission <-> tool); calling it here is safe because the
+      // constructor runs after both modules have finished evaluating.
+      knownNames = new Set(getAllToolNames());
+    } catch {
+      return;
+    }
+
+    if (knownNames.size === 0) {
+      return;
+    }
+
+    for (const rule of denyRules) {
+      for (const entry of rule.tools ?? []) {
+        if (hasGlobChars(entry)) {
+          continue;
+        }
+        if (knownNames.has(entry)) {
+          continue;
+        }
+        const ruleLabel = rule.id ?? rule.name ?? '<unnamed>';
+        logger.warn(
+          `Permission deny rule '${ruleLabel}' references unknown tool '${entry}'; ` +
+            `entry will not match anything. Check for typos.`
+        );
+      }
+    }
   }
 
   // ============ Doom Loop Detection ============

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -507,6 +507,16 @@ export function getAllToolSchemas(): Array<{
   return getToolRegistry().getSchemas();
 }
 
+/**
+ * Get the names of every registered tool (static and dynamic).
+ * Used by the permission system to validate deny-rule tool entries.
+ */
+export function getAllToolNames(): string[] {
+  return getToolRegistry()
+    .list()
+    .map((t) => t.name);
+}
+
 // Re-export for convenience
 export {
   truncateOutput,

--- a/src/tool/registry.ts
+++ b/src/tool/registry.ts
@@ -5,6 +5,10 @@
 
 import type { Tool } from './index.js';
 
+// Re-export the registry-name accessor used by the permission system to
+// cross-check deny-rule tool entries against the actual registered tools.
+export { getAllToolNames } from './index.js';
+
 export interface ToolResolutionContext {
   sessionId: string;
   agentId?: string;


### PR DESCRIPTION
## Summary

Three small guards around `PermissionRule.tools` glob handling, mirroring the
behaviour shipped in claude-code v2.1.166.

- **Startup warning** — `PermissionManager` now emits a one-line `logger.warn`
  for every `decision: 'deny'` rule whose `tools` entry is a literal name
  (no `*`/`?`) and does not match any registered tool. Catches silent typos
  like `tools: ['Bsah']`. Skipped when the registry is empty (early
  bootstrap, isolated unit tests).
- **Asymmetric allow-rule guard** — `PermissionRuleSchema.superRefine`
  rejects allow rules whose `tools` entries contain `*`/`?` unless the
  pattern is prefixed `mcp__` (cline/claude MCP-namespace exemption).
  Prevents `tools: ['*'], decision: 'allow'` from accidentally turning off
  the deny-secrets rule. Deny rules are unchanged — wildcard denies remain
  intentional.
- **Wildcard-deny test surface** — confirms `tools: ['*'], decision: 'deny'`
  matches every registered tool name via `evaluate`.

## Files changed

- `src/permission/index.ts` — schema `superRefine`, constructor warning
  walk, helpers + new logger import.
- `src/tool/index.ts` — new `getAllToolNames()` accessor over the global
  tool registry.
- `src/tool/registry.ts` — re-exports `getAllToolNames` for
  permission-system consumers.
- `src/permission/__tests__/wildcard-tools.test.ts` — new test file
  covering the four cases listed in the issue plus a "deny rules retain
  glob support" regression check.

## Verification

```
npm run lint           # 0 errors (pre-existing warnings unchanged)
npm run typecheck      # clean
npm run format:check   # clean
npm test               # 2521 passed, 2 skipped
npm run build          # clean
```

Source: anthropics/claude-code CHANGELOG v2.1.166. Research item:
`.github/research/2026-06-06-research.md` Item #5.

Closes #713