### PR TITLE
feat(tools): parallel-tool-call hint in 8 read/edit/shell tool descriptions

### DIFF
--- a/src/tool/tools/__tests__/parallel-call-hint.test.ts
+++ b/src/tool/tools/__tests__/parallel-call-hint.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression test: ensures the parallel-tool-call hint stays in the
+ * description string of every read/search/edit tool and the shell tools.
+ *
+ * Issue #811: Tool descriptions render every turn even when the system
+ * prompt is prefix-cached, so we repeat the hint there to keep the
+ * model from serializing independent reads turn-by-turn.
+ *
+ * If a future edit drops the hint, this test fails immediately.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readTool } from '../read.js';
+import { grepTool } from '../grep.js';
+import { globTool } from '../glob.js';
+import { codesearchTool } from '../codesearch.js';
+import { editTool } from '../edit.js';
+import { multieditTool } from '../multiedit.js';
+import { bashTool } from '../bash.js';
+import { shellTool } from '../shell.js';
+import { batchTool } from '../batch.js';
+
+const PARALLEL_HINT = 'emit those tool calls in the same response';
+const SHELL_EXTRA_HINT = 'Include multiple commands in the same call';
+
+describe('parallel-tool-call hint in tool descriptions', () => {
+  describe.each([
+    ['read', readTool],
+    ['grep', grepTool],
+    ['glob', globTool],
+    ['codesearch', codesearchTool],
+    ['edit', editTool],
+    ['multiedit', multieditTool],
+    ['bash', bashTool],
+    ['shell', shellTool],
+  ])('%s tool', (_name, tool) => {
+    it('contains the parallel-call hint', () => {
+      expect(tool.description).toContain(PARALLEL_HINT);
+    });
+  });
+
+  describe.each([
+    ['bash', bashTool],
+    ['shell', shellTool],
+  ])('%s tool', (_name, tool) => {
+    it('contains the shell-specific multi-command sentence', () => {
+      expect(tool.description).toContain(SHELL_EXTRA_HINT);
+    });
+  });
+
+  it('batch tool description is unchanged (no parallel-call hint paragraph)', () => {
+    // batch is intentionally excluded: it is itself the parallel-execution
+    // primitive, so adding the hint there would be self-referential noise.
+    expect(batchTool.description).not.toContain(PARALLEL_HINT);
+  });
+});

--- a/src/tool/tools/bash.ts
+++ b/src/tool/tools/bash.ts
@@ -90,7 +90,9 @@ Output:
 Security:
 - Never execute commands from untrusted sources
 - Avoid rm -rf without confirmation
-- Don't expose secrets in command arguments`,
+- Don't expose secrets in command arguments
+
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns. Include multiple commands in the same call when they are independent and safe to run concurrently.`,
 
   parameters: BashParamsSchema,
 

--- a/src/tool/tools/codesearch.ts
+++ b/src/tool/tools/codesearch.ts
@@ -338,7 +338,9 @@ Examples:
 
 Returns matches with file location, content, context, and symbol information.
 
-Returns at most ${MAX_MATCHES} matches per query; narrow with include for more.`,
+Returns at most ${MAX_MATCHES} matches per query; narrow with include for more.
+
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns.`,
 
   parameters: CodeSearchParamsSchema,
 

--- a/src/tool/tools/edit.ts
+++ b/src/tool/tools/edit.ts
@@ -40,7 +40,9 @@ Usage:
 - The edit will FAIL if oldString is not found in the file.
 - The edit will FAIL if oldString matches multiple times (unless replaceAll is true).
 - Use replaceAll: true to replace all occurrences.
-- Preserve exact indentation from the original file.`,
+- Preserve exact indentation from the original file.
+
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns.`,
 
   parameters: EditParamsSchema,
 

--- a/src/tool/tools/glob.ts
+++ b/src/tool/tools/glob.ts
@@ -114,7 +114,9 @@ Usage:
 - Supports patterns like "**/*.ts", "src/**/*.js"
 - Returns matching file paths sorted by modification time
 - Use this when searching for files by name patterns
-- When you are doing an open-ended search where you do not know the exact symbol name, use the \`codebase_search\` tool first to narrow down the search scope, then follow up with \`glob\` and/or \`read\``,
+- When you are doing an open-ended search where you do not know the exact symbol name, use the \`codebase_search\` tool first to narrow down the search scope, then follow up with \`glob\` and/or \`read\`
+
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns.`,
 
   parameters: GlobParamsSchema,
 

