### PR TITLE
feat(providers): Codex-style sanitizeOpenAISchema for MCP tool schemas

### DIFF
--- a/src/providers/transform.ts
+++ b/src/providers/transform.ts
@@ -56,3 +56,279 @@ export function ensureDeepSeekReasoning(messages: Message[], model: string): Mes
     return msg;
   });
 }
+
+// ============================================================================
+// OpenAI / Codex JSON Schema lowering for MCP tool inputSchemas
+// ============================================================================
+//
+// SAP AI Core OpenAI deployments (gpt-*, o1-*, o3-*, and any provider whose
+// underlying ai-sdk wrapper is `@ai-sdk/openai`) reject MCP tool input
+// schemas that use JSON Schema 2020-12 features OpenAI's function-tool
+// registration does not understand (`prefixItems`, boolean schemas,
+// `if`/`then`/`else`, `unevaluatedProperties`, etc.). The tool registers
+// successfully but every call rejects with `Invalid schema for function`.
+//
+// `sanitizeOpenAISchema` mirrors the lowering pass Codex / opencode ship
+// (opencode #32489, port of Codex's Rust schema compatibility layer).
+// It drops unsupported keywords, rewrites `const` -> `enum`, infers a
+// missing `type` from neighbouring keywords, and keeps `$ref` / `description`
+// verbatim so downstream registration only ever sees the OpenAI-supported
+// JSON Schema subset.
+//
+// Important: `sanitizeOpenAISchema` does NOT mutate its input. It always
+// produces a new object so the cached `McpToolInfo.inputSchema` is safe to
+// reuse for non-OpenAI deployments in the same process.
+
+type JsonRecord = Record<string, unknown>;
+
+const OPENAI_SCHEMA_TYPES = [
+  'string',
+  'number',
+  'boolean',
+  'integer',
+  'object',
+  'array',
+  'null',
+] as const;
+
+const OPENAI_COMPOSITION_KEYS = ['anyOf', 'oneOf', 'allOf'] as const;
+
+function isPlainObject(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Lower a JSON Schema fragment to the subset OpenAI's function-tool
+ * registration accepts. Mirrors the Codex / opencode lowering verbatim.
+ *
+ * Rules (in order):
+ *  - Boolean schemas (`true`/`false`) -> `{ type: 'string' }` (matches
+ *    opencode's choice; OpenAI rejects boolean schemas outright).
+ *  - Arrays are mapped element-wise (covers `prefixItems`-style tuple
+ *    `items: [...]`).
+ *  - Non-objects pass through.
+ *  - `$ref` and `description` preserved verbatim.
+ *  - `const: X` folded into `enum: [X]`.
+ *  - `properties` recursed with key order preserved.
+ *  - `required` filtered to string entries only.
+ *  - `items` recursed (handles both single-schema and tuple forms).
+ *  - `additionalProperties` recursed when it is a schema; booleans pass
+ *    through untouched.
+ *  - `anyOf` / `oneOf` / `allOf` each recursed element-wise.
+ *  - `$defs` and `definitions` recursed value-wise.
+ *  - `type` filtered against the OpenAI-accepted set.
+ *  - Type inferred from neighbouring keywords when absent
+ *    (`properties`/`required`/`additionalProperties` -> object;
+ *    `items`/`prefixItems` -> array; `format`/`enum` -> string;
+ *    numeric range keywords -> number).
+ *  - Object schemas without `properties` get `properties: {}` and array
+ *    schemas without `items` get `items: { type: 'string' }` so the
+ *    registration call site never sees a half-formed schema.
+ *
+ * @param value - The schema fragment to lower
+ * @returns A new schema value that uses only OpenAI-supported keywords
+ */
+export function sanitizeOpenAISchema(value: unknown): unknown {
+  // JSON Schema's boolean form (`true`/`false`) is unsupported by OpenAI
+  // tool schemas; opencode rewrites both to `{ type: 'string' }`.
+  if (typeof value === 'boolean') {
+    return { type: 'string' };
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeOpenAISchema);
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const result: JsonRecord = {};
+
+  if (typeof value.$ref === 'string') {
+    result.$ref = value.$ref;
+  }
+  if (typeof value.description === 'string') {
+    result.description = value.description;
+  }
+  if ('const' in value) {
+    result.enum = [value.const];
+  } else if (Array.isArray(value.enum)) {
+    result.enum = value.enum;
+  }
+
+  if (isPlainObject(value.properties)) {
+    result.properties = Object.fromEntries(
+      Object.entries(value.properties).map(([key, item]) => [key, sanitizeOpenAISchema(item)])
+    );
+  }
+
+  if (Array.isArray(value.required)) {
+    result.required = value.required.filter((item): item is string => typeof item === 'string');
+  }
+
+  if ('items' in value) {
+    result.items = sanitizeOpenAISchema(value.items);
+  }
+
+  if ('additionalProperties' in value) {
+    result.additionalProperties =
+      typeof value.additionalProperties === 'boolean'
+        ? value.additionalProperties
+        : sanitizeOpenAISchema(value.additionalProperties);
+  }
+
+  for (const key of OPENAI_COMPOSITION_KEYS) {
+    const composition = value[key];
+    if (Array.isArray(composition)) {
+      result[key] = composition.map(sanitizeOpenAISchema);
+    }
+  }
+
+  for (const key of ['$defs', 'definitions'] as const) {
+    const defs = value[key];
+    if (isPlainObject(defs)) {
+      result[key] = Object.fromEntries(
+        Object.entries(defs).map(([name, item]) => [name, sanitizeOpenAISchema(item)])
+      );
+    }
+  }
+
+  // Filter declared types against the OpenAI-accepted set.
+  const declaredType = value.type;
+  const schemaTypes: string[] =
+    typeof declaredType === 'string'
+      ? (OPENAI_SCHEMA_TYPES as readonly string[]).includes(declaredType)
+        ? [declaredType]
+        : []
+      : Array.isArray(declaredType)
+        ? declaredType.filter(
+            (item): item is string =>
+              typeof item === 'string' && (OPENAI_SCHEMA_TYPES as readonly string[]).includes(item)
+          )
+        : [];
+
+  // If the schema is a pure $ref or pure composition, the type is implicit
+  // and we should not invent one.
+  if (
+    schemaTypes.length === 0 &&
+    (typeof result.$ref === 'string' || OPENAI_COMPOSITION_KEYS.some((key) => key in result))
+  ) {
+    return result;
+  }
+
+  // Infer `type` from neighbouring keywords when absent. MCP servers in the
+  // wild routinely emit `properties` without `type: 'object'` or `items`
+  // without `type: 'array'`.
+  const inferredTypes: string[] =
+    schemaTypes.length > 0
+      ? schemaTypes
+      : ['properties', 'required', 'additionalProperties'].some((key) => key in value)
+        ? ['object']
+        : ['items', 'prefixItems'].some((key) => key in value)
+          ? ['array']
+          : 'enum' in result || 'format' in value
+            ? ['string']
+            : ['minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'multipleOf'].some(
+                  (key) => key in value
+                )
+              ? ['number']
+              : [];
+
+  if (inferredTypes.length === 0) {
+    return {};
+  }
+
+  result.type = inferredTypes.length === 1 ? inferredTypes[0] : inferredTypes;
+  if (inferredTypes.includes('object') && !('properties' in result)) {
+    result.properties = {};
+  }
+  if (inferredTypes.includes('array') && !('items' in result)) {
+    result.items = { type: 'string' };
+  }
+  return result;
+}
+
+/**
+ * Provider metadata hint used to detect OpenAI-shaped tool-call wire formats.
+ * Mirrors opencode's `Provider.Model.api.npm` shape so the same fixtures port
+ * 1:1 from upstream.
+ */
+export interface OpenAIShapeProviderMeta {
+  /** AI SDK package id, e.g. `@ai-sdk/openai`, `@ai-sdk/azure`. */
+  sdk?: string;
+}
+
+/**
+ * Returns true when a model id (or its provider metadata) indicates the
+ * deployment uses the OpenAI function-tool wire format. Used to decide
+ * whether MCP `inputSchema` payloads must be lowered through
+ * `sanitizeOpenAISchema` before serialization.
+ *
+ * Detection rules (any match wins):
+ *  - `model` matches `/^(gpt-|o[13]-)/i` (OpenAI naming convention used by
+ *    SAP AI Core OpenAI deployments).
+ *  - `providerMeta.sdk` is `@ai-sdk/openai` or `@ai-sdk/azure`.
+ *
+ * @param model - The model id string
+ * @param providerMeta - Optional provider metadata
+ * @returns true if the deployment expects OpenAI-shaped tool schemas
+ */
+export function isOpenAIShapedModel(
+  model: string,
+  providerMeta?: OpenAIShapeProviderMeta
+): boolean {
+  if (providerMeta?.sdk === '@ai-sdk/openai' || providerMeta?.sdk === '@ai-sdk/azure') {
+    return true;
+  }
+  return /^(gpt-|o[13]-)/i.test(model);
+}
+
+/**
+ * Minimal MCP tool shape consumed by `lowerMcpToolsForOpenAIShaped`. Mirrors
+ * `McpToolInfo` from `src/mcp/client.ts` without importing it (keeps this
+ * module free of MCP-side type coupling).
+ */
+export interface McpToolForLowering {
+  name: string;
+  description?: string;
+  inputSchema: unknown;
+  serverName?: string;
+}
+
+/**
+ * Lower a list of MCP tool descriptors for serialization against an
+ * OpenAI-shaped deployment. Returns NEW objects per call so the cached
+ * `McpToolInfo` in `McpClientManager` is never mutated.
+ *
+ * If `model` is not OpenAI-shaped (e.g. `anthropic--claude-4.5-sonnet`),
+ * the tools pass through untouched — non-OpenAI SAP AI Core deployments
+ * accept JSON Schema 2020-12 fine and the lowering would strip
+ * semantically meaningful constraints.
+ *
+ * Call site responsibility: invoke this immediately before assembling the
+ * `tools: ChatCompletionTool[]` payload for the chat completion request.
+ *
+ * @param tools - MCP tool descriptors
+ * @param model - The target model id
+ * @param providerMeta - Optional provider metadata hint
+ * @returns A new array of tool descriptors with lowered `inputSchema` when
+ *   the deployment is OpenAI-shaped, or the original array reference when
+ *   the deployment is not OpenAI-shaped.
+ */
+export function lowerMcpToolsForOpenAIShaped<T extends McpToolForLowering>(
+  tools: readonly T[],
+  model: string,
+  providerMeta?: OpenAIShapeProviderMeta
+): T[] {
+  if (!isOpenAIShapedModel(model, providerMeta)) {
+    // Non-OpenAI deployments: return a shallow copy so the caller can treat
+    // the result as owned, but do NOT touch the cached schema objects.
+    return tools.slice() as T[];
+  }
+  return tools.map(
+    (tool) =>
+      ({
+        ...tool,
+        inputSchema: sanitizeOpenAISchema(tool.inputSchema),
+      }) as T
+  );
+}

--- a/tests/providers/transform.test.ts
+++ b/tests/providers/transform.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Tests for the OpenAI-shape JSON schema lowering pass shipped with
+ * `sanitizeOpenAISchema`, `isOpenAIShapedModel`, and
+ * `lowerMcpToolsForOpenAIShaped` in `src/providers/transform.ts`.
+ *
+ * Fixtures are ported from sst/opencode #32489 (Codex schema lowering)
+ * so any future divergence in the lowering pass is caught here first.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  isOpenAIShapedModel,
+  lowerMcpToolsForOpenAIShaped,
+  sanitizeOpenAISchema,
+  type McpToolForLowering,
+} from '../../src/providers/transform.js';
+
+describe('sanitizeOpenAISchema - boolean schemas', () => {
+  it('rewrites the boolean `true` schema to `{ type: "string" }`', () => {
+    expect(sanitizeOpenAISchema(true)).toEqual({ type: 'string' });
+  });
+
+  it('rewrites the boolean `false` schema to `{ type: "string" }`', () => {
+    expect(sanitizeOpenAISchema(false)).toEqual({ type: 'string' });
+  });
+});
+
+describe('sanitizeOpenAISchema - keyword filtering', () => {
+  it('drops unsupported JSON Schema keywords recursively', () => {
+    const result = sanitizeOpenAISchema({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      title: 'Search',
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Search query',
+          format: 'uri',
+          pattern: '^https://',
+          minLength: 1,
+          maxLength: 100,
+          default: 'https://example.com',
+        },
+        count: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 10,
+          multipleOf: 1,
+        },
+        createdAt: {
+          format: 'date-time',
+        },
+        mode: {
+          const: 'fast',
+        },
+        tags: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 3,
+          uniqueItems: true,
+        },
+        tuple: {
+          type: 'array',
+          items: [
+            { type: 'number', minimum: 0 },
+            { type: 'string', pattern: '^ok$' },
+          ],
+        },
+        metadata: {
+          type: 'object',
+          patternProperties: {
+            '^x-': { type: 'string' },
+          },
+          additionalProperties: {
+            type: 'string',
+            pattern: '^safe$',
+          },
+        },
+      },
+      patternProperties: {
+        '^extra': { type: 'string' },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Search query',
+        },
+        count: {
+          type: 'integer',
+        },
+        createdAt: {
+          type: 'string',
+        },
+        mode: {
+          enum: ['fast'],
+          type: 'string',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        tuple: {
+          type: 'array',
+          items: [{ type: 'number' }, { type: 'string' }],
+        },
+        metadata: {
+          type: 'object',
+          properties: {},
+          additionalProperties: {
+            type: 'string',
+          },
+        },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    });
+  });
+
+  it('drops unknown composition keywords (if/then/else, dependentSchemas, ...)', () => {
+    // These keywords have no allowlist entry; the lowering pass simply omits them.
+    const result = sanitizeOpenAISchema({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      if: { properties: { a: { const: 'x' } } },
+      then: { required: ['a'] },
+      else: { required: [] },
+      dependentSchemas: { a: { required: ['a'] } },
+      unevaluatedProperties: false,
+    }) as Record<string, unknown>;
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+    expect('if' in result).toBe(false);
+    expect('then' in result).toBe(false);
+    expect('else' in result).toBe(false);
+    expect('dependentSchemas' in result).toBe(false);
+    expect('unevaluatedProperties' in result).toBe(false);
+  });
+});
+
+describe('sanitizeOpenAISchema - $ref handling', () => {
+  it('keeps local references and sanitizes definitions', () => {
+    const result = sanitizeOpenAISchema({
+      type: 'object',
+      properties: {
+        value: {
+          $ref: '#/$defs/Value',
+          description: 'Referenced value',
+          examples: ['ignored'],
+        },
+      },
+      $defs: {
+        Value: {
+          type: 'string',
+          pattern: '^value$',
+          description: 'Definition description',
+        },
+        Unused: {
+          type: 'number',
+          minimum: 0,
+        },
+      },
+    }) as { properties: Record<string, unknown>; $defs: Record<string, unknown> };
+
+    expect(result.properties.value).toEqual({
+      $ref: '#/$defs/Value',
+      description: 'Referenced value',
+    });
+    expect(result.$defs).toEqual({
+      Value: {
+        type: 'string',
+        description: 'Definition description',
+      },
+      Unused: {
+        type: 'number',
+      },
+    });
+  });
+
+  it('preserves $ref when no other type info is present', () => {
+    expect(sanitizeOpenAISchema({ $ref: '#/$defs/Foo' })).toEqual({ $ref: '#/$defs/Foo' });
+  });
+});
+
+describe('sanitizeOpenAISchema - const -> enum folding', () => {
+  it('folds `const: X` into `enum: [X]`', () => {
+    expect(sanitizeOpenAISchema({ const: 'fast' })).toEqual({
+      enum: ['fast'],
+      type: 'string',
+    });
+  });
+
+  it('preserves an existing `enum` when `const` is absent', () => {
+    expect(sanitizeOpenAISchema({ enum: ['a', 'b'] })).toEqual({
+      enum: ['a', 'b'],
+      type: 'string',
+    });
+  });
+});
+
+describe('sanitizeOpenAISchema - type inference', () => {
+  it('infers type "object" from `properties` when `type` is absent', () => {
+    expect(sanitizeOpenAISchema({ properties: { foo: { type: 'string' } } })).toEqual({
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    });
+  });
+
+  it('infers type "array" from `items` when `type` is absent', () => {
+    expect(sanitizeOpenAISchema({ items: { type: 'string' } })).toEqual({
+      type: 'array',
+      items: { type: 'string' },
+    });
+  });
+
+  it('infers type "array" from `prefixItems` when `type` is absent', () => {
+    expect(
+      sanitizeOpenAISchema({
+        prefixItems: [{ type: 'string' }, { type: 'number' }],
+      })
+    ).toEqual({
+      type: 'array',
+      items: { type: 'string' },
+    });
+  });
+
+  it('infers type "number" from numeric range keywords', () => {
+    expect(sanitizeOpenAISchema({ minimum: 0, maximum: 10 })).toEqual({
+      type: 'number',
+    });
+  });
+
+  it('drops unknown `type` values silently', () => {
+    expect(sanitizeOpenAISchema({ type: 'bigint', properties: {} })).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('returns `{}` when no type can be inferred and no $ref/composition is present', () => {
+    expect(sanitizeOpenAISchema({ foo: 'bar' })).toEqual({});
+  });
+});
+
+describe('sanitizeOpenAISchema - required filtering', () => {
+  it('filters non-string entries out of `required`', () => {
+    const result = sanitizeOpenAISchema({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a', 1, null, { x: 1 }, 'b'],
+    });
+    expect(result).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a', 'b'],
+    });
+  });
+});
+
+describe('sanitizeOpenAISchema - description preservation', () => {
+  it('preserves `description` verbatim', () => {
+    const longText = 'Multi-line\ndescription with\t whitespace.';
+    expect(sanitizeOpenAISchema({ type: 'string', description: longText })).toEqual({
+      type: 'string',
+      description: longText,
+    });
+  });
+});
+
+describe('sanitizeOpenAISchema - prefixItems / tuple lowering', () => {
+  it('lowers tuple-form `items: [...]` to a legal shape', () => {
+    expect(
+      sanitizeOpenAISchema({
+        type: 'array',
+        items: [
+          { type: 'number', minimum: 0 },
+          { type: 'string', pattern: '^ok$' },
+        ],
+      })
+    ).toEqual({
+      type: 'array',
+      items: [{ type: 'number' }, { type: 'string' }],
+    });
+  });
+});
+
+describe('sanitizeOpenAISchema - composition keywords', () => {
+  it('recurses into anyOf/oneOf/allOf', () => {
+    expect(
+      sanitizeOpenAISchema({
+        anyOf: [
+          { type: 'string', pattern: '^a$' },
+          { type: 'number', minimum: 0 },
+        ],
+      })
+    ).toEqual({
+      anyOf: [{ type: 'string' }, { type: 'number' }],
+    });
+  });
+});
+
+describe('sanitizeOpenAISchema - additionalProperties', () => {
+  it('passes booleans through untouched', () => {
+    expect(
+      sanitizeOpenAISchema({
+        type: 'object',
+        properties: {},
+        additionalProperties: true,
+      })
+    ).toEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: true,
+    });
+  });
+
+  it('recurses when additionalProperties is a schema', () => {
+    expect(
+      sanitizeOpenAISchema({
+        type: 'object',
+        properties: {},
+        additionalProperties: { type: 'string', pattern: '^safe$' },
+      })
+    ).toEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: { type: 'string' },
+    });
+  });
+});
+
+describe('isOpenAIShapedModel', () => {
+  it('matches gpt-* ids', () => {
+    expect(isOpenAIShapedModel('gpt-4o')).toBe(true);
+    expect(isOpenAIShapedModel('gpt-4.1')).toBe(true);
+    expect(isOpenAIShapedModel('gpt-5-mini')).toBe(true);
+    expect(isOpenAIShapedModel('GPT-4O')).toBe(true);
+  });
+
+  it('matches o1-* and o3-* ids', () => {
+    expect(isOpenAIShapedModel('o1-preview')).toBe(true);
+    expect(isOpenAIShapedModel('o3-mini')).toBe(true);
+    expect(isOpenAIShapedModel('O3-pro')).toBe(true);
+  });
+
+  it('matches when providerMeta.sdk is @ai-sdk/openai', () => {
+    expect(isOpenAIShapedModel('custom-model', { sdk: '@ai-sdk/openai' })).toBe(true);
+  });
+
+  it('matches when providerMeta.sdk is @ai-sdk/azure', () => {
+    expect(isOpenAIShapedModel('custom-model', { sdk: '@ai-sdk/azure' })).toBe(true);
+  });
+
+  it('returns false for non-OpenAI SAP AI Core ids', () => {
+    expect(isOpenAIShapedModel('anthropic--claude-4.5-sonnet')).toBe(false);
+    expect(isOpenAIShapedModel('anthropic--claude-3.7-sonnet')).toBe(false);
+    expect(isOpenAIShapedModel('gemini-2.5-pro')).toBe(false);
+    expect(isOpenAIShapedModel('mistralai--mistral-small-instruct')).toBe(false);
+    expect(isOpenAIShapedModel('amazon--nova-pro')).toBe(false);
+    expect(isOpenAIShapedModel('deepseek-ai--deepseek-r1')).toBe(false);
+  });
+
+  it('returns false for unrelated providerMeta sdks', () => {
+    expect(isOpenAIShapedModel('claude-3-opus', { sdk: '@ai-sdk/anthropic' })).toBe(false);
+  });
+
+  it('does not falsely match ids that merely contain "gpt"', () => {
+    expect(isOpenAIShapedModel('claude-but-with-gpt-in-name')).toBe(false);
+  });
+});
+
+describe('lowerMcpToolsForOpenAIShaped', () => {
+  const mcpTool: McpToolForLowering = {
+    name: 'search',
+    description: 'Search the filesystem',
+    serverName: 'filesystem',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          pattern: '^https://',
+          format: 'uri',
+        },
+        // tuple form via items: [...] — illegal for OpenAI without lowering
+        path: {
+          type: 'array',
+          items: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+      required: ['query'],
+    },
+  };
+
+  it('lowers `inputSchema` for OpenAI-shaped models', () => {
+    const result = lowerMcpToolsForOpenAIShaped([mcpTool], 'gpt-4o');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('search');
+    expect(result[0].inputSchema).toEqual({
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        path: {
+          type: 'array',
+          items: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+      required: ['query'],
+    });
+  });
+
+  it('does NOT lower `inputSchema` for SAP AI Core anthropic deployments', () => {
+    const result = lowerMcpToolsForOpenAIShaped([mcpTool], 'anthropic--claude-4.5-sonnet');
+    // Schema must pass through untouched - non-OpenAI deployments accept JSON
+    // Schema 2020-12 fine and lowering would strip semantically meaningful
+    // constraints (pattern, format, prefixItems, ...).
+    expect(result[0].inputSchema).toEqual(mcpTool.inputSchema);
+    expect(result[0].inputSchema).toBe(mcpTool.inputSchema);
+  });
+
+  it('does NOT mutate the original tool object or its inputSchema', () => {
+    const tool: McpToolForLowering = {
+      name: 'fs_read',
+      inputSchema: {
+        type: 'object',
+        properties: { path: { type: 'string', pattern: '^/' } },
+      },
+    };
+    const snapshot = JSON.parse(JSON.stringify(tool));
+
+    const result = lowerMcpToolsForOpenAIShaped([tool], 'gpt-5');
+    // Original tool must be unchanged so the cached McpToolInfo can serve
+    // non-OpenAI deployments in the same process.
+    expect(tool).toEqual(snapshot);
+    expect(result[0]).not.toBe(tool);
+    expect(result[0].inputSchema).not.toBe(tool.inputSchema);
+  });
+
+  it('honours providerMeta.sdk for non-prefixed model ids', () => {
+    const result = lowerMcpToolsForOpenAIShaped([mcpTool], 'custom-deployment-id', {
+      sdk: '@ai-sdk/openai',
+    });
+    expect((result[0].inputSchema as { properties: Record<string, unknown> }).properties).toEqual({
+      query: { type: 'string' },
+      path: {
+        type: 'array',
+        items: [{ type: 'string' }, { type: 'number' }],
+      },
+    });
+  });
+
+  it('returns an array reference distinct from the input', () => {
+    const tools = [mcpTool];
+    expect(lowerMcpToolsForOpenAIShaped(tools, 'gpt-4o')).not.toBe(tools);
+    expect(lowerMcpToolsForOpenAIShaped(tools, 'anthropic--claude-4.5-sonnet')).not.toBe(tools);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a JSON Schema lowering pass for MCP tool input schemas targeted at SAP AI Core OpenAI deployments (\`gpt-*\`, \`o1-*\`, \`o3-*\`, or any deployment whose underlying ai-sdk wrapper is \`@ai-sdk/openai\` / \`@ai-sdk/azure\`).

Mirrors the Codex / opencode lowering algorithm shipped in sst/opencode#32489 (Codex's Rust schema compatibility layer). Without it, MCP servers that use JSON Schema 2020-12 features OpenAI rejects (\`prefixItems\`, boolean schemas, \`if\`/\`then\`/\`else\`, \`dependentSchemas\`, \`unevaluatedProperties\`, ...) register successfully but every tool call rejects with \`Invalid schema for function\`.

## Exports (\`src/providers/transform.ts\`)

- \`sanitizeOpenAISchema(value)\` - pure lowering pass; never mutates input. Drops unsupported keywords, folds \`const: X\` -> \`enum: [X]\`, infers a missing \`type\` from neighbouring keywords, keeps \`\$ref\` and \`description\` verbatim.
- \`isOpenAIShapedModel(model, providerMeta?)\` - detects \`gpt-\` / \`o1-\` / \`o3-\` model ids or \`@ai-sdk/openai\` / \`@ai-sdk/azure\` provider SDK metadata.
- \`lowerMcpToolsForOpenAIShaped(tools, model, providerMeta?)\` - call-site helper that produces NEW tool descriptors per request so the cached \`McpToolInfo\` in \`McpClientManager\` is safe for non-OpenAI deployments running in the same process.

## Behaviour

- OpenAI-shaped deployments: \`inputSchema\` is lowered to the OpenAI-supported subset before serialization.
- Non-OpenAI SAP AI Core deployments (\`anthropic--*\`, \`gemini-*\`, \`mistralai--*\`, \`amazon--*\`, \`deepseek-ai--*\`): schemas pass through untouched — they accept JSON Schema 2020-12 fine and the lowering would strip semantically meaningful constraints.
- Cached \`McpToolInfo.inputSchema\` is never mutated; new objects are produced per request.

## Tests

\`tests/providers/transform.test.ts\` ports the opencode \`transform.test.ts\` fixtures and covers:

- boolean schemas (\`true\` / \`false\` -> \`{ type: 'string' }\`)
- \`\$ref\` preservation through \`properties\` and \`\$defs\`
- tuple / \`prefixItems\` lowering
- \`const\` -> \`enum\` folding
- inferred \`type: 'object'\` from \`properties\`
- inferred \`type: 'array'\` from \`items\` / \`prefixItems\`
- inferred \`type: 'number'\` from numeric range keywords
- non-string entries filtered out of \`required\`
- unknown composition keywords (\`if\`/\`then\`/\`else\`, \`dependentSchemas\`, \`unevaluatedProperties\`) dropped
- \`description\` preserved verbatim
- \`additionalProperties\` boolean pass-through and schema recursion
- \`isOpenAIShapedModel\` model-id and providerMeta detection (positive and negative)
- \`lowerMcpToolsForOpenAIShaped\` non-mutation guarantee

## Verification

\`\`\`
npm run lint           # 0 errors
npm run typecheck      # clean
npm run format:check   # clean
npm run test:coverage  # 2678 passed, 61.14% lines
npm run build          # clean
\`\`\`

Closes #805