### PR TITLE
feat(tools): stream large text files in read tool

### DIFF
--- a/src/tool/tools/read.ts
+++ b/src/tool/tools/read.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod';
 import * as fs from 'fs/promises';
 import { createReadStream } from 'fs';
+import * as readline from 'readline';
 import * as path from 'path';
 import { defineTool, truncateOutput, MAX_LINES, type ToolResult } from '../index.js';
 import {
@@ -27,7 +28,13 @@ interface ReadFileResult {
   type: 'file';
   path: string;
   content: string;
-  totalLines: number;
+  /**
+   * Total number of lines in the file. For ranged reads (caller supplied an
+   * `offset` and/or `limit`) this is `null` because we stream the file rather
+   * than loading it into memory, so an exact count would require a second
+   * pass. Callers can rely on `eof` / `nextOffset` (in the hint) instead.
+   */
+  totalLines: number | null;
   shownLines: number;
   offset: number;
   partial?: boolean;
@@ -49,49 +56,106 @@ export function getFileEncoding(filePath: string): EncodingInfo | undefined {
 }
 
 /**
- * Read file with streaming for better UTF-8 handling and memory efficiency
+ * Maximum file size for implicit whole-file reads (no offset/limit). Files
+ * above this threshold must be read with an explicit offset/limit so the
+ * streaming path is used and the whole file is never buffered into memory.
  */
-async function readFileStreaming(
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/**
+ * Number of bytes read from the head of the file purely to detect encoding
+ * (BOM markers, UTF-8 fallback) before streaming the rest of the file.
+ */
+const ENCODING_PROBE_BYTES = 64 * 1024; // 64 KB
+
+/**
+ * Read up to `ENCODING_PROBE_BYTES` from the head of the file so we can
+ * detect the encoding (and binary-ness) without buffering the whole file.
+ */
+async function readEncodingProbe(filePath: string): Promise<Buffer> {
+  const handle = await fs.open(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(ENCODING_PROBE_BYTES);
+    const { bytesRead } = await handle.read(buf, 0, ENCODING_PROBE_BYTES, 0);
+    return buf.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+interface StreamedLines {
+  /** Captured 1-based slice [offset, offset+limit-1]. */
+  lines: string[];
+  /** Last 1-based line number scanned (== total lines if eof). */
+  totalLinesScanned: number;
+  /** True if the stream reached end-of-file before `limit` lines were captured. */
+  eof: boolean;
+}
+
+/**
+ * Stream a file line-by-line and return the requested 1-based [offset,
+ * offset+limit-1] window without buffering the whole file. Lines are decoded
+ * from the supplied encoding when Node accepts it directly; otherwise raw
+ * UTF-8 is assumed (matches `decodeWithEncoding`'s fallback).
+ *
+ * NOTE: `totalLinesScanned` only equals the file's true total line count
+ * when `eof === true`. For ranged reads we never re-scan the tail of the
+ * file just to compute a total; callers should use `eof` instead.
+ */
+async function readLinesStreaming(
   filePath: string,
-  options?: { offset?: number; limit?: number; maxBytes?: number }
-): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    let totalBytes = 0;
-    const maxBytes = options?.maxBytes;
+  opts: { offset: number; limit: number; encoding: EncodingInfo }
+): Promise<StreamedLines> {
+  const { offset, limit, encoding } = opts;
+  const startIdx = Math.max(1, offset);
+  const endIdx = startIdx + limit - 1;
 
-    const stream = createReadStream(filePath, {
-      encoding: undefined, // Read as Buffer for proper UTF-8 handling
-      start: options?.offset ? options.offset - 1 : undefined,
-      end: options?.limit && options?.offset ? options.offset + options.limit - 1 : undefined,
-    });
+  // readline accepts a small set of named encodings via stream.setEncoding.
+  // For everything else we let readline operate on Buffer chunks (default)
+  // and rely on the UTF-8 fallback path used elsewhere in this module.
+  const stream = createReadStream(filePath);
+  const nodeEncoding: 'utf-8' | 'utf16le' =
+    encoding.encoding === 'utf-16le' || encoding.encoding === 'utf16le' ? 'utf16le' : 'utf-8';
+  stream.setEncoding(nodeEncoding);
 
-    stream.on('data', (chunk: Buffer) => {
-      if (maxBytes && totalBytes + chunk.length > maxBytes) {
-        // Only take what we need to reach maxBytes
-        const remaining = maxBytes - totalBytes;
-        if (remaining > 0) {
-          chunks.push(chunk.subarray(0, remaining));
-        }
-        stream.destroy(); // Stop reading
-      } else {
-        chunks.push(chunk);
-        totalBytes += chunk.length;
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  const captured: string[] = [];
+  let lineNo = 0;
+  let eof = true;
+
+  try {
+    for await (const line of rl) {
+      lineNo++;
+      if (lineNo < startIdx) {
+        continue;
       }
-    });
+      if (lineNo > endIdx) {
+        // We have all requested lines; close the stream early so we don't
+        // continue reading the rest of the file.
+        eof = false;
+        break;
+      }
+      captured.push(line);
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
 
-    stream.on('end', () => {
-      const buffer = Buffer.concat(chunks);
-      resolve(buffer);
-    });
+  // Strip a leading BOM character that readline may have surfaced as part of
+  // the very first line when the file started with a UTF-8 BOM.
+  if (
+    captured.length > 0 &&
+    encoding.hasBOM &&
+    encoding.encoding === 'utf-8' &&
+    startIdx === 1 &&
+    captured[0].charCodeAt(0) === 0xfeff
+  ) {
+    captured[0] = captured[0].slice(1);
+  }
 
-    stream.on('close', () => {
-      const buffer = Buffer.concat(chunks);
-      resolve(buffer);
-    });
-
-    stream.on('error', reject);
-  });
+  return { lines: captured, totalLinesScanned: lineNo, eof };
 }
 
 export const readTool = defineTool<typeof ReadParamsSchema, ReadResult>({
@@ -185,57 +249,106 @@ Usage:
         return officeResult;
       }
 
-      // Read file
-      // Use streaming for better UTF-8 handling
-      const buffer = await readFileStreaming(filePath);
+      // Probe the head of the file once so we can both classify it as binary
+      // and detect the encoding without loading the whole file into memory.
+      const probe = await readEncodingProbe(filePath);
 
-      // Check for binary first
-      if (isBinaryFile(buffer)) {
+      if (isBinaryFile(probe)) {
         return {
           success: false,
           error: `Cannot read binary file: ${filePath}`,
         };
       }
 
-      // Detect and decode with proper encoding
-      const encoding = detectEncoding(buffer);
-      const content = decodeWithEncoding(buffer, encoding);
-
+      const encoding = detectEncoding(probe);
       // Cache encoding for write operations
       fileEncodings.set(filePath, encoding);
 
-      const lines = content.split('\n');
-      const totalLines = lines.length;
+      const isImplicitWholeFileRead = params.offset === undefined && params.limit === undefined;
 
+      if (isImplicitWholeFileRead) {
+        // Whole-file path keeps the existing semantics (exact totalLines,
+        // PARTIAL view hint when truncated) but is gated on file size to
+        // protect heap usage. Ranged reads bypass this limit because they
+        // are bounded by `limit`.
+        if (stat.size > MAX_FILE_SIZE_BYTES) {
+          return {
+            success: false,
+            error: 'File too large for whole-file read; pass an explicit offset/limit',
+            hint: 'Use the ranged form: read(path, offset, limit)',
+          };
+        }
+
+        const buffer = await fs.readFile(filePath);
+        const content = decodeWithEncoding(buffer, encoding);
+
+        const lines = content.split('\n');
+        const totalLines = lines.length;
+
+        const offset = 1;
+        const limit = MAX_LINES;
+        const startIdx = 0;
+        const endIdx = Math.min(startIdx + limit, lines.length);
+        const selectedLines = lines.slice(startIdx, endIdx);
+
+        const numberedLines = selectedLines.map((line, i) => `${startIdx + i + 1}: ${line}`);
+        const output = numberedLines.join('\n');
+        const { content: truncated, truncated: wasTruncated } = truncateOutput(output);
+
+        const isPartialView = wasTruncated;
+        const nextOffset = endIdx + 1;
+
+        let hint: string | undefined;
+        if (isPartialView) {
+          hint = `PARTIAL view — file has ${totalLines} lines, showing 1..${endIdx}. Call read again with offset=${nextOffset} to continue.`;
+        } else if (wasTruncated) {
+          hint = `Output truncated. Use offset=${nextOffset} to continue reading.`;
+        }
+
+        const fileResult: ToolResult<ReadResult> = {
+          success: true,
+          data: {
+            type: 'file',
+            path: filePath,
+            content: truncated,
+            totalLines,
+            shownLines: selectedLines.length,
+            offset,
+            ...(isPartialView ? { partial: true } : {}),
+          },
+          truncated: wasTruncated,
+          hint,
+        };
+        attachAgentsMdReminders(fileResult, filePath, context);
+        return fileResult;
+      }
+
+      // Ranged read: stream the file line-by-line so memory stays bounded by
+      // `limit` rather than the file size.
       const offset = Math.max(1, params.offset ?? 1);
       const limit = params.limit ?? MAX_LINES;
 
-      // Extract requested lines
-      const startIdx = offset - 1;
-      const endIdx = Math.min(startIdx + limit, lines.length);
-      const selectedLines = lines.slice(startIdx, endIdx);
+      const { lines: selectedLines, eof } = await readLinesStreaming(filePath, {
+        offset,
+        limit,
+        encoding,
+      });
 
-      // Add line numbers
+      const startIdx = offset - 1;
       const numberedLines = selectedLines.map((line, i) => `${startIdx + i + 1}: ${line}`);
 
       const output = numberedLines.join('\n');
       const { content: truncated, truncated: wasTruncated } = truncateOutput(output);
 
-      // Implicit whole-file read: caller did not specify offset or limit.
-      const isImplicitWholeFileRead = params.offset === undefined && params.limit === undefined;
-      const isPartialView = wasTruncated && isImplicitWholeFileRead;
-
-      // Compute the next offset for resumed reads. When the rendered output is
-      // truncated by line budget we may have shown fewer than `selectedLines.length`
-      // lines, but for both branches `endIdx + 1` is the next 1-indexed line that
-      // was not yet shown (capped by `Math.min` against `lines.length` above).
-      const nextOffset = endIdx + 1;
+      // Compute the next 1-indexed line that was not yet shown. If the stream
+      // reached EOF and we already got all the lines, there is no next page.
+      const nextOffset = startIdx + selectedLines.length + 1;
 
       let hint: string | undefined;
-      if (isPartialView) {
-        hint = `PARTIAL view — file has ${totalLines} lines, showing 1..${endIdx}. Call read again with offset=${nextOffset} to continue.`;
-      } else if (wasTruncated) {
+      if (wasTruncated) {
         hint = `Output truncated. Use offset=${nextOffset} to continue reading.`;
+      } else if (!eof) {
+        hint = `Continue reading with offset=${nextOffset}.`;
       }
 
       const fileResult: ToolResult<ReadResult> = {
@@ -244,10 +357,11 @@ Usage:
           type: 'file',
           path: filePath,
           content: truncated,
-          totalLines,
+          // Streamed reads do not know the file's total line count without a
+          // second pass; expose null and let callers rely on the hint.
+          totalLines: null,
           shownLines: selectedLines.length,
           offset,
-          ...(isPartialView ? { partial: true } : {}),
         },
         truncated: wasTruncated,
         hint,

--- a/tests/tool/tools/read.test.ts
+++ b/tests/tool/tools/read.test.ts
@@ -346,6 +346,159 @@ describe('Read Tool', () => {
     });
   });
 
+  describe('streaming for ranged reads', () => {
+    it(
+      'returns the requested tail of a 200000-line file without buffering it all',
+      { timeout: 60_000 },
+      async () => {
+        const testFile = path.join(tempDir, 'huge-streamed.txt');
+        // Build content in batches of 1000 lines to avoid 200k separate write
+        // syscalls (which dominates the test runtime) while still avoiding a
+        // single 200k-element JS array allocation.
+        const totalLines = 200_000;
+        const batchSize = 1000;
+        const handle = await fs.open(testFile, 'w');
+        try {
+          for (let start = 1; start <= totalLines; start += batchSize) {
+            const end = Math.min(start + batchSize - 1, totalLines);
+            const parts: string[] = [];
+            for (let i = start; i <= end; i++) {
+              parts.push(`line ${i}`);
+            }
+            let chunk = parts.join('\n');
+            if (end < totalLines) {
+              chunk += '\n';
+            }
+            await handle.write(chunk);
+          }
+        } finally {
+          await handle.close();
+        }
+
+        // Force a GC-ish baseline by allocating then releasing — best-effort
+        // smoke test, the assertion budget below is generous.
+        const before = process.memoryUsage().rss;
+
+        const result = await readTool.execute(
+          { filePath: testFile, offset: 199_950, limit: 50 },
+          context
+        );
+
+        const after = process.memoryUsage().rss;
+
+        expect(result.success).toBe(true);
+        if (result.data?.type === 'file') {
+          // First and last requested lines should be present, a line just
+          // outside the window should not.
+          expect(result.data.content).toContain('199950: line 199950');
+          expect(result.data.content).toContain('199999: line 199999');
+          expect(result.data.content).not.toContain('199949: line 199949');
+          expect(result.data.content).not.toContain(`${totalLines}: line ${totalLines}`);
+          expect(result.data.shownLines).toBe(50);
+          expect(result.data.offset).toBe(199_950);
+          // Streamed reads do not know the total — null sentinel.
+          expect(result.data.totalLines).toBeNull();
+        }
+
+        // RSS should not have grown by more than ~50 MB. The file on disk is
+        // ~2-3 MB so a non-streaming implementation would still be small here,
+        // but the budget protects against an obvious 10x regression.
+        const grownMB = (after - before) / (1024 * 1024);
+        expect(grownMB).toBeLessThan(50);
+      }
+    );
+
+    it('returns whatever was captured if EOF is reached before limit', async () => {
+      const testFile = path.join(tempDir, 'short-window.txt');
+      await fs.writeFile(testFile, 'a\nb\nc\nd\ne');
+
+      const result = await readTool.execute({ filePath: testFile, offset: 4, limit: 100 }, context);
+
+      expect(result.success).toBe(true);
+      if (result.data?.type === 'file') {
+        expect(result.data.shownLines).toBe(2);
+        expect(result.data.content).toContain('4: d');
+        expect(result.data.content).toContain('5: e');
+      }
+    });
+
+    it('preserves UTF-8 content (including multi-byte chars) on the streaming path', async () => {
+      const testFile = path.join(tempDir, 'utf8-streamed.txt');
+      const lines = ['ascii first', 'unicode: 日本語', 'emoji: 🚀✨', 'last'];
+      await fs.writeFile(testFile, lines.join('\n'), 'utf-8');
+
+      const result = await readTool.execute({ filePath: testFile, offset: 1, limit: 10 }, context);
+
+      expect(result.success).toBe(true);
+      if (result.data?.type === 'file') {
+        expect(result.data.content).toContain('1: ascii first');
+        expect(result.data.content).toContain('2: unicode: 日本語');
+        expect(result.data.content).toContain('3: emoji: 🚀✨');
+        expect(result.data.content).toContain('4: last');
+      }
+    });
+  });
+
+  describe('whole-file size guard', () => {
+    it(
+      'rejects implicit whole-file reads above MAX_FILE_SIZE_BYTES with a hint',
+      { timeout: 30_000 },
+      async () => {
+        const testFile = path.join(tempDir, 'too-big.txt');
+        // ~12 MB > 10 MB threshold, but built without holding 12 MB in JS at once.
+        const chunk = 'x'.repeat(1024 * 1024); // 1 MB
+        const handle = await fs.open(testFile, 'w');
+        try {
+          for (let i = 0; i < 12; i++) {
+            await handle.write(chunk + '\n');
+          }
+        } finally {
+          await handle.close();
+        }
+
+        const result = await readTool.execute({ filePath: testFile }, context);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('File too large');
+        expect(result.hint).toContain('offset');
+      }
+    );
+
+    it(
+      'still allows ranged reads on files above the whole-file threshold',
+      { timeout: 30_000 },
+      async () => {
+        const testFile = path.join(tempDir, 'big-but-windowed.txt');
+        const handle = await fs.open(testFile, 'w');
+        try {
+          // Many short lines surrounded by a few large lines so the file goes
+          // over the whole-file threshold but a small window does not.
+          const big = 'y'.repeat(1024 * 1024); // 1 MB
+          // 12 padding lines = 12 MB pushes the file past 10 MB.
+          for (let i = 0; i < 12; i++) {
+            await handle.write(big + '\n');
+          }
+          // Append an unmistakable marker at the tail.
+          await handle.write('TAIL_LINE_A\nTAIL_LINE_B');
+        } finally {
+          await handle.close();
+        }
+
+        const result = await readTool.execute(
+          { filePath: testFile, offset: 13, limit: 2 },
+          context
+        );
+
+        expect(result.success).toBe(true);
+        if (result.data?.type === 'file') {
+          expect(result.data.shownLines).toBe(2);
+          expect(result.data.content).toContain('13: TAIL_LINE_A');
+          expect(result.data.content).toContain('14: TAIL_LINE_B');
+        }
+      }
+    );
+  });
+
   describe('tool metadata', () => {
     it('should have correct name', () => {
       expect(readTool.name).toBe('read');


### PR DESCRIPTION
Closes #777

## What

Replaces the in-memory `fs.readFile` + `split('\n')` slicing in the `read` tool with a `readline`-based streaming implementation so ranged reads on large files no longer load the entire file into memory.

## Why

`src/tool/tools/read.ts` previously read the whole file into a Buffer then sliced lines. A 50 MB log read with `offset=49000, limit=50` allocated ~50 MB on the JS heap to return ~3 KB. On the 7 GB GitHub Actions runner heap this could OOM the orchestrator under realistic agent loads.

## How

- New `readLinesStreaming()` helper uses `readline.createInterface` over `createReadStream` to yield only the requested 1-based [offset, offset+limit-1] window.
- Encoding (BOM markers, UTF-8 fallback) is detected from a one-shot 64 KB probe at the head of the file (`fs.open` + `fileHandle.read`) instead of buffering the full contents.
- New `MAX_FILE_SIZE_BYTES` (10 MB) guard rejects implicit whole-file reads past the threshold and points callers at the ranged form. Ranged reads bypass the guard because they are bounded by `limit`.
- For streamed ranged reads, `totalLines` is `null` (no second pass), and continuation is signalled via the hint computed from `selectedLines.length + offset` (option **b** from the issue).
- Office-document branch (DOCX/XLSX/XLSM) is untouched.

## Tests

- 200 000-line tail read returns the requested window only, with `totalLines: null`.
- EOF before `limit` returns whatever was captured.
- UTF-8 multi-byte preservation on the streaming path.
- 12 MB whole-file read returns structured error + hint.
- Ranged read on a 12 MB file succeeds.
- All existing read-tool tests (encoding, partial view, office docs, line numbering, `truncateOutput` integration) still pass.

## Verification

- `npm run lint` — 0 errors.
- `npm run typecheck` — clean.
- `npm run format:check` — clean.
- `npm test` — 2581 passed / 2 skipped.
- `npm run build` — clean.

[alexi-bot]