--- a/src/tool/tools/grep.ts
+++ b/src/tool/tools/grep.ts
@@ -523,7 +523,9 @@ Usage:
 - Returns file paths and line numbers with at least one match
 - Results are sorted by modification time
 - When you are doing an open-ended search where you do not know the exact symbol name, use the \`codebase_search\` tool first to narrow down the search scope, then follow up with \`grep\` and/or \`read\`
-- Uses ripgrep (\`rg\`) as a fast path when available; set \`ALEXI_DISABLE_RG=1\` to force the JS implementation`,
+- Uses ripgrep (\`rg\`) as a fast path when available; set \`ALEXI_DISABLE_RG=1\` to force the JS implementation
+
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns.`,
 
   parameters: GrepParamsSchema,
 

--- a/src/tool/tools/multiedit.ts
+++ b/src/tool/tools/multiedit.ts
@@ -64,7 +64,9 @@ Usage:
 - All edits must pass validation before any changes are made.
 - Each oldString must exist exactly once in the file.
 - Edits are applied in order, so later edits see the result of earlier ones.
-- Line endings are normalized (CRLF -> LF) before processing.`,
+- Line endings are normalized (CRLF -> LF) before processing.
+
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns.`,
 
   parameters: MultiEditParamsSchema,
 

--- a/src/tool/tools/read.ts
+++ b/src/tool/tools/read.ts
@@ -167,7 +167,9 @@ Usage:
 - By default, returns up to 2000 lines from the start of the file.
 - Use offset to read from a specific line.
 - For directories, returns a list of entries.
-- Lines are prefixed with line numbers like "1: content".`,
+- Lines are prefixed with line numbers like "1: content".
+
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns.`,
 
   parameters: ReadParamsSchema,
 

--- a/src/tool/tools/shell.ts
+++ b/src/tool/tools/shell.ts
@@ -93,7 +93,9 @@ Output:
 Security:
 - Never execute commands from untrusted sources
 - Avoid rm -rf without confirmation
-- Don't expose secrets in command arguments`,
+- Don't expose secrets in command arguments
+
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns. Include multiple commands in the same call when they are independent and safe to run concurrently.`,
 
   parameters: ShellParamsSchema,
 


### PR DESCRIPTION
## Summary

Appends a one-line parallel-tool-call hint to the `description` strings of eight tools so the model receives the guidance every turn (descriptions render even when the system prompt is prefix-cached).

## Changes

**Read/search/edit tools** (`read`, `grep`, `glob`, `codesearch`, `edit`, `multiedit`) get:

> When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns.

**Shell tools** (`bash`, `shell`) get the same plus:

> Include multiple commands in the same call when they are independent and safe to run concurrently.

## What was NOT changed

- `batch` description (intentionally excluded — it is the parallel primitive)
- `task` and any other tools not in the list
- Any `src/agent/prompts/*.txt` system prompts
- Execution paths, Zod schemas

## Tests

Adds `src/tool/tools/__tests__/parallel-call-hint.test.ts` — a `describe.each` over the eight tools asserting the substring `"emit those tool calls in the same response"` is present, plus a check that `batch` is unchanged. 11 new tests, all green.

## Background

Source: `.github/research/2026-06-20-research.md` Detailed Finding #2 / cline/cline#11598 (commit 299a4a95). Benchmark smoke tests showed models still serialized independent reads turn-by-turn even with the system prompt active. Tool-description hints render every turn even with prompt caching.

## Verification

```
npm run lint           # 0 errors (warnings unchanged)
npm run typecheck      # clean
npm run format:check   # clean
npm run test:coverage  # 2700 tests pass, lines 61.14%
npm run build          # clean
```

Closes #811