### PR TITLE
ci(ci): re-apply auto-implement label + harden agent2 planning prompt

### DIFF
--- a/.github/prompts/agent2-planning-system.md
+++ b/.github/prompts/agent2-planning-system.md
@@ -9,7 +9,12 @@ Read: `.github/research/*-spec.md` (latest by date)
 ## Output
 
 1. File: `.github/research/YYYY-MM-DD-plan.md`
-2. GitHub issues (3-5) with label `auto-implement`
+2. GitHub issues (3-5) with labels `auto-implement,enhancement`
+
+The `auto-implement` label is REQUIRED on every issue. Without it,
+`auto-implement.yml` (which queries `labels=auto-implement`) cannot pick the
+issue up and the engineering pipeline silently stalls. `enhancement` alone is
+not enough.
 
 ## Process
 
@@ -42,7 +47,30 @@ EOF
 gh issue create --title "[category] Feature name" --label "auto-implement,enhancement" --body-file /tmp/issue.md
 ```
 
-4. Save plan:
+The `--label "auto-implement,enhancement"` argument is mandatory. Do not drop
+`auto-implement` even if you add additional labels.
+
+4. Verify each created issue actually carries the label. Right after every
+   `gh issue create`, run:
+
+```bash
+# Replace <num> with the issue number returned by gh issue create.
+gh issue view <num> --json labels --jq '[.labels[].name] | index("auto-implement") // empty'
+# Expected: prints "0" (or another non-empty index). Empty output means the
+# label was NOT applied -- re-add it before continuing:
+gh issue edit <num> --add-label auto-implement
+```
+
+   At the end of the planning run, sanity-check the full set:
+
+```bash
+gh issue list --label auto-implement --state open --json number --jq 'length'
+# Expected: at least the number of issues you just created. If lower, locate
+# the missing ones with `gh issue list --state open --json number,labels` and
+# re-apply the label with `gh issue edit <num> --add-label auto-implement`.
+```
+
+5. Save plan:
 
 ```markdown
 # Plan — YYYY-MM-DD
@@ -59,3 +87,9 @@ gh issue create --title "[category] Feature name" --label "auto-implement,enhanc
 - Check duplicates first: `gh issue list --label auto-implement --state open`
 - Each issue must be self-contained (Agent 3 implements with no questions)
 - Include exact file paths in "How" section
+- Every issue MUST carry the `auto-implement` label. After creating each
+  issue, verify with `gh issue list --label auto-implement --state open` (or
+  `gh issue view <num> --json labels`). If the label is missing, re-add it
+  with `gh issue edit <num> --add-label auto-implement` before continuing.
+  Issues without `auto-implement` are invisible to `auto-implement.yml` and
+  block the engineering pipeline.


### PR DESCRIPTION
## Summary

- Re-applies the `auto-implement` label to 10 stranded prior-cycle issues so `auto-implement.yml` can pick them up again (one-shot `gh` operations -- no code change needed for that part).
- Hardens `.github/prompts/agent2-planning-system.md` so future planning runs (a) document `auto-implement` as REQUIRED, not just an example label, and (b) verify each created issue actually carries the label, with a re-apply path when it does not.

Closes #741.

## Step 1 -- Relabel evidence (already executed against the live repo)

```text
$ for n in 723 725 726 727 728 729 731 732 733 734; do
    gh issue edit "$n" --add-label "auto-implement"
  done
https://github.com/ausardcompany/alexi/issues/723
https://github.com/ausardcompany/alexi/issues/725
https://github.com/ausardcompany/alexi/issues/726
https://github.com/ausardcompany/alexi/issues/727
https://github.com/ausardcompany/alexi/issues/728
https://github.com/ausardcompany/alexi/issues/729
https://github.com/ausardcompany/alexi/issues/731
https://github.com/ausardcompany/alexi/issues/732
https://github.com/ausardcompany/alexi/issues/733
https://github.com/ausardcompany/alexi/issues/734
```

Note: the issue's Step 1 only listed 9 (omitting #731), but #731 was also missing the label at the time of this run, so it was included to satisfy the Done-when "all 10" criterion.

## Step 3 -- Verification

```text
$ gh issue list --label auto-implement --state open --json number --jq 'length'
13

$ gh issue list --label auto-implement --state open --json number --jq '.[].number' | sort -n
723
725
726
727
728
729
731
732
733
734
738
739
740
```

All 10 target issues from #741 (`723, 725, 726, 727, 728, 729, 731, 732, 733, 734`) are present. The extra 3 (`738, 739, 740`) were filed by a separate 06-08 planning cycle and are correctly labeled.

## Step 2 -- Prompt patch (the only file change in this PR)

`.github/prompts/agent2-planning-system.md`:

- Output section now states `auto-implement` is REQUIRED, with a one-paragraph rationale referencing the `auto-implement.yml` query.
- New process step 4: post-create verification with `gh issue view <num> --json labels --jq '[.labels[].name] | index("auto-implement") // empty'` plus a re-apply path via `gh issue edit <num> --add-label auto-implement`.
- New end-of-run sanity check on `gh issue list --label auto-implement --state open --json number --jq 'length'`.
- Mirrored the rule in the Constraints section so it cannot be missed.

The example `gh issue create --label "auto-implement,enhancement"` was already correct; the bug was in execution discipline, not in the example, so the surrounding prose now makes the requirement explicit.

## Gates

```text
npm run lint         -> 0 errors (1264 pre-existing warnings, unchanged)
npm run typecheck    -> clean
npm run format:check -> clean (no source changes)
npm run build        -> clean
```

`npm test` not re-run because the change is docs-only and does not touch any test surface, but the rest of the gate passes.

## Out of scope

- No source code changes (no `src/`).
- No workflow YAML changes; only the planning prompt was edited.
- The recurrence rationale tied to 2026-06-07 research lines 44-50 is preserved by the verification step itself -- if a future planning run drops the label, the post-create check will fail loudly inside that same run.

[alexi-bot]