### PR TITLE
test(tools): lock in bash/shell tool not echoing input command (#765)

### DIFF
--- a/src/tool/tools/__tests__/bash-no-command-echo.test.ts
+++ b/src/tool/tools/__tests__/bash-no-command-echo.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression tests for issue #765: ensure the bash tool result payload
+ * never includes the input `command` string. Echoing the command back
+ * doubles cached-turn token spend on heredoc-heavy workloads
+ * (cline/cline#11463, commit 7f9d5461, 2026-06-11).
+ *
+ * NOTE: tests target src/tool/tools/bash.ts directly (not the shell.ts
+ * alias) so that any future regression in either implementation is
+ * caught independently.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bashTool } from '../bash.js';
+import type { ToolContext } from '../../index.js';
+
+describe('bash tool — no command echo (issue #765)', () => {
+  const context: ToolContext = {
+    workdir: process.cwd(),
+  };
+
+  function uniqueMarker(prefix: string): string {
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    return `${prefix}-${stamp}-${'X'.repeat(80)}`;
+  }
+
+  it('(a) success path: simple echo command is not present in result.data', async () => {
+    const marker = uniqueMarker('AX765-success-marker');
+    const command = `: '${marker}'; echo hello`;
+
+    const result = await bashTool.executeUnsafe({ command }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    expect(JSON.stringify(result.data)).not.toContain(marker);
+    expect(result.data?.stdout.trim()).toBe('hello');
+  });
+
+  it('(b) heredoc payload (8 KB) does not appear in result.data', async () => {
+    const heredocMarker = uniqueMarker('AX765-heredoc-marker');
+    const big = 'X'.repeat(8192);
+    const command = `cat > /dev/null <<'EOF'\n${heredocMarker}\n${big}\nEOF\n`;
+
+    const result = await bashTool.executeUnsafe({ command }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+
+    const serialized = JSON.stringify(result.data);
+    expect(serialized).not.toContain(heredocMarker);
+    expect(serialized).not.toContain(big);
+
+    // Tight bound: result.data should be small since stdout/stderr empty.
+    expect(serialized.length).toBeLessThan(1024);
+  });
+
+  it('(c) failure path (exit 1): command is not echoed back in result.data', async () => {
+    const marker = uniqueMarker('AX765-error-marker');
+    const command = `: '${marker}'; exit 1`;
+
+    const result = await bashTool.executeUnsafe({ command }, context);
+
+    expect(result.success).toBe(false);
+    expect(result.data).toBeDefined();
+    expect(result.data?.exitCode).toBe(1);
+    expect(JSON.stringify(result.data)).not.toContain(marker);
+  });
+
+  it('(d) timeout path: command is not echoed back in result.data', async () => {
+    const marker = uniqueMarker('AX765-timeout-marker');
+    const command = `: '${marker}'; sleep 10`;
+
+    const result = await bashTool.executeUnsafe({ command, timeout: 200 }, context);
+
+    expect(result.data).toBeDefined();
+    expect(result.data?.timedOut).toBe(true);
+    expect(JSON.stringify(result.data)).not.toContain(marker);
+  }, 10000);
+});

--- a/src/tool/tools/__tests__/shell-no-command-echo.test.ts
+++ b/src/tool/tools/__tests__/shell-no-command-echo.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for issue #765: ensure the shell tool result payload
+ * never includes the input `command` string. Echoing the command back
+ * doubles cached-turn token spend on heredoc-heavy workloads
+ * (cline/cline#11463, commit 7f9d5461, 2026-06-11).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shellTool } from '../shell.js';
+import type { ToolContext } from '../../index.js';
+
+describe('shell tool — no command echo (issue #765)', () => {
+  const context: ToolContext = {
+    workdir: process.cwd(),
+  };
+
+  /**
+   * Build a "marker" command of the given size whose text is unique and
+   * unlikely to appear in stdout/stderr by accident. The marker is always
+   * > 64 chars so it falls inside the assertNoCommandEcho gate as well.
+   */
+  function uniqueMarker(prefix: string): string {
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    return `${prefix}-${stamp}-${'X'.repeat(80)}`;
+  }
+
+  it('(a) success path: simple echo command is not present in result.data', async () => {
+    const marker = uniqueMarker('AX765-success-marker');
+    // Wrap the marker inside a shell comment so it doesn't get echoed
+    // back to stdout. The marker is unique, so any occurrence in the
+    // serialized result payload would have to come from the result
+    // itself echoing `params.command`.
+    const command = `: '${marker}'; echo hello`;
+
+    const result = await shellTool.executeUnsafe({ command }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    expect(JSON.stringify(result.data)).not.toContain(marker);
+    expect(result.data?.stdout.trim()).toBe('hello');
+  });
+
+  it('(b) heredoc payload (8 KB) does not appear in result.data', async () => {
+    const heredocMarker = uniqueMarker('AX765-heredoc-marker');
+    const big = 'X'.repeat(8192);
+    // Write the heredoc to /dev/null so stdout stays small. The marker
+    // and the 8 KB body are part of `params.command` only.
+    const command = `cat > /dev/null <<'EOF'\n${heredocMarker}\n${big}\nEOF\n`;
+
+    const result = await shellTool.executeUnsafe({ command }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+
+    const serialized = JSON.stringify(result.data);
+    expect(serialized).not.toContain(heredocMarker);
+    expect(serialized).not.toContain(big);
+
+    // Tight bound: result.data should be small (well under the 8 KB
+    // heredoc body) since stdout/stderr are empty.
+    expect(serialized.length).toBeLessThan(1024);
+  });
+
+  it('(c) failure path (exit 1): command is not echoed back in result.data', async () => {
+    const marker = uniqueMarker('AX765-error-marker');
+    const command = `: '${marker}'; exit 1`;
+
+    const result = await shellTool.executeUnsafe({ command }, context);
+
+    expect(result.success).toBe(false);
+    expect(result.data).toBeDefined();
+    expect(result.data?.exitCode).toBe(1);
+    expect(JSON.stringify(result.data)).not.toContain(marker);
+  });
+
+  it('(d) timeout path: command is not echoed back in result.data', async () => {
+    const marker = uniqueMarker('AX765-timeout-marker');
+    const command = `: '${marker}'; sleep 10`;
+
+    const result = await shellTool.executeUnsafe({ command, timeout: 200 }, context);
+
+    expect(result.data).toBeDefined();
+    expect(result.data?.timedOut).toBe(true);
+    expect(JSON.stringify(result.data)).not.toContain(marker);
+  }, 10000);
+});

--- a/src/tool/tools/bash.ts
+++ b/src/tool/tools/bash.ts
@@ -20,11 +20,32 @@ const BashParamsSchema = z.object({
     .describe('Optional description of what the command does (recommended for complex commands)'),
 });
 
+// NOTE: the input `command` is intentionally NOT echoed back in the
+// result. The provider already has it as the tool-call input;
+// duplicating it inflates every cached turn (heredoc payloads double
+// in size). See research 2026-06-13 item #2 (cline/cline#11463,
+// commit 7f9d5461, 2026-06-11).
 interface BashResult {
   stdout: string;
   stderr: string;
   exitCode: number;
   timedOut: boolean;
+}
+
+/**
+ * Test-only guard: throws if the input command appears anywhere in the
+ * serialized result payload. Gated by NODE_ENV === 'test' so production
+ * has zero overhead. Bound to commands of length > 64 to avoid false
+ * positives on short commands whose text might legitimately appear in
+ * stdout (e.g. when the command is `pwd` or `echo`).
+ */
+function assertNoCommandEcho(result: BashResult, command: string): void {
+  if (process.env.NODE_ENV === 'test' && command.length > 64) {
+    const serialized = JSON.stringify(result);
+    if (serialized.includes(command)) {
+      throw new Error('command echoed back in bash tool result');
+    }
+  }
 }
 
 const DEFAULT_TIMEOUT = 120000; // 2 minutes
@@ -193,6 +214,8 @@ Security:
           timedOut,
         };
 
+        assertNoCommandEcho(result, params.command);
+
         if (context.signal?.aborted) {
           resolve({
             success: false,
@@ -233,15 +256,19 @@ Security:
         context.signal?.removeEventListener('abort', abortHandler);
         killed = true;
 
+        const errorResult: BashResult = {
+          stdout,
+          stderr,
+          exitCode: -1,
+          timedOut: false,
+        };
+
+        assertNoCommandEcho(errorResult, params.command);
+
         resolve({
           success: false,
           error: err.message,
-          data: {
-            stdout,
-            stderr,
-            exitCode: -1,
-            timedOut: false,
-          },
+          data: errorResult,
         });
       });
     });

--- a/src/tool/tools/shell.ts
+++ b/src/tool/tools/shell.ts
@@ -22,12 +22,33 @@ const ShellParamsSchema = z.object({
     .describe('Optional description of what the command does (recommended for complex commands)'),
 });
 
+// NOTE: the input `command` is intentionally NOT echoed back in the
+// result. The provider already has it as the tool-call input;
+// duplicating it inflates every cached turn (heredoc payloads double
+// in size). See research 2026-06-13 item #2 (cline/cline#11463,
+// commit 7f9d5461, 2026-06-11).
 interface ShellResult {
   stdout: string;
   stderr: string;
   exitCode: number;
   timedOut: boolean;
   shellType?: string;
+}
+
+/**
+ * Test-only guard: throws if the input command appears anywhere in the
+ * serialized result payload. Gated by NODE_ENV === 'test' so production
+ * has zero overhead. Bound to commands of length > 64 to avoid false
+ * positives on short commands like `ls` or `pwd` whose text might
+ * legitimately appear in stdout (e.g. when the command is `pwd`).
+ */
+function assertNoCommandEcho(result: ShellResult, command: string): void {
+  if (process.env.NODE_ENV === 'test' && command.length > 64) {
+    const serialized = JSON.stringify(result);
+    if (serialized.includes(command)) {
+      throw new Error('command echoed back in shell tool result');
+    }
+  }
 }
 
 const DEFAULT_TIMEOUT = 120000; // 2 minutes
@@ -200,6 +221,8 @@ Security:
           shellType: shellInfo.type,
         };
 
+        assertNoCommandEcho(result, params.command);
+
         if (context.signal?.aborted) {
           resolve({
             success: false,
@@ -240,16 +263,20 @@ Security:
         context.signal?.removeEventListener('abort', abortHandler);
         killed = true;
 
+        const errorResult: ShellResult = {
+          stdout,
+          stderr,
+          exitCode: -1,
+          timedOut: false,
+          shellType: shellInfo.type,
+        };
+
+        assertNoCommandEcho(errorResult, params.command);
+
         resolve({
           success: false,
           error: err.message,
-          data: {
-            stdout,
-            stderr,
-            exitCode: -1,
-            timedOut: false,
-            shellType: shellInfo.type,
-          },
+          data: errorResult,
         });
       });
     });


### PR DESCRIPTION
## Summary

- Locks in the current behaviour of `src/tool/tools/bash.ts` and `src/tool/tools/shell.ts` not echoing the input `command` back into the result payload.
- Adds an explanatory comment on `BashResult` / `ShellResult` so future refactors do not silently re-introduce the upstream cline behaviour (cline/cline#11463, commit 7f9d5461).
- Adds a test-only `assertNoCommandEcho` helper (gated by `NODE_ENV === 'test'` and command length > 64) called from both success and error branches in each tool. Zero overhead in production.
- Adds 4 tests per tool (8 total): success, 8 KB heredoc payload, exit-1 failure, and timeout -- each asserting the input command does not appear in `JSON.stringify(result.data)`.

## Why

Heredoc prompts are a hot path for code generation. Echoing the heredoc back inside the tool result doubles the bytes stuffed into every subsequent cached turn. Cline measured this as a meaningful contributor to long-session token spend (cline/cline#11463, +134 -6).

The local code already does the right thing, but without a regression test the next refactor -- particularly any "include params for debugging" change -- would silently bring the problem back.

## Validation

- `npm run typecheck` -- clean
- `npm run lint` -- 0 errors (warnings only, all pre-existing)
- `npm run format:check` -- clean
- `npm test` -- 2570 passed (2 skipped), 180 test files
- `npm run test:coverage` -- lines 59.36 percent (well above the 40 percent CI floor)
- `npm run build` -- clean

## Scope

- No public API change to either tool.
- No edits to `.github/`, `dist/`, `coverage/`, or `package.json` version.

Closes #765