### PR TITLE
fix(tools): apply_patch validates context/deletion lines, fails closed on hunk mismatch

### DIFF
--- a/src/tool/tools/apply-patch.ts
+++ b/src/tool/tools/apply-patch.ts
@@ -20,13 +20,56 @@ interface ApplyPatchResult {
 }
 
 /**
- * Apply a unified diff patch to content
+ * Error thrown when a patch hunk does not match the file contents.
+ *
+ * Carries enough context to surface the failure back to the caller without
+ * silently corrupting the file: which hunk failed, which line in the source
+ * file, and what was expected vs. actually present.
  */
-function applyPatchToContent(originalContent: string, patch: string): string {
+export class PatchHunkError extends Error {
+  readonly hunkNumber: number;
+  readonly filePath: string;
+  readonly expected: string;
+  readonly actual: string;
+  readonly lineNumber: number;
+
+  constructor(opts: {
+    hunkNumber: number;
+    filePath: string;
+    expected: string;
+    actual: string;
+    lineNumber: number;
+  }) {
+    super(
+      `Patch hunk ${opts.hunkNumber} failed at line ${opts.lineNumber}: ` +
+        `expected ${JSON.stringify(opts.expected)}, got ${JSON.stringify(opts.actual)}`
+    );
+    this.name = 'PatchHunkError';
+    this.hunkNumber = opts.hunkNumber;
+    this.filePath = opts.filePath;
+    this.expected = opts.expected;
+    this.actual = opts.actual;
+    this.lineNumber = opts.lineNumber;
+  }
+}
+
+/**
+ * Apply a unified diff patch to content.
+ *
+ * Validates context (` `) and deletion (`-`) lines against the actual file
+ * contents and throws {@link PatchHunkError} on any mismatch so a stale or
+ * wrong patch cannot silently corrupt the file.
+ */
+function applyPatchToContent(
+  originalContent: string,
+  patch: string,
+  filePath: string = ''
+): string {
   const lines = originalContent.split('\n');
   const patchLines = patch.split('\n');
 
   let lineIndex = 0;
+  let hunkNumber = 0;
   const result: string[] = [];
   let i = 0;
 
@@ -35,6 +78,7 @@ function applyPatchToContent(originalContent: string, patch: string): string {
 
     // Parse hunk header: @@ -start,count +start,count @@
     if (line.startsWith('@@')) {
+      hunkNumber++;
       const match = line.match(/@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@/);
       if (match) {
         const oldStart = parseInt(match[1], 10) - 1; // Convert to 0-indexed
@@ -51,7 +95,27 @@ function applyPatchToContent(originalContent: string, patch: string): string {
 
     // Context line (unchanged)
     if (line.startsWith(' ')) {
-      result.push(lines[lineIndex]);
+      const expected = line.slice(1);
+      if (lineIndex >= lines.length) {
+        throw new PatchHunkError({
+          hunkNumber,
+          filePath,
+          expected,
+          actual: '<EOF>',
+          lineNumber: lineIndex + 1,
+        });
+      }
+      const actual = lines[lineIndex];
+      if (actual !== expected) {
+        throw new PatchHunkError({
+          hunkNumber,
+          filePath,
+          expected,
+          actual,
+          lineNumber: lineIndex + 1,
+        });
+      }
+      result.push(actual);
       lineIndex++;
       i++;
       continue;
@@ -59,6 +123,26 @@ function applyPatchToContent(originalContent: string, patch: string): string {
 
     // Deletion line
     if (line.startsWith('-')) {
+      const expected = line.slice(1);
+      if (lineIndex >= lines.length) {
+        throw new PatchHunkError({
+          hunkNumber,
+          filePath,
+          expected,
+          actual: '<EOF>',
+          lineNumber: lineIndex + 1,
+        });
+      }
+      const actual = lines[lineIndex];
+      if (actual !== expected) {
+        throw new PatchHunkError({
+          hunkNumber,
+          filePath,
+          expected,
+          actual,
+          lineNumber: lineIndex + 1,
+        });
+      }
       // Skip this line in original
       lineIndex++;
       i++;
@@ -160,8 +244,21 @@ Usage:
       // Decode with detected encoding
       const originalContent = decodeWithEncoding(buffer, encoding);
 
-      // Apply patch
-      const patchedContent = applyPatchToContent(originalContent, params.patch);
+      // Apply patch (may throw PatchHunkError before any file write)
+      let patchedContent: string;
+      try {
+        patchedContent = applyPatchToContent(originalContent, params.patch, filePath);
+      } catch (err) {
+        if (err instanceof PatchHunkError) {
+          return {
+            success: false,
+            error:
+              `Patch hunk ${err.hunkNumber} failed at line ${err.lineNumber}: ` +
+              `expected ${JSON.stringify(err.expected)}, got ${JSON.stringify(err.actual)}`,
+          };
+        }
+        throw err;
+      }
 
       // Encode back with original encoding
       const encodedBuffer = encodeWithEncoding(patchedContent, encoding);

--- a/tests/tool/tools/apply-patch.test.ts
+++ b/tests/tool/tools/apply-patch.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import os from 'os';
+
+// Mock the tool index module to bypass permission checks (mirror write.test.ts pattern)
+vi.mock('../../../src/tool/index.js', async () => {
+  const actual = await vi.importActual('../../../src/tool/index.js');
+  return {
+    ...actual,
+    defineTool: (def: {
+      name: string;
+      description: string;
+      execute: (...args: unknown[]) => unknown;
+    }) => ({
+      ...def,
+      execute: def.execute,
+      executeUnsafe: def.execute,
+      toFunctionSchema: () => ({
+        name: def.name,
+        description: def.description,
+        parameters: {},
+      }),
+    }),
+  };
+});
+
+import { applyPatchTool, PatchHunkError } from '../../../src/tool/tools/apply-patch.js';
+import type { ToolContext } from '../../../src/tool/index.js';
+
+describe('apply_patch tool', () => {
+  let tempDir: string;
+  let context: ToolContext;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'apply-patch-test-'));
+    context = { workdir: tempDir };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('PatchHunkError', () => {
+    it('exposes the expected fields', () => {
+      const err = new PatchHunkError({
+        hunkNumber: 2,
+        filePath: '/tmp/foo.ts',
+        expected: 'foo',
+        actual: 'bar',
+        lineNumber: 7,
+      });
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('PatchHunkError');
+      expect(err.hunkNumber).toBe(2);
+      expect(err.filePath).toBe('/tmp/foo.ts');
+      expect(err.expected).toBe('foo');
+      expect(err.actual).toBe('bar');
+      expect(err.lineNumber).toBe(7);
+      expect(err.message).toContain('hunk 2');
+      expect(err.message).toContain('line 7');
+    });
+  });
+
+  describe('valid patch', () => {
+    it('applies a valid patch and updates the file', async () => {
+      const filePath = path.join(tempDir, 'valid.txt');
+      const original = ['line one', 'line two', 'line three'].join('\n');
+      await fs.writeFile(filePath, original, 'utf-8');
+
+      const patch = ['@@ -1,3 +1,3 @@', ' line one', '-line two', '+line TWO', ' line three'].join(
+        '\n'
+      );
+
+      const result = await applyPatchTool.execute({ path: filePath, patch }, context);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.path).toBe(filePath);
+      expect(result.data?.diff.length ?? 0).toBeGreaterThan(0);
+
+      const updated = await fs.readFile(filePath, 'utf-8');
+      expect(updated).toBe(['line one', 'line TWO', 'line three'].join('\n'));
+    });
+  });
+
+  describe('context line mismatch', () => {
+    it('returns success: false and does not write the file', async () => {
+      const filePath = path.join(tempDir, 'ctx-mismatch.txt');
+      const original = ['alpha', 'beta', 'gamma'].join('\n');
+      await fs.writeFile(filePath, original, 'utf-8');
+
+      // Context line `WRONG` does not match actual `alpha`
+      const patch = ['@@ -1,3 +1,3 @@', ' WRONG', '-beta', '+BETA', ' gamma'].join('\n');
+
+      const result = await applyPatchTool.execute({ path: filePath, patch }, context);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('hunk 1');
+      expect(result.error).toContain('expected');
+
+      // File must remain unchanged
+      const onDisk = await fs.readFile(filePath, 'utf-8');
+      expect(onDisk).toBe(original);
+    });
+  });
+
+  describe('deletion line mismatch', () => {
+    it('returns success: false and leaves the file untouched on disk', async () => {
+      const filePath = path.join(tempDir, 'del-mismatch.txt');
+      const original = ['alpha', 'beta', 'gamma'].join('\n');
+      await fs.writeFile(filePath, original, 'utf-8');
+
+      // Deletion targets `WRONG` but actual line at index 1 is `beta`
+      const patch = ['@@ -1,3 +1,3 @@', ' alpha', '-WRONG', '+BETA', ' gamma'].join('\n');
+
+      const result = await applyPatchTool.execute({ path: filePath, patch }, context);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('hunk 1');
+
+      const onDisk = await fs.readFile(filePath, 'utf-8');
+      expect(onDisk).toBe(original);
+    });
+  });
+
+  describe('patch overruns EOF', () => {
+    it('returns success: false when the patch references lines past the end of file', async () => {
+      const filePath = path.join(tempDir, 'eof.txt');
+      const original = ['only line'].join('\n');
+      await fs.writeFile(filePath, original, 'utf-8');
+
+      // Hunk header says start at line 1, but expects 3 lines of context past EOF
+      const patch = [
+        '@@ -1,3 +1,3 @@',
+        ' only line',
+        ' missing line',
+        '-also missing',
+        '+replacement',
+      ].join('\n');
+
+      const result = await applyPatchTool.execute({ path: filePath, patch }, context);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('hunk 1');
+      expect(result.error).toContain('<EOF>');
+
+      const onDisk = await fs.readFile(filePath, 'utf-8');
+      expect(onDisk).toBe(original);
+    });
+  });
+
+  describe('tool metadata', () => {
+    it('has the expected name', () => {
+      expect(applyPatchTool.name).toBe('apply_patch');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #789. Validates context and deletion lines in `applyPatchToContent` and aborts on hunk mismatch with a typed `PatchHunkError`, so a stale or wrong patch can never silently corrupt a file and still report `success: true`.

## Changes

- **`src/tool/tools/apply-patch.ts`**:
  - New exported class `PatchHunkError extends Error` with fields `hunkNumber`, `filePath`, `expected`, `actual`, `lineNumber` (1-indexed).
  - `applyPatchToContent` now tracks `hunkNumber` (incremented on every `@@` header) and validates:
    - ` ` context lines: compares `line.slice(1)` against `lines[lineIndex]`; throws on mismatch.
    - `-` deletion lines: same comparison; throws on mismatch.
    - Bounds check against `lines.length` — overruns throw with `actual: '<EOF>'`.
  - `execute()` catches `PatchHunkError` BEFORE `fs.writeFile` and returns `success: false` with a descriptive error. The existing fallback `catch` for unrelated errors is preserved.

- **`tests/tool/tools/apply-patch.test.ts`** (new): covers valid apply, context mismatch, deletion mismatch, EOF overrun, and `PatchHunkError` shape. Each failure path verifies the file on disk is unchanged.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run format:check` — clean
- `npm test` — 2609 passed / 2 skipped (185 files)
- `npm run build` — succeeds

## Source

cline/cline#11509 (commit `d8eb0631`, 2026-06-12, +50 -5). Tracked in `.github/research/2026-06-15-research.md` Item #1.

Closes #789

[alexi-bot]