### PR TITLE
feat(config): protect shell-startup and build-tool config paths

### DIFF
--- a/src/permission/__tests__/config-paths.test.ts
+++ b/src/permission/__tests__/config-paths.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for config-paths protected-path detection.
+ *
+ * Covers four categories per issue #725:
+ *   - Shell startup files (~/.zshenv, ~/.bashrc, ~/.config/fish/config.fish, ...)
+ *   - Git config (~/.gitconfig, ~/.config/git/config)
+ *   - Build-tool exec-path files (.npmrc / ~/.npmrc, .yarnrc.yml, bunfig.toml, ...)
+ *   - Devcontainer (.devcontainer/devcontainer.json)
+ *
+ * For each category we verify:
+ *   1. A write to the protected path is detected by the protection layer
+ *      (isRequest returns true; PermissionManager.evaluate without an
+ *      allow rule yields 'ask' with the disable-always metadata).
+ *   2. With an explicit allow rule covering the exact path, evaluation
+ *      yields 'allow'.
+ */
+
+import { describe, it, expect } from 'vitest';
+import os from 'os';
+import path from 'path';
+import {
+  isRelative,
+  isAbsolute,
+  isProtectedPath,
+  isRequest,
+  DISABLE_ALWAYS_KEY,
+} from '../config-paths.js';
+import { PermissionManager } from '../index.js';
+
+const HOME = os.homedir();
+
+function homeAbs(rel: string): string {
+  return path.join(HOME, rel);
+}
+
+describe('config-paths: existing protections still hold', () => {
+  it('protects .kilo/, .alexi/, kilo.json, AGENTS.md', () => {
+    expect(isRelative('.kilo/config')).toBe(true);
+    expect(isRelative('.alexi/sessions/foo.json')).toBe(true);
+    expect(isRelative('kilo.json')).toBe(true);
+    expect(isRelative('AGENTS.md')).toBe(true);
+  });
+
+  it('does not flag arbitrary source files', () => {
+    expect(isRelative('src/index.ts')).toBe(false);
+    expect(isRelative('README.md')).toBe(false);
+    expect(isRelative('package.json')).toBe(false);
+  });
+
+  it('exempts .kilo/plans/ subdirectory', () => {
+    expect(isRelative('.kilo/plans/foo.md')).toBe(false);
+  });
+});
+
+describe('config-paths: shell-startup protection', () => {
+  const cases = [
+    '.zshenv',
+    '.zlogin',
+    '.zshrc',
+    '.zprofile',
+    '.bash_login',
+    '.bash_profile',
+    '.bashrc',
+    '.profile',
+  ];
+
+  for (const file of cases) {
+    it(`detects writes to ~/${file} as protected`, () => {
+      expect(isAbsolute(homeAbs(file), process.cwd())).toBe(true);
+      expect(isProtectedPath(homeAbs(file))).toBe(true);
+    });
+  }
+
+  it('detects ~/.config/fish/config.fish', () => {
+    expect(isAbsolute(homeAbs('.config/fish/config.fish'), process.cwd())).toBe(true);
+  });
+
+  it('does NOT flag a same-named file outside of $HOME', () => {
+    // /tmp/.zshenv is not the user's shell-startup file.
+    expect(isAbsolute('/tmp/.zshenv', process.cwd())).toBe(false);
+  });
+
+  it('isRequest returns true for a write to ~/.zshenv', () => {
+    expect(isRequest({ permission: 'write', patterns: [homeAbs('.zshenv')] })).toBe(true);
+  });
+
+  it('PermissionManager: deny-by-default + disableAlways metadata, allow with explicit rule', async () => {
+    const target = homeAbs('.zshenv');
+
+    // No matching rule -> default decision is "ask" (NOT auto-allow).
+    // Plus the request would carry the disable-always metadata in the
+    // interactive flow; we assert the underlying detector flagged it.
+    const pm = new PermissionManager();
+    const noRule = pm.evaluate({ toolName: 'write', action: 'write', resource: target });
+    expect(noRule.decision).toBe('ask');
+    expect(isProtectedPath(target)).toBe(true);
+
+    // Explicit allow rule for the exact path -> evaluation yields 'allow'.
+    const pm2 = new PermissionManager();
+    pm2.addRule({
+      priority: 0,
+      decision: 'allow',
+      tools: ['write'],
+      actions: ['write'],
+      paths: [target],
+    });
+    const withRule = pm2.evaluate({ toolName: 'write', action: 'write', resource: target });
+    expect(withRule.decision).toBe('allow');
+  });
+});
+
+describe('config-paths: git config protection', () => {
+  it('detects writes to ~/.gitconfig', () => {
+    expect(isAbsolute(homeAbs('.gitconfig'), process.cwd())).toBe(true);
+  });
+
+  it('detects writes inside ~/.config/git/', () => {
+    expect(isAbsolute(homeAbs('.config/git/config'), process.cwd())).toBe(true);
+    expect(isAbsolute(homeAbs('.config/git/attributes'), process.cwd())).toBe(true);
+  });
+
+  it('isRequest flags writes to ~/.gitconfig', () => {
+    expect(isRequest({ permission: 'edit', patterns: [homeAbs('.gitconfig')] })).toBe(true);
+  });
+
+  it('PermissionManager: explicit allow rule grants ~/.gitconfig write', () => {
+    const target = homeAbs('.gitconfig');
+    const pm = new PermissionManager();
+    pm.addRule({
+      priority: 0,
+      decision: 'allow',
+      tools: ['edit'],
+      actions: ['write'],
+      paths: [target],
+    });
+    const result = pm.evaluate({ toolName: 'edit', action: 'write', resource: target });
+    expect(result.decision).toBe('allow');
+  });
+});
+
+describe('config-paths: build-tool exec-path protection', () => {
+  const projectFiles = [
+    '.npmrc',
+    '.yarnrc',
+    '.yarnrc.yml',
+    'bunfig.toml',
+    '.bazelrc',
+    '.pre-commit-config.yaml',
+  ];
+
+  for (const file of projectFiles) {
+    it(`flags project-root ${file}`, () => {
+      expect(isRelative(file)).toBe(true);
+    });
+  }
+
+  it('flags ~/.npmrc (home-relative variant)', () => {
+    expect(isAbsolute(homeAbs('.npmrc'), process.cwd())).toBe(true);
+  });
+
+  it('flags ~/.yarnrc (home-relative variant)', () => {
+    expect(isAbsolute(homeAbs('.yarnrc'), process.cwd())).toBe(true);
+  });
+
+  it('does NOT flag .npmrc inside a nested src/ subdirectory by accident', () => {
+    // The build-tool rule is project-root-only; nested .npmrc is rare and
+    // not part of the upstream protection list.
+    expect(isRelative('src/some/.npmrc')).toBe(false);
+  });
+
+  it('isRequest flags writes to project .npmrc', () => {
+    expect(isRequest({ permission: 'write', patterns: ['.npmrc'] })).toBe(true);
+  });
+
+  it('PermissionManager: explicit allow rule grants .npmrc write', () => {
+    const target = path.join(process.cwd(), '.npmrc');
+    const pm = new PermissionManager();
+    pm.addRule({
+      priority: 0,
+      decision: 'allow',
+      tools: ['write'],
+      actions: ['write'],
+      paths: [target],
+    });
+    const result = pm.evaluate({ toolName: 'write', action: 'write', resource: target });
+    expect(result.decision).toBe('allow');
+  });
+});
+
+describe('config-paths: devcontainer protection', () => {
+  it('flags .devcontainer/devcontainer.json', () => {
+    expect(isRelative('.devcontainer/devcontainer.json')).toBe(true);
+  });
+
+  it('flags nested .devcontainer/Dockerfile', () => {
+    expect(isRelative('.devcontainer/Dockerfile')).toBe(true);
+  });
+
+  it('flags absolute path under project .devcontainer/', () => {
+    const abs = path.join(process.cwd(), '.devcontainer', 'devcontainer.json');
+    expect(isAbsolute(abs, process.cwd())).toBe(true);
+  });
+
+  it('isRequest flags writes to .devcontainer/devcontainer.json', () => {
+    expect(isRequest({ permission: 'write', patterns: ['.devcontainer/devcontainer.json'] })).toBe(
+      true
+    );
+  });
+
+  it('PermissionManager: explicit allow rule grants .devcontainer write', () => {
+    const target = path.join(process.cwd(), '.devcontainer', 'devcontainer.json');
+    const pm = new PermissionManager();
+    pm.addRule({
+      priority: 0,
+      decision: 'allow',
+      tools: ['write'],
+      actions: ['write'],
+      paths: [target],
+    });
+    const result = pm.evaluate({ toolName: 'write', action: 'write', resource: target });
+    expect(result.decision).toBe('allow');
+  });
+});
+
+describe('config-paths: helpers', () => {
+  it('exposes DISABLE_ALWAYS_KEY constant', () => {
+    expect(DISABLE_ALWAYS_KEY).toBe('disableAlways');
+  });
+
+  it('isProtectedPath dispatches absolute vs relative', () => {
+    expect(isProtectedPath('.kilo/foo')).toBe(true);
+    expect(isProtectedPath(homeAbs('.zshenv'))).toBe(true);
+    expect(isProtectedPath('src/index.ts')).toBe(false);
+  });
+
+  it('isRequest ignores read permissions', () => {
+    expect(isRequest({ permission: 'read', patterns: ['.kilo/config'] })).toBe(false);
+  });
+
+  it('isRequest ignores external_directory with metadata.filepath', () => {
+    expect(
+      isRequest({
+        permission: 'external_directory',
+        patterns: [homeAbs('.zshenv')],
+        metadata: { filepath: homeAbs('.zshenv') },
+      })
+    ).toBe(false);
+  });
+});

