### PR TITLE
feat: [ci] Add sst/opencode to research-agent reference repo list (#760)

### DIFF
--- a/.github/prompts/agent1-research-system.md
+++ b/.github/prompts/agent1-research-system.md
@@ -13,6 +13,7 @@ Write file: `.github/research/YYYY-MM-DD-spec.md`
    - `gh api repos/anthropics/claude-code/commits?per_page=20 --jq '.[].commit.message'`
    - `gh api repos/cline/cline/commits?per_page=20 --jq '.[].commit.message'`
    - `gh api repos/aider-ai/aider/commits?per_page=20 --jq '.[].commit.message'`
+   - `gh api repos/sst/opencode/commits?per_page=20 --jq '.[].commit.message'`
 
 2. Check what we already have: `ls src/tool/tools/ && ls src/core/`
 
@@ -28,7 +29,7 @@ Write file: `.github/research/YYYY-MM-DD-spec.md`
 ### 1. [Feature Name]
 - **What**: One sentence describing the feature
 - **Why**: Why users need it
-- **Source**: Which repo/commit inspired this
+- **Source**: Which repo/commit inspired this (e.g. `sst/opencode#31752`)
 - **Category**: tool | provider | command | mcp | config
 - **Size**: small (< 4h) | medium (1-2 days)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ The agent fleet has been refactored into a T-shape model. There is one shared ba
 | `.github/workflows/agent-data.yml`             | `data`           | manual / scheduled       |
 | `.github/workflows/agent-security.yml`         | `security`       | manual / scheduled       |
 
+`agent1-research.yml` polls these reference repos for daily commit signal: `Kilo-Org/kilocode`, `anthropics/claude-code`, `cline/cline`, `aider-ai/aider`, and `sst/opencode`. Update the list in `.github/prompts/agent1-research-system.md` (not in the workflow YAML).
+
 ### Adding a new agent (~30 lines of YAML)
 
 1. If a new vertical is needed, write `.github/prompts/role-<name>.md` following the existing role-file shape (identity / vertical knowledge / what you own / must NOT do / inputs / outputs / DoD). Keep it under ~80 lines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Version bumped** from `1.17.1` to `1.17.2` in `package.json` (release reference: PR #758, commit `1b0df735` — `feat(sync): apply upstream changes (2026-06-11)`).
+- **Upstream sync metadata refreshed** in `.github/last-sync-commits.json` (workflow run `27340436170`, timestamp `2026-06-11T10:27:47Z`):
+  - `kilocode` upstream HEAD advanced from `c7a06d2f` to `8b2a1000` (`Kilo-Org/kilocode`).
+  - `opencode` upstream HEAD advanced from `97e713e8` to `318dbe93` (`anomalyco/opencode`).
+  - `claude-code` upstream HEAD advanced from `1c5f951a` to `3a7c7361` (`anthropics/claude-code`).
+- **Header-comment formatting normalization** (commit `9e105b7c`, agent factory engineering run): Removed the extra blank line between the JSDoc header comment and the first `import` statement in three files to satisfy the repository's Prettier configuration. Pure formatting change with no behavioral, API, runtime, or type-shape impact:
+  - `src/agent/index.ts` (Agent System — `AgentSchema`, `AgentMode`, agent registry and `@syntax` switching).
+  - `src/core/catalog.ts` (Model Catalog — `ModelCapability` Zod enum and centralized model capability tracking).
+  - `src/tool/registry.ts` (Enhanced Tool Registry — `EnhancedToolRegistry`, `PromptToolResolver`, `ToolResolutionContext`, `ToolResolutionError`).
+
 ### Added
 
 - **Skill tool description guard test** (`src/tool/skill.test.ts`): A regression test asserting that the registered skill tool's description does not contain the placeholder strings `tool-skill` or `Skill for tool tests.`, both of which were used by an upstream test scaffold and must not leak into the production tool description rendered to the LLM. The canonical skill tool implementation lives in `src/tool/tools/skill.ts` and is exported as `skillTool` (registered under the name `'skill'`).


### PR DESCRIPTION
## Summary

Automated implementation of #760 by **Kilo CLI** via the agent factory (role=engineering).

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 2
- **Branch**: `auto/760-ci-add-sst-opencode-to-research-agent-reference-re`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #760
