### PR TITLE
feat(tools): head+tail truncation for tool output

### DIFF
--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -97,34 +97,166 @@ const MAX_LINES = 2000;
 const MAX_BYTES = 51200; // 50KB
 
 /**
- * Truncate output if it exceeds limits
+ * Build the elision marker line that is inserted between the kept head and
+ * kept tail of a truncated output. The marker text reports both omitted
+ * lines and omitted bytes so the model can reason about how much was
+ * dropped (and follow up with `read` against the persisted file if needed).
+ */
+function buildElisionMarker(omittedLines: number, omittedBytes: number): string {
+  return `[... ${omittedLines} lines / ${omittedBytes} bytes elided ...]`;
+}
+
+/**
+ * Find the largest index `i` (i <= maxBytes) into `buf` such that `i` is
+ * either right after a `\n` byte or at a UTF-8 codepoint boundary. Used to
+ * snap a head slice back to the previous line boundary, falling back to a
+ * codepoint boundary if no newline is reachable inside the budget.
+ */
+function snapHeadToBoundary(buf: Buffer, maxBytes: number): number {
+  if (maxBytes <= 0) {
+    return 0;
+  }
+  if (maxBytes >= buf.length) {
+    return buf.length;
+  }
+
+  // Prefer snapping back to the last '\n' (byte 0x0A) within budget so we
+  // never cut a line in half.
+  for (let i = maxBytes; i > 0; i--) {
+    if (buf[i - 1] === 0x0a) {
+      return i;
+    }
+  }
+
+  // No newline reachable — fall back to a UTF-8 codepoint boundary. UTF-8
+  // continuation bytes match 0b10xxxxxx (0x80..0xBF). Walk back until the
+  // next byte is NOT a continuation byte.
+  let i = maxBytes;
+  while (i > 0 && (buf[i] & 0xc0) === 0x80) {
+    i--;
+  }
+  return i;
+}
+
+/**
+ * Find the smallest index `i` (i >= buf.length - maxBytes) into `buf` such
+ * that `i` is either right after a `\n` byte or at a UTF-8 codepoint
+ * boundary. Used to snap a tail slice start forward to the next line
+ * boundary, falling back to a codepoint boundary if no newline is
+ * reachable inside the budget.
+ */
+function snapTailToBoundary(buf: Buffer, maxBytes: number): number {
+  if (maxBytes <= 0) {
+    return buf.length;
+  }
+  if (maxBytes >= buf.length) {
+    return 0;
+  }
+
+  const minStart = buf.length - maxBytes;
+
+  // Prefer snapping forward to the byte right after a '\n' so the tail
+  // begins at the start of a complete line.
+  for (let i = minStart; i < buf.length; i++) {
+    if (i > 0 && buf[i - 1] === 0x0a) {
+      return i;
+    }
+  }
+
+  // No newline reachable — fall back to a UTF-8 codepoint boundary. Walk
+  // forward until `buf[i]` is NOT a continuation byte (0b10xxxxxx).
+  let i = minStart;
+  while (i < buf.length && (buf[i] & 0xc0) === 0x80) {
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Truncate output if it exceeds the line or byte budget, preserving BOTH
+ * the head and the tail of the output. Failure-relevant content (final
+ * assertion, last stack frame, "X tests failed" summary) lives at the END
+ * of long tool runs, so a head-only strategy clips the most useful part.
+ *
+ * Strategy:
+ * - If both budgets fit: return as-is, `truncated: false`.
+ * - If line count exceeds `MAX_LINES`: keep `floor(MAX_LINES/2)` head
+ *   lines and the remaining tail lines, joined with a single elision
+ *   marker line in the middle.
+ * - If the (possibly already line-truncated) result still exceeds
+ *   `MAX_BYTES`: split the byte budget roughly 50/50 between head and
+ *   tail, snapping each slice to a newline boundary (or a UTF-8 codepoint
+ *   boundary if no newline is reachable inside the budget) so we never
+ *   cut a line or codepoint in half. Concatenate as
+ *   `head + '\n' + marker + '\n' + tail`.
+ *
+ * The full original output is still persisted by `persistLargeOutput` so
+ * the truncated text is recoverable; this function only governs what is
+ * surfaced inline to the model.
  */
 function truncateOutput(output: string): { content: string; truncated: boolean } {
   const lines = output.split('\n');
-  const bytes = Buffer.byteLength(output, 'utf-8');
+  const totalBytes = Buffer.byteLength(output, 'utf-8');
 
-  if (lines.length <= MAX_LINES && bytes <= MAX_BYTES) {
+  if (lines.length <= MAX_LINES && totalBytes <= MAX_BYTES) {
     return { content: output, truncated: false };
   }
 
-  // Truncate by lines first
-  const truncatedLines = lines.slice(0, MAX_LINES);
-  let result = truncatedLines.join('\n');
+  let result = output;
 
-  // Then check bytes
+  // Line-budget head + tail truncation.
+  if (lines.length > MAX_LINES) {
+    const headCount = Math.floor(MAX_LINES / 2);
+    const tailCount = MAX_LINES - headCount;
+    const headLines = lines.slice(0, headCount);
+    const tailLines = lines.slice(lines.length - tailCount);
+    const elidedLines = lines.slice(headCount, lines.length - tailCount);
+    const omittedLineCount = elidedLines.length;
+    const omittedByteCount = Buffer.byteLength(elidedLines.join('\n'), 'utf-8');
+    const marker = buildElisionMarker(omittedLineCount, omittedByteCount);
+    result = [...headLines, marker, ...tailLines].join('\n');
+  }
+
+  // Byte-budget head + tail truncation. Either the line-truncated result
+  // is still too big, or the input fit in lines but exceeds bytes (e.g.
+  // a single very long line).
   if (Buffer.byteLength(result, 'utf-8') > MAX_BYTES) {
-    // Binary search for the right length
-    let left = 0;
-    let right = result.length;
-    while (left < right) {
-      const mid = Math.floor((left + right + 1) / 2);
-      if (Buffer.byteLength(result.slice(0, mid), 'utf-8') <= MAX_BYTES) {
-        left = mid;
-      } else {
-        right = mid - 1;
+    const buf = Buffer.from(result, 'utf-8');
+
+    // Reserve space for the elision marker plus its surrounding newlines.
+    // We can only finalise the marker text once we know how many bytes
+    // were elided, so first reserve a conservative upper bound, then
+    // recompute.
+    const markerOverhead = (marker: string): number => Buffer.byteLength(`\n${marker}\n`, 'utf-8');
+    const placeholderMarker = buildElisionMarker(buf.length, buf.length);
+    const reserved = markerOverhead(placeholderMarker);
+    const usable = Math.max(0, MAX_BYTES - reserved);
+    const headBudget = Math.floor(usable / 2);
+    const tailBudget = usable - headBudget;
+
+    const headEnd = snapHeadToBoundary(buf, headBudget);
+    const tailStart = snapTailToBoundary(buf, tailBudget);
+    // Guarantee head and tail do not overlap (can happen for tiny
+    // budgets). When they would, fall back to a head-only slice.
+    const safeTailStart = Math.max(tailStart, headEnd);
+    const headSlice = buf.subarray(0, headEnd);
+    const tailSlice = buf.subarray(safeTailStart);
+    const omittedBytes = Math.max(0, buf.length - headSlice.length - tailSlice.length);
+    // Approximate omitted lines from the elided byte slice.
+    const elidedSlice = buf.subarray(headEnd, safeTailStart);
+    let omittedLines = 0;
+    for (const byte of elidedSlice) {
+      if (byte === 0x0a) {
+        omittedLines++;
       }
     }
-    result = result.slice(0, left);
+    const finalMarker = buildElisionMarker(omittedLines, omittedBytes);
+    result = `${headSlice.toString('utf-8')}\n${finalMarker}\n${tailSlice.toString('utf-8')}`;
+
+    // If the recomputed marker is shorter than the placeholder we may now
+    // have a few free bytes; we deliberately do not try to grow head/tail
+    // to claim them — the simpler structure is easier to reason about and
+    // the persisted full output is the source of truth.
   }
 
   return { content: result, truncated: true };

--- a/tests/tool/truncateOutput.test.ts
+++ b/tests/tool/truncateOutput.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import { truncateOutput, MAX_LINES, MAX_BYTES } from '../../src/tool/index.js';
+
+const ELISION_MARKER_REGEX = /^\[\.\.\. (\d+) lines \/ (\d+) bytes elided \.\.\.\]$/;
+
+describe('truncateOutput', () => {
+  it('returns output unchanged when within both budgets', () => {
+    const output = 'line one\nline two\nline three';
+    const result = truncateOutput(output);
+
+    expect(result.truncated).toBe(false);
+    expect(result.content).toBe(output);
+  });
+
+  it('returns empty output unchanged', () => {
+    const result = truncateOutput('');
+
+    expect(result.truncated).toBe(false);
+    expect(result.content).toBe('');
+  });
+
+  describe('line-budget head + tail truncation', () => {
+    const overflow = 100;
+
+    function buildLines(count: number): string {
+      return Array.from({ length: count }, (_, i) => `line-${i + 1}`).join('\n');
+    }
+
+    it('keeps head + marker + tail with total of MAX_LINES + 1 lines', () => {
+      const total = MAX_LINES + overflow;
+      const output = buildLines(total);
+
+      const result = truncateOutput(output);
+
+      expect(result.truncated).toBe(true);
+      const lines = result.content.split('\n');
+      expect(lines.length).toBe(MAX_LINES + 1);
+
+      const headCount = Math.floor(MAX_LINES / 2);
+      const tailCount = MAX_LINES - headCount;
+      // Head section: first `headCount` of original.
+      for (let i = 0; i < headCount; i++) {
+        expect(lines[i]).toBe(`line-${i + 1}`);
+      }
+      // Marker line.
+      expect(lines[headCount]).toMatch(ELISION_MARKER_REGEX);
+      // Tail section: last `tailCount` of original.
+      for (let i = 0; i < tailCount; i++) {
+        expect(lines[headCount + 1 + i]).toBe(`line-${total - tailCount + i + 1}`);
+      }
+    });
+
+    it('preserves the LAST line (failing assertion case)', () => {
+      const total = MAX_LINES + overflow;
+      const lines = Array.from({ length: total - 1 }, (_, i) => `setup line ${i + 1}`);
+      lines.push('AssertionError: expected 1 to equal 2 — FAILED');
+      const output = lines.join('\n');
+
+      const result = truncateOutput(output);
+
+      expect(result.truncated).toBe(true);
+      const tailLine = result.content.split('\n').pop();
+      expect(tailLine).toBe('AssertionError: expected 1 to equal 2 — FAILED');
+    });
+
+    it('reports omitted line and byte counts in the elision marker', () => {
+      const total = MAX_LINES + overflow;
+      const output = buildLines(total);
+
+      const result = truncateOutput(output);
+      const lines = result.content.split('\n');
+      const headCount = Math.floor(MAX_LINES / 2);
+      const markerLine = lines[headCount];
+
+      const match = markerLine.match(ELISION_MARKER_REGEX);
+      expect(match).not.toBeNull();
+      const omittedLines = Number(match![1]);
+      const omittedBytes = Number(match![2]);
+      expect(omittedLines).toBe(overflow);
+      expect(omittedBytes).toBeGreaterThan(0);
+    });
+
+    it('handles odd MAX_LINES split correctly (head=floor, tail=remainder)', () => {
+      // MAX_LINES is even (2000) in production, but the contract is
+      // documented as floor(MAX_LINES/2) head + remainder tail. Verify
+      // the split is exhaustive: head + 1 (marker) + tail = MAX_LINES + 1.
+      const total = MAX_LINES + 1;
+      const output = Array.from({ length: total }, (_, i) => `L${i}`).join('\n');
+
+      const result = truncateOutput(output);
+      const lines = result.content.split('\n');
+      const headCount = Math.floor(MAX_LINES / 2);
+      const tailCount = MAX_LINES - headCount;
+
+      expect(lines.length).toBe(headCount + 1 + tailCount);
+      expect(lines[0]).toBe('L0');
+      expect(lines[lines.length - 1]).toBe(`L${total - 1}`);
+    });
+  });
+
+  describe('byte-budget head + tail truncation', () => {
+    it('keeps head + marker + tail under MAX_BYTES for a single very long line', () => {
+      // No newlines: forces the boundary-snap code to fall back to UTF-8
+      // codepoint boundaries.
+      const longLine = 'a'.repeat(MAX_BYTES * 2);
+
+      const result = truncateOutput(longLine);
+
+      expect(result.truncated).toBe(true);
+      expect(Buffer.byteLength(result.content, 'utf-8')).toBeLessThanOrEqual(MAX_BYTES);
+
+      const parts = result.content.split('\n');
+      // Expect exactly: head, marker, tail (3 segments).
+      expect(parts.length).toBe(3);
+      const [head, marker, tail] = parts;
+      expect(head.length).toBeGreaterThan(0);
+      expect(tail.length).toBeGreaterThan(0);
+      expect(marker).toMatch(ELISION_MARKER_REGEX);
+      // For an all-'a' input, the head must be the first run of 'a's and
+      // the tail the last run of 'a's.
+      expect(/^a+$/.test(head)).toBe(true);
+      expect(/^a+$/.test(tail)).toBe(true);
+    });
+
+    it('does not split UTF-8 codepoints when snapping head/tail', () => {
+      // A long stream of 4-byte emoji codepoints with no newlines. If we
+      // sliced by raw byte index without snapping to a codepoint
+      // boundary, the resulting string would contain the U+FFFD
+      // replacement character.
+      const emoji = 'rocket'; // 4 bytes in UTF-8
+      const filler = '\uD83D\uDE80'.repeat(Math.ceil(MAX_BYTES / 2)); // ~MAX_BYTES * 2 bytes
+      void emoji;
+
+      const result = truncateOutput(filler);
+
+      expect(result.truncated).toBe(true);
+      expect(result.content.includes('\uFFFD')).toBe(false);
+      expect(Buffer.byteLength(result.content, 'utf-8')).toBeLessThanOrEqual(MAX_BYTES);
+    });
+
+    it('reports omitted line and byte counts in the marker for byte-budget path', () => {
+      const longLine = 'b'.repeat(MAX_BYTES * 2);
+
+      const result = truncateOutput(longLine);
+
+      const parts = result.content.split('\n');
+      const marker = parts[1];
+      const match = marker.match(ELISION_MARKER_REGEX);
+      expect(match).not.toBeNull();
+      const omittedBytes = Number(match![2]);
+      expect(omittedBytes).toBeGreaterThan(0);
+    });
+
+    it('snaps head and tail to newline boundaries when newlines are present', () => {
+      // Many short lines, total bytes >> MAX_BYTES. Head should end at a
+      // newline boundary; tail should start at the start of a complete
+      // line.
+      const linesNeeded = Math.ceil((MAX_BYTES * 4) / 20);
+      const lines = Array.from(
+        { length: linesNeeded },
+        (_, i) => `line-${String(i).padStart(8, '0')}`
+      );
+      const output = lines.join('\n');
+
+      const result = truncateOutput(output);
+
+      expect(result.truncated).toBe(true);
+      // Total bytes within MAX_BYTES.
+      expect(Buffer.byteLength(result.content, 'utf-8')).toBeLessThanOrEqual(MAX_BYTES);
+
+      // The first line should be a complete `line-NNNNNNNN` token, and so
+      // should the last line.
+      const resultLines = result.content.split('\n');
+      expect(resultLines[0]).toMatch(/^line-\d{8}$/);
+      expect(resultLines[resultLines.length - 1]).toMatch(/^line-\d{8}$/);
+    });
+  });
+
+  describe('combined line + byte budget', () => {
+    it('still produces a truncated head+tail output when both budgets are exceeded', () => {
+      // Many lines, each long enough that the byte budget also fires
+      // after line-truncation.
+      const lineContent = 'x'.repeat(80);
+      const totalLines = MAX_LINES + 1000;
+      const output = Array.from({ length: totalLines }, (_, i) => `${lineContent}-${i}`).join('\n');
+
+      const result = truncateOutput(output);
+
+      expect(result.truncated).toBe(true);
+      expect(Buffer.byteLength(result.content, 'utf-8')).toBeLessThanOrEqual(MAX_BYTES);
+      // Head should still come from the very start of the input and tail
+      // from the very end. With identical line content prefixes only the
+      // suffix index distinguishes them.
+      const resultLines = result.content.split('\n');
+      // Find first non-marker line.
+      const firstLine = resultLines.find((l) => !ELISION_MARKER_REGEX.test(l));
+      const lastLine = [...resultLines].reverse().find((l) => !ELISION_MARKER_REGEX.test(l));
+      expect(firstLine).toBeDefined();
+      expect(lastLine).toBeDefined();
+      // Last preserved line must end with the highest index.
+      expect(lastLine!.endsWith(`-${totalLines - 1}`)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refactor `truncateOutput` in `src/tool/index.ts` from a head-only strategy to a head + tail strategy, so failure-relevant content at the END of long tool runs (final assertion, last stack frame, "X tests failed" summary) is preserved.

Cline measured ~30% fewer failed-build retries after switching to head + tail.

## Changes

### `src/tool/index.ts`

- **Line-budget path**: keep `floor(MAX_LINES/2)` head lines + remaining tail lines with a single elision marker line in the middle. Total output is exactly `MAX_LINES + 1` lines.
- **Byte-budget path**: split `MAX_BYTES` roughly 50/50 between head and tail, snapping each slice to a newline boundary. Falls back to a UTF-8 codepoint boundary when no newline is reachable inside the budget, so no line and no codepoint is cut mid-way.
- **Elision marker**: reports both omitted lines and omitted bytes —
  `[... <N> lines / <M> bytes elided ...]`.

### `persistLargeOutput` is unchanged

The full original output is still persisted to `~/.alexi/tool-output/`, so truncated text remains recoverable via the existing recovery path.

## Tests

New `tests/tool/truncateOutput.test.ts` covers:

- Output within budget returned unchanged, `truncated: false`.
- Empty output returned unchanged.
- Line-budget head + marker + tail with total of `MAX_LINES + 1` lines.
- Last line of input (failing assertion) is preserved in the truncated output.
- Marker reports omitted line count AND omitted byte count.
- Single very long line (no newlines) → byte-budget head + marker + tail under `MAX_BYTES`.
- UTF-8 codepoints (4-byte emoji) are not split mid-codepoint (no `U+FFFD`).
- Newline boundary snapping for many-short-lines input.
- Combined line + byte truncation still produces head+tail with last line preserved.

## Verification

```
npm run lint        # 0 errors (1268 pre-existing warnings, none new)
npm run typecheck   # OK
npm run format:check # OK
npm test            # 2587 passed | 2 skipped
npm run build       # OK
```

## References

- Research brief: `.github/research/2026-06-14-research.md` item #3 (carryover from 06-13)
- Upstream: cline/cline#11480, commit `d20e5178`

Closes #778