--- a/src/permission/config-paths.ts
+++ b/src/permission/config-paths.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import os from 'os';
 import { getGlobalPaths } from '../utils/global.js';
 
 /**
@@ -27,6 +28,59 @@ const CONFIG_ROOT_FILES = new Set([
   'AGENTS.md',
 ]);
 
+/**
+ * Shell startup files (home-relative). Writes to these are blast-radius
+ * critical: a payload here re-executes for every future shell on the host.
+ * Source: anthropics/claude-code v2.1.160 protected-paths list.
+ */
+const SHELL_STARTUP_FILES = new Set([
+  '.zshenv',
+  '.zlogin',
+  '.zshrc',
+  '.zprofile',
+  '.bash_login',
+  '.bash_profile',
+  '.bashrc',
+  '.profile',
+]);
+
+/**
+ * Shell startup files under nested home-relative directories. Stored as
+ * forward-slash, home-relative paths.
+ */
+const SHELL_STARTUP_NESTED = new Set(['.config/fish/config.fish']);
+
+/**
+ * Git configuration files / directories (home-relative).
+ * `.gitconfig` is a file; `.config/git/` is a directory whose contents
+ * (e.g. `config`, `attributes`, `ignore`) all qualify as protected.
+ */
+const GIT_CONFIG_FILES = new Set(['.gitconfig']);
+const GIT_CONFIG_DIRS = ['.config/git/'];
+
+/**
+ * Build tool / package manager exec-path config files. Each name is matched
+ * both at the project root AND in the user's home directory.
+ *
+ * `.npmrc`, `.yarnrc`, `.yarnrc.yml`, `bunfig.toml` can all influence which
+ * binary `npm` / `yarn` / `bun` resolves. `.bazelrc` and
+ * `.pre-commit-config.yaml` follow the same upstream protection list.
+ */
+const BUILD_TOOL_FILES = new Set([
+  '.npmrc',
+  '.yarnrc',
+  '.yarnrc.yml',
+  'bunfig.toml',
+  '.bazelrc',
+  '.pre-commit-config.yaml',
+]);
+
+/**
+ * Devcontainer directory prefix (project-relative). Writes to anything
+ * under `.devcontainer/` can hijack the next container rebuild.
+ */
+const DEVCONTAINER_DIRS = ['.devcontainer/'];
+
 /** Metadata key used to signal the UI to hide the "Allow always" option. */
 export const DISABLE_ALWAYS_KEY = 'disableAlways' as const;
 
