### PR TITLE
fix(core): preserve image/resource MCP error content parts (#790)

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -57,6 +57,42 @@ const CACHE_TTL_MS = 30000; // 30 seconds
 const DEFAULT_TOOL_CALL_TIMEOUT_MS = 60000; // 60 seconds
 const MAX_PAGES = 100; // Safety cap for paginated tools/list
 
+/**
+ * Format a single MCP content part into a string suitable for the model.
+ *
+ * - `text` parts pass through their text verbatim.
+ * - `image` parts render as `[image: <mime>, <bytes> bytes omitted]` so the
+ *   model knows an image was returned without flooding context with base64.
+ * - `resource` parts render as `[resource: <uri>]` so the model can reference
+ *   the file/URI that was returned.
+ * - Any other type falls back to `JSON.stringify(part)` to avoid silent loss.
+ */
+export function formatContentPart(part: unknown): string {
+  const p = part as {
+    type?: string;
+    text?: string;
+    mimeType?: string;
+    data?: string;
+    uri?: string;
+    resource?: { uri?: string };
+  };
+  switch (p.type) {
+    case 'text':
+      return typeof p.text === 'string' ? p.text : '';
+    case 'image': {
+      const mime = p.mimeType ?? 'unknown';
+      const bytes = typeof p.data === 'string' ? Math.floor((p.data.length * 3) / 4) : 0;
+      return `[image: ${mime}, ${bytes} bytes omitted]`;
+    }
+    case 'resource': {
+      const uri = p.resource?.uri ?? p.uri ?? 'unknown';
+      return `[resource: ${uri}]`;
+    }
+    default:
+      return JSON.stringify(part);
+  }
+}
+
 export class McpClientManager {
   private connections: Map<string, McpConnection> = new Map();
   private toolCache: Map<string, ToolCache> = new Map();
@@ -443,21 +479,19 @@ export class McpClientManager {
         return { success: true, result: text };
       }
 
-      // Extract text content from result
-      const content = (result.content || []) as Array<{ type: string; text?: string }>;
-      const textContent = content
-        .filter(
-          (c): c is { type: 'text'; text: string } =>
-            c.type === 'text' && typeof c.text === 'string'
-        )
-        .map((c) => c.text)
-        .join('\n');
+      // Extract content from result, preserving non-text parts as compact
+      // placeholders so the model can reason about structured failures
+      // (e.g. an MCP error that returns text + a `resource` link to the
+      // offending file). Spec-compliant MCP servers routinely return mixed
+      // content arrays; filtering them to text-only loses critical context.
+      const content = (result.content || []) as unknown[];
+      const flattened = content.map(formatContentPart).join('\n');
 
       if (result.isError) {
-        return { success: false, error: textContent || 'Unknown error' };
+        return { success: false, error: flattened || 'Unknown error' };
       }
 
-      return { success: true, result: textContent };
+      return { success: true, result: flattened };
     } catch (error) {
       clearTimeout(timer);
       if (error instanceof Error && error.name === 'AbortError') {

--- a/tests/mcp/error-content.test.ts
+++ b/tests/mcp/error-content.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock child_process.spawn
+const mockSpawn = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Mock @modelcontextprotocol/sdk
+const mockClientConnect = vi.fn().mockResolvedValue(undefined);
+const mockClientListTools = vi.fn().mockResolvedValue({ tools: [] });
+const mockClientCallTool = vi.fn();
+const mockClientClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  return {
+    Client: class MockClient {
+      connect = mockClientConnect;
+      listTools = mockClientListTools;
+      callTool = mockClientCallTool;
+      close = mockClientClose;
+    },
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+// Mock config loading
+vi.mock('../../src/mcp/config.js', () => ({
+  loadMcpConfig: vi.fn().mockReturnValue({ version: '1.0', servers: [] }),
+  resolveEnvVars: vi.fn((env?: Record<string, string>) => env ?? {}),
+}));
+
+import { McpClientManager, formatContentPart } from '../../src/mcp/client.js';
+import type { McpServerConfig } from '../../src/mcp/config.js';
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdin = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.pid = 12345;
+  return proc;
+}
+
+describe('McpClientManager.callTool — error content preservation', () => {
+  let manager: McpClientManager;
+
+  const stdioConfig: McpServerConfig = {
+    name: 'test-server',
+    transport: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+    enabled: true,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    manager = new McpClientManager();
+    mockSpawn.mockReturnValue(createMockProcess());
+    await manager.connect(stdioConfig);
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAll();
+    vi.restoreAllMocks();
+  });
+
+  it('preserves text + resource parts in error message', async () => {
+    mockClientCallTool.mockResolvedValue({
+      isError: true,
+      content: [
+        { type: 'text', text: 'failed' },
+        { type: 'resource', resource: { uri: 'file:///a' } },
+      ],
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('failed\n[resource: file:///a]');
+  });
+
+  it('renders image parts as compact placeholders in error message', async () => {
+    mockClientCallTool.mockResolvedValue({
+      isError: true,
+      content: [{ type: 'image', mimeType: 'image/png', data: 'AAAA' }],
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^\[image: image\/png, \d+ bytes omitted\]$/);
+  });
+
+  it('falls back to "Unknown error" when isError is true and content is empty', async () => {
+    mockClientCallTool.mockResolvedValue({
+      isError: true,
+      content: [],
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Unknown error');
+  });
+
+  it('preserves mixed content on success path', async () => {
+    mockClientCallTool.mockResolvedValue({
+      content: [
+        { type: 'text', text: 'rendered output' },
+        { type: 'image', mimeType: 'image/jpeg', data: 'AAAAAAAA' },
+      ],
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(true);
+    expect(typeof result.result).toBe('string');
+    const text = result.result as string;
+    expect(text).toContain('rendered output');
+    expect(text).toContain('[image: image/jpeg,');
+  });
+
+  it('preserves resource parts on success path', async () => {
+    mockClientCallTool.mockResolvedValue({
+      content: [
+        { type: 'text', text: 'see file' },
+        { type: 'resource', resource: { uri: 'file:///path/to/file.ts' } },
+      ],
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe('see file\n[resource: file:///path/to/file.ts]');
+  });
+
+  it('still prefers structuredContent over content when both are present in error', async () => {
+    mockClientCallTool.mockResolvedValue({
+      isError: true,
+      structuredContent: { code: 'ENOENT' },
+      content: [{ type: 'resource', resource: { uri: 'file:///missing' } }],
+    });
+
+    const result = await manager.callTool('test-server', 'some-tool', {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('{"code":"ENOENT"}');
+  });
+});
+
+describe('formatContentPart helper', () => {
+  it('returns text verbatim for text parts', () => {
+    expect(formatContentPart({ type: 'text', text: 'hello' })).toBe('hello');
+  });
+
+  it('returns empty string when text part has no text', () => {
+    expect(formatContentPart({ type: 'text' })).toBe('');
+  });
+
+  it('formats image parts with mime + estimated byte count', () => {
+    // Base64 'AAAA' (4 chars) -> 3 bytes
+    expect(formatContentPart({ type: 'image', mimeType: 'image/png', data: 'AAAA' })).toBe(
+      '[image: image/png, 3 bytes omitted]'
+    );
+  });
+
+  it('formats image parts with default mime when missing', () => {
+    expect(formatContentPart({ type: 'image' })).toBe('[image: unknown, 0 bytes omitted]');
+  });
+
+  it('formats resource parts using nested resource.uri', () => {
+    expect(formatContentPart({ type: 'resource', resource: { uri: 'file:///a' } })).toBe(
+      '[resource: file:///a]'
+    );
+  });
+
+  it('formats resource parts using top-level uri as fallback', () => {
+    expect(formatContentPart({ type: 'resource', uri: 'file:///b' })).toBe('[resource: file:///b]');
+  });
+
+  it('JSON-stringifies unknown content types', () => {
+    expect(formatContentPart({ type: 'audio', data: 'xyz' })).toBe('{"type":"audio","data":"xyz"}');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #790. `MCPClient.callTool` previously filtered `result.content` to
`type === 'text'` items only, silently dropping every `image` and
`resource` part on both success and error paths. Spec-compliant MCP
servers (filesystem, ast-grep, several Codex-pattern servers) routinely
return `isError: true` with mixed content (an error string PLUS a
`resource` link to the offending file) — the model would see only
`'Unknown error'` for what was actually a structured failure.

## Changes

- `src/mcp/client.ts`: extracted a `formatContentPart` helper that
  renders each MCP content part by `type`:
  - `text` → text verbatim
  - `image` → `[image: <mime>, <bytes> bytes omitted]`
  - `resource` → `[resource: <uri>]` (nested `resource.uri` or top-level `uri`)
  - other → `JSON.stringify(part)`
- `callTool` now uses this helper for the `content` flattening on both
  the success and error branches. `structuredContent` fast path is
  unchanged.
- New tests in `tests/mcp/error-content.test.ts` covering:
  - text + resource mix in `isError` → both parts preserved
  - image part in `isError` → compact placeholder
  - empty content + `isError` → `'Unknown error'` fallback
  - mixed content on success → both text and placeholder preserved
  - resource part on success
  - `structuredContent` still wins over `content`
  - direct unit tests for the `formatContentPart` helper

## Source

sst/opencode#32244 (commit `dfb616f0`, 2026-06-15). Tracked in
`.github/research/2026-06-15-research.md` Item #3.

## Verification

```
npm run lint           # 0 errors
npm run typecheck      # clean
npm run format:check   # clean
npm test               # 2622 passed, 2 skipped
npm run build          # success
```

Closes #790

[alexi-bot]