### PR TITLE
fix(core): default empty properties on object MCP tool schemas

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -120,6 +120,14 @@ export class McpClientManager {
 
   /**
    * Map a raw MCP tool to McpToolInfo, tolerating malformed schemas.
+   *
+   * Also normalizes object schemas that omit `properties` to an empty object,
+   * because OpenAI-shaped function-tool registration (used by SAP AI Core
+   * deployments) rejects the entire `tools` payload when an object schema
+   * lacks `properties`. Spec-compliant MCP servers (e.g. the official
+   * `@modelcontextprotocol/server-time`) emit `{ type: 'object' }` with no
+   * `properties` for zero-arg tools; without this fix the whole server
+   * silently disables for that session. See opencode `25cb2be6`.
    */
   private mapToolInfo(
     tool: { name: string; description?: string; inputSchema: unknown },
@@ -139,6 +147,17 @@ export class McpClientManager {
         type: 'object',
         properties: {},
       };
+    }
+
+    // Default `properties` to `{}` when the schema declares an object type but
+    // omits it. We deliberately do NOT rewrite schemas that already have
+    // `properties` set (even to a truthy non-object value) — those are the
+    // user's responsibility.
+    const schemaType = (inputSchema as { type?: unknown }).type;
+    const isObjectType =
+      schemaType === 'object' || (Array.isArray(schemaType) && schemaType.includes('object'));
+    if (isObjectType && (inputSchema as { properties?: unknown }).properties === undefined) {
+      inputSchema = { ...inputSchema, properties: {} };
     }
 
     return {

--- a/tests/mcp/client.test.ts
+++ b/tests/mcp/client.test.ts
@@ -59,6 +59,15 @@ describe('McpClientManager', () => {
     vi.clearAllMocks();
     manager = new McpClientManager();
     mockSpawn.mockReturnValue(createMockProcess());
+    // `vi.restoreAllMocks` in afterEach wipes the StdioClientTransport
+    // implementation, so reinstate it before each test. Use a regular
+    // function so it can be invoked with `new`.
+    vi.mocked(StdioClientTransport).mockImplementation(function () {
+      return {} as unknown as InstanceType<typeof StdioClientTransport>;
+    });
+    mockClientConnect.mockResolvedValue(undefined);
+    mockClientListTools.mockResolvedValue({ tools: [] });
+    mockClientClose.mockResolvedValue(undefined);
   });
 
   afterEach(async () => {
@@ -228,6 +237,106 @@ describe('McpClientManager', () => {
           }),
         })
       );
+    });
+  });
+
+  describe('inputSchema normalization', () => {
+    it('should default missing properties to {} when schema type is "object"', async () => {
+      mockClientListTools.mockResolvedValueOnce({
+        tools: [
+          {
+            name: 'get_current_time',
+            description: 'Returns the current time',
+            inputSchema: { type: 'object' },
+          },
+        ],
+      });
+
+      const connection = await manager.connect(stdioConfig);
+
+      expect(connection.status).toBe('connected');
+      expect(connection.tools).toHaveLength(1);
+      expect(connection.tools[0].inputSchema).toEqual({
+        type: 'object',
+        properties: {},
+      });
+    });
+
+    it('should default missing properties to {} when schema type array includes "object"', async () => {
+      mockClientListTools.mockResolvedValueOnce({
+        tools: [
+          {
+            name: 'maybe_object',
+            inputSchema: { type: ['object', 'null'] },
+          },
+        ],
+      });
+
+      const connection = await manager.connect(stdioConfig);
+
+      expect(connection.tools[0].inputSchema).toEqual({
+        type: ['object', 'null'],
+        properties: {},
+      });
+    });
+
+    it('should preserve existing properties when already set', async () => {
+      mockClientListTools.mockResolvedValueOnce({
+        tools: [
+          {
+            name: 'has_props',
+            inputSchema: {
+              type: 'object',
+              properties: { foo: { type: 'string' } },
+              required: ['foo'],
+            },
+          },
+        ],
+      });
+
+      const connection = await manager.connect(stdioConfig);
+
+      expect(connection.tools[0].inputSchema).toEqual({
+        type: 'object',
+        properties: { foo: { type: 'string' } },
+        required: ['foo'],
+      });
+    });
+
+    it('should leave non-object schemas alone (no properties injected)', async () => {
+      mockClientListTools.mockResolvedValueOnce({
+        tools: [
+          {
+            name: 'string_tool',
+            inputSchema: { type: 'string' },
+          },
+        ],
+      });
+
+      const connection = await manager.connect(stdioConfig);
+
+      expect(connection.tools[0].inputSchema).toEqual({ type: 'string' });
+      expect(
+        (connection.tools[0].inputSchema as { properties?: unknown }).properties
+      ).toBeUndefined();
+    });
+
+    it('should fall back to permissive default for malformed (non-object) schemas', async () => {
+      mockClientListTools.mockResolvedValueOnce({
+        tools: [
+          {
+            name: 'broken',
+            inputSchema: null as unknown,
+          },
+        ],
+      });
+
+      const connection = await manager.connect(stdioConfig);
+
+      expect(connection.tools[0].inputSchema).toEqual({
+        type: 'object',
+        properties: {},
+      });
     });
   });
 });


### PR DESCRIPTION
## What

Normalizes MCP tool `inputSchema` so any schema declaring `type: 'object'` (or an array containing `'object'`) but omitting `properties` is rewritten to include `properties: {}`. Single conditional in `mapToolInfo` at `src/mcp/client.ts`, plus regression tests.

## Why

Spec-compliant MCP servers (e.g. `@modelcontextprotocol/server-time`, several `mcp-toolbox` zero-arg tools) emit `inputSchema: { type: 'object' }` with no `properties` for tools that take no arguments. OpenAI-shaped function-tool registration (used by SAP AI Core deployments) requires `properties` to be present (even empty) when `type === 'object'` and rejects the whole `tools` payload otherwise — silently disabling the entire MCP server for that session.

opencode shipped the same one-line normalization in sst/opencode#32568 (`25cb2be6`).

## How

- `src/mcp/client.ts` `mapToolInfo`: after the existing permissive fallback for non-object schemas, default `properties` to `{}` when the schema's `type` is `'object'` (or an array including `'object'`) and `properties` is `undefined`. Schemas that already set `properties` (even to a truthy non-object value) are left alone.
- `src/mcp/server.ts` already serves tools with `properties: ... || {}` at line 73, so no change needed there.
- `tests/mcp/client.test.ts`: 5 regression cases covering object `type`, array `type` including `object`, preserving existing `properties`, leaving non-object schemas alone, and the malformed-schema permissive fallback.

## Verification

- `npm run lint` (0 errors)
- `npm run typecheck`
- `npm run format:check`
- `npm run test:coverage` (188 files, 2646 passed)
- `npm run build`

Closes #803