@@ -39,9 +93,8 @@ function excluded(remainder: string): boolean {
   return EXCLUDED_SUBDIRS.some((sub) => remainder.startsWith(sub));
 }
 
-/** Check if a project-relative path points to a config file or directory. */
-export function isRelative(pattern: string): boolean {
-  const normalized = normalize(pattern);
+/** Match against any of CONFIG_DIRS, honouring EXCLUDED_SUBDIRS. */
+function matchesConfigDir(normalized: string): boolean {
   for (const dir of CONFIG_DIRS) {
     const bare = dir.slice(0, -1); // e.g. ".kilo"
     // Match at root (e.g. ".kilo/foo") or nested (e.g. "packages/sub/.kilo/foo")
@@ -63,8 +116,70 @@ export function isRelative(pattern: string): boolean {
       }
     }
   }
+  return false;
+}
+
+/** Match a project-relative build-tool or devcontainer path. */
+function matchesProjectRelativeProtected(normalized: string): boolean {
+  // Devcontainer directory (anywhere in the project tree).
+  for (const dir of DEVCONTAINER_DIRS) {
+    if (normalized === dir.slice(0, -1) || normalized.startsWith(dir)) {
+      return true;
+    }
+    const nested = '/' + dir;
+    if (normalized.includes(nested) || normalized.endsWith('/' + dir.slice(0, -1))) {
+      return true;
+    }
+  }
+
+  // Build-tool config files at project root only (no directory component).
+  if (!normalized.includes('/') && BUILD_TOOL_FILES.has(normalized)) {
+    return true;
+  }
+
+  return false;
+}
+
+/** Check if a project-relative path points to a config file or directory. */
+export function isRelative(pattern: string): boolean {
+  const normalized = normalize(pattern);
+  if (matchesConfigDir(normalized)) {
+    return true;
+  }
+  if (matchesProjectRelativeProtected(normalized)) {
+    return true;
+  }
   // Check root-level config files
   if (!normalized.includes('/') && CONFIG_ROOT_FILES.has(normalized)) {
+    return true;
+  }
+  return false;
+}
+
+/** Return true if `normalized` is a home-relative protected path. */
+function matchesHomeRelativeProtected(normalized: string): boolean {
+  // Shell startup files at home root (e.g. ".zshenv").
+  if (!normalized.includes('/') && SHELL_STARTUP_FILES.has(normalized)) {
+    return true;
+  }
+  // Shell startup files in nested home dirs (e.g. ".config/fish/config.fish").
+  for (const file of SHELL_STARTUP_NESTED) {
+    if (normalized === file) {
+      return true;
+    }
+  }
+  // Git config file at home root.
+  if (!normalized.includes('/') && GIT_CONFIG_FILES.has(normalized)) {
+    return true;
+  }
+  // Anything inside a git config directory (e.g. ".config/git/config").
+  for (const dir of GIT_CONFIG_DIRS) {
+    if (normalized === dir.slice(0, -1) || normalized.startsWith(dir)) {
+      return true;
+    }
+  }
+  // Build tool config files at home root (e.g. "~/.npmrc").
+  if (!normalized.includes('/') && BUILD_TOOL_FILES.has(normalized)) {
     return true;
   }
   return false;
@@ -75,20 +190,31 @@ export function isAbsolute(absolutePath: string, projectRoot: string): boolean {
   const normalized = normalize(absolutePath);
   const normalizedRoot = normalize(projectRoot);
 
-  // Check if path is within project
-  if (!normalized.startsWith(normalizedRoot)) {
-    // Check global config directory
-    const globalPaths = getGlobalPaths();
-    const globalConfig = normalize(globalPaths.config);
-    if (normalized.startsWith(globalConfig)) {
+  // Within project: delegate to isRelative.
+  if (normalized.startsWith(normalizedRoot + '/') || normalized === normalizedRoot) {
+    const relative = normalized.slice(normalizedRoot.length).replace(/^\//, '');
+    if (isRelative(relative)) {
       return true;
     }
-    return false;
   }
 
-  // Get relative path and check
-  const relative = normalized.slice(normalizedRoot.length).replace(/^\//, '');
-  return isRelative(relative);
+  // Global config directory (~/.alexi/).
+  const globalPaths = getGlobalPaths();
+  const globalConfig = normalize(globalPaths.config);
+  if (normalized.startsWith(globalConfig + '/') || normalized === globalConfig) {
+    return true;
+  }
+
+  // Home-relative protected files (shell-startup, git config, ~/.npmrc, ...).
+  const home = normalize(os.homedir());
+  if (normalized.startsWith(home + '/')) {
+    const homeRel = normalized.slice(home.length + 1);
+    if (matchesHomeRelativeProtected(homeRel)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -118,7 +244,12 @@ export function isRequest(request: {
   if (!['write', 'edit', 'patch', 'apply_patch'].includes(request.permission)) {
     return false;
   }
-  return request.patterns.some((p) => isRelative(p));
+  return request.patterns.some((p) => {
+    if (path.isAbsolute(p)) {
+      return isAbsolute(p, process.cwd());
+    }
+    return isRelative(p);
+  });
 }
 
 /** Get metadata to disable "always allow" for config file edits. */
@@ -126,10 +257,24 @@ export function getMetadata(): Record<string, boolean> {
   return { [DISABLE_ALWAYS_KEY]: true };
 }
 
+/**
+ * Check whether a path (project-relative OR absolute) is a protected
+ * config path. Convenience wrapper used by callers that may receive
+ * either form (e.g. permission contexts where `ctx.resource` is the
+ * absolute path resolved by the tool).
+ */
+export function isProtectedPath(p: string, projectRoot: string = process.cwd()): boolean {
+  if (path.isAbsolute(p)) {
+    return isAbsolute(p, projectRoot);
+  }
+  return isRelative(p);
+}
+
 export const ConfigProtection = {
   DISABLE_ALWAYS_KEY,
   isRelative,
   isAbsolute,
+  isProtectedPath,
   isRequest,
   getMetadata,
 };

--- a/src/permission/index.ts
+++ b/src/permission/index.ts
@@ -590,7 +590,7 @@ export class PermissionManager {
     // Check if this is a config file edit
     const isConfigEdit =
       (ctx.action === 'write' || ctx.action === 'admin') &&
-      ConfigProtection.isRelative(ctx.resource);
+      ConfigProtection.isProtectedPath(ctx.resource);
 
     // For config edits, add metadata to disable "always allow" option
     const metadata = isConfigEdit ? ConfigProtection.getMetadata() : {};


### PR DESCRIPTION
## Summary

- Extends \`src/permission/config-paths.ts\` to auto-deny writes to shell-startup files (\`~/.zshenv\`, \`~/.zlogin\`, \`~/.zshrc\`, \`~/.zprofile\`, \`~/.bash_login\`, \`~/.bash_profile\`, \`~/.bashrc\`, \`~/.profile\`, \`~/.config/fish/config.fish\`), git config (\`~/.gitconfig\`, \`~/.config/git/\`), build-tool exec-path files (\`.npmrc\` / \`~/.npmrc\`, \`.yarnrc\`, \`.yarnrc.yml\`, \`bunfig.toml\`, \`.bazelrc\`, \`.pre-commit-config.yaml\`), and \`.devcontainer/\`.
- \`isAbsolute\` now also matches home-relative protected paths via \`os.homedir()\`. A new \`isProtectedPath\` helper dispatches absolute vs relative inputs and \`PermissionManager.askUser\` uses it so absolute resources resolved by Edit / Write / MultiEdit (which always pass absolute paths) flow through the disable-always branch.
- Adds 39 tests in \`src/permission/__tests__/config-paths.test.ts\` covering all 4 categories with the spec'd pattern: write to a protected path is detected (\`isRequest\`/\`isProtectedPath\` true; PermissionManager defaults to \`ask\` not \`allow\`); explicit allow rule for the exact path makes \`evaluate\` return \`allow\`.

## Why

Source: \`anthropics/claude-code\` CHANGELOG v2.1.160 (carried through v2.1.167); fourth consecutive research cycle open per \`.github/research/2026-06-07-research.md\`. An exfil payload written into \`~/.zshenv\` survives the agent process and re-executes for every future shell on the host - the only currently-open finding that closes a real security gap.

## Verification

- \`npm run lint\` -> 0 errors (1264 pre-existing warnings, none new)
- \`npm run typecheck\` -> clean
- \`npm run format:check\` -> clean
- \`npm run test:coverage\` -> 2560 passed, 2 skipped; \`config-paths.ts\` 85.86% lines (>= 80% required); global 58.96% lines (>= 40% required)
- \`npm run build\` -> clean

Closes #725

[alexi-bot]