### PR TITLE
docs(ci): rotate research repo list - drop continuedev, add sst/opencode

### DIFF
--- a/.github/prompts/agent1-research-task.md
+++ b/.github/prompts/agent1-research-task.md
@@ -16,7 +16,7 @@ Read it to understand what was already analyzed and focus on NEW developments.
    - `gh api repos/anthropics/claude-code/commits?per_page=20 --jq '.[].commit.message'`
    - `gh api repos/cline/cline/commits?per_page=20 --jq '.[].commit.message'`
    - `gh api repos/aider-ai/aider/commits?per_page=20 --jq '.[].commit.message'`
-   - `gh api repos/continuedev/continue/commits?per_page=20 --jq '.[].commit.message'`
+   - `gh api repos/sst/opencode/commits?per_page=20 --jq '.[].commit.message'`
 
 2. Identify significant new features, patterns, or improvements
 


### PR DESCRIPTION
## Summary

- Replace `continuedev/continue` with `sst/opencode` on line 19 of `.github/prompts/agent1-research-task.md`
- Aligns the per-run TASK prompt with `agent1-research-system.md` line 16, which already lists the new repo set
- No source code, lint, typecheck, or test changes

## Why

Per the 2026-06-11 research brief (`Actionable Recommendations` #4):

> Reference-repo rotation confirmed: `sst/opencode` shipped 2/4 actionable items today. Drop continuedev (week 9 dryness), add `sst/opencode`.

Today the SYSTEM and TASK prompts disagree on which five repos the research role polls — leaving `sst/opencode` ungrepped while a 9-week-dry repo is still queried daily.

## Verification

```bash
diff \
  <(grep -oE 'repos/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+' .github/prompts/agent1-research-system.md | sort -u) \
  <(grep -oE 'repos/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+' .github/prompts/agent1-research-task.md | sort -u)
```

Returns empty — the two files now reference the same five repos.

Standard gates (`lint`, `typecheck`, `format:check`) pass; no `.ts`/`.tsx` change so behavioural tests are unaffected.

## Out of scope

- `.github/prompts/role-consulting.md` line 13-14 (separate `role-management` change)
- `aider-ai/aider` rotation (one quiet day is not a rotation signal)

Closes #763