### PR TITLE
fix(core): prefer structuredContent over content in MCP callTool result

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -430,6 +430,19 @@ export class McpClientManager {
       );
       clearTimeout(timer);
 
+      // Per the MCP spec, `structuredContent` is the canonical machine-readable
+      // output and `content` is human-readable narration. Spec-compliant servers
+      // (Qt Creator, several Codex-pattern servers) emit ONLY `structuredContent`,
+      // so prefer it when present and fall back to `content` flattening otherwise.
+      const structured = (result as { structuredContent?: unknown }).structuredContent;
+      if (structured !== undefined && structured !== null) {
+        const text = typeof structured === 'string' ? structured : JSON.stringify(structured);
+        if (result.isError) {
+          return { success: false, error: text || 'Unknown error' };
+        }
+        return { success: true, result: text };
+      }
+
       // Extract text content from result
       const content = (result.content || []) as Array<{ type: string; text?: string }>;
       const textContent = content

--- a/tests/mcp/structured-content.test.ts
+++ b/tests/mcp/structured-content.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock child_process.spawn
+const mockSpawn = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Mock @modelcontextprotocol/sdk
+const mockClientConnect = vi.fn().mockResolvedValue(undefined);
+const mockClientListTools = vi.fn().mockResolvedValue({ tools: [] });
+const mockClientCallTool = vi.fn();
+const mockClientClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  return {
+    Client: class MockClient {
+      connect = mockClientConnect;
+      listTools = mockClientListTools;
+      callTool = mockClientCallTool;
+      close = mockClientClose;
+    },
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+// Mock config loading
+vi.mock('../../src/mcp/config.js', () => ({
+  loadMcpConfig: vi.fn().mockReturnValue({ version: '1.0', servers: [] }),
+  resolveEnvVars: vi.fn((env?: Record<string, string>) => env ?? {}),
+}));
+
+import { McpClientManager } from '../../src/mcp/client.js';
+import type { McpServerConfig } from '../../src/mcp/config.js';
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdin = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.pid = 12345;
+  return proc;
+}
+
+describe('McpClientManager.callTool — structuredContent handling', () => {
+  let manager: McpClientManager;
+
+  const stdioConfig: McpServerConfig = {
+    name: 'test-server',
+    transport: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+    enabled: true,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    manager = new McpClientManager();
+    mockSpawn.mockReturnValue(createMockProcess());
+    await manager.connect(stdioConfig);
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAll();
+    vi.restoreAllMocks();
+  });
+
+  it('returns JSON-stringified structuredContent when only structuredContent is present', async () => {
+    mockClientCallTool.mockResolvedValue({
+      structuredContent: { foo: 'bar' },
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe('{"foo":"bar"}');
+  });
+
+  it('falls back to content flattening when only content is present', async () => {
+    mockClientCallTool.mockResolvedValue({
+      content: [{ type: 'text', text: 'hello' }],
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe('hello');
+  });
+
+  it('prefers structuredContent over content when both are present', async () => {
+    mockClientCallTool.mockResolvedValue({
+      structuredContent: { foo: 'bar' },
+      content: [{ type: 'text', text: 'narrative description' }],
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe('{"foo":"bar"}');
+  });
+
+  it('falls back to content path when structuredContent is null', async () => {
+    mockClientCallTool.mockResolvedValue({
+      structuredContent: null,
+      content: [{ type: 'text', text: 'fallback text' }],
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe('fallback text');
+  });
+
+  it('honors isError when structuredContent is set', async () => {
+    mockClientCallTool.mockResolvedValue({
+      structuredContent: { foo: 'bar' },
+      isError: true,
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('{"foo":"bar"}');
+  });
+
+  it('returns raw string when structuredContent is already a string', async () => {
+    mockClientCallTool.mockResolvedValue({
+      structuredContent: 'plain string',
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe('plain string');
+  });
+});


### PR DESCRIPTION
## Summary

- Make `McpClientManager.callTool` prefer `result.structuredContent` over `result.content` when an MCP server returns it, falling back to today's content-flattening path when only `content` is present.
- Honor `result.isError` in both the structured and content branches.
- Add 6 new test cases covering structured-only, content-only, both, null structured, isError + structured, and string structured.

## Why

Per the MCP spec, `structuredContent` is the canonical machine-readable output and `content` is human-readable narration. Spec-compliant servers (Qt Creator, several Codex-pattern servers) emit ONLY `structuredContent`. Today our `callTool` filters `result.content` for `type === 'text'` items and joins them — when `content` is empty the model receives an empty string and concludes the tool silently failed.

Source: sst/opencode#32074, commit be227503 (2026-06-12, +9 -3).

## Test Plan

- New: `tests/mcp/structured-content.test.ts` — 6 cases all passing.
- Existing: `npm test -- mcp` → 50 tests, 7 files, all green.
- Full gate: lint (0 errors), typecheck, format:check, test:coverage, build all green locally.

Closes #767