### PR TITLE
feat(providers): per-model carve-out for reasoning_effort gating

### DIFF
--- a/src/providers/__tests__/deepseek.test.ts
+++ b/src/providers/__tests__/deepseek.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../model-match.js', async () => {
+  const actual = await vi.importActual<typeof import('../model-match.js')>('../model-match.js');
+  return {
+    ...actual,
+    modelSupportsReasoningEffort: vi.fn((modelId: string) => {
+      const lower = modelId.toLowerCase();
+      if (lower.includes('deepseek')) {
+        return 'levels';
+      }
+      if (lower.includes('binary-thinker')) {
+        return 'binary';
+      }
+      return 'none';
+    }),
+  };
+});
+
+import { buildDeepSeekRequest } from '../deepseek.js';
+
+describe('buildDeepSeekRequest', () => {
+  const messages = [{ role: 'user', content: 'hi' }];
+
+  describe('reasoning_effort dispatch', () => {
+    it('preserves existing deepseek behaviour bit-for-bit when modelId is omitted ("levels" default)', () => {
+      const request = buildDeepSeekRequest(messages, { reasoningEffort: 'high' });
+      expect(request.reasoning_effort).toBe('high');
+      expect(request.enable_thinking).toBeUndefined();
+    });
+
+    it('sends reasoning_effort as-is for "levels" mode (deepseek modelId)', () => {
+      const request = buildDeepSeekRequest(messages, {
+        reasoningEffort: 'medium',
+        modelId: 'deepseek-r1',
+      });
+      expect(request.reasoning_effort).toBe('medium');
+      expect(request.enable_thinking).toBeUndefined();
+    });
+
+    it('sends enable_thinking: true and drops reasoning_effort for "binary" mode', () => {
+      const request = buildDeepSeekRequest(messages, {
+        reasoningEffort: 'low',
+        modelId: 'binary-thinker-v1',
+      });
+      expect(request.enable_thinking).toBe(true);
+      expect(request.reasoning_effort).toBeUndefined();
+    });
+
+    it('does not forward reasoning_effort for "none" mode (unknown modelId)', () => {
+      const request = buildDeepSeekRequest(messages, {
+        reasoningEffort: 'high',
+        modelId: 'anthropic--claude-4.7-opus',
+      });
+      expect(request.reasoning_effort).toBeUndefined();
+      expect(request.enable_thinking).toBeUndefined();
+    });
+
+    it('does nothing when reasoningEffort is not provided', () => {
+      const request = buildDeepSeekRequest(messages, {});
+      expect(request.reasoning_effort).toBeUndefined();
+      expect(request.enable_thinking).toBeUndefined();
+    });
+  });
+
+  describe('max_tokens handling (unchanged)', () => {
+    it('forwards numeric max_tokens', () => {
+      const request = buildDeepSeekRequest(messages, { maxTokens: 256 });
+      expect(request.max_tokens).toBe(256);
+      expect(request.max_completion_tokens).toBeUndefined();
+    });
+
+    it('forwards "max" as max_completion_tokens', () => {
+      const request = buildDeepSeekRequest(messages, { maxTokens: 'max' });
+      expect(request.max_completion_tokens).toBe('max');
+      expect(request.max_tokens).toBeUndefined();
+    });
+  });
+});

--- a/src/providers/__tests__/model-match.test.ts
+++ b/src/providers/__tests__/model-match.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { modelSupportsReasoningEffort } from '../model-match.js';
+
+describe('modelSupportsReasoningEffort', () => {
+  it('returns "levels" for deepseek model ids', () => {
+    expect(modelSupportsReasoningEffort('deepseek-r1')).toBe('levels');
+  });
+
+  it('is case-insensitive when matching deepseek', () => {
+    expect(modelSupportsReasoningEffort('DeepSeek-R1')).toBe('levels');
+    expect(modelSupportsReasoningEffort('sap-ai-core/DEEPSEEK-V3')).toBe('levels');
+  });
+
+  it('returns "none" for an unknown model id', () => {
+    expect(modelSupportsReasoningEffort('anthropic--claude-4.7-opus')).toBe('none');
+  });
+
+  it('returns "none" for an empty model id', () => {
+    expect(modelSupportsReasoningEffort('')).toBe('none');
+  });
+});

--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -3,6 +3,8 @@
  * Handles DeepSeek model features and API quirks
  */
 
+import { modelSupportsReasoningEffort } from './model-match.js';
+
 interface Message {
   role: string;
   content: string;
@@ -19,6 +21,7 @@ interface ProviderRequest {
 export interface DeepSeekOptions {
   maxTokens?: number | 'max';
   reasoningEffort?: 'low' | 'medium' | 'high';
+  modelId?: string;
 }
 
 /**
@@ -40,9 +43,17 @@ export function buildDeepSeekRequest(
     request.max_tokens = options.maxTokens;
   }
 
-  // Add reasoning effort if specified
+  // Dispatch reasoning_effort handling on per-model capability.
+  // When modelId is omitted, default to 'levels' to preserve existing
+  // DeepSeek behaviour bit-for-bit.
   if (options.reasoningEffort) {
-    request.reasoning_effort = options.reasoningEffort;
+    const mode = options.modelId ? modelSupportsReasoningEffort(options.modelId) : 'levels';
+    if (mode === 'levels') {
+      request.reasoning_effort = options.reasoningEffort;
+    } else if (mode === 'binary') {
+      request.enable_thinking = true;
+    }
+    // 'none' -> do nothing
   }
 
   return request;

--- a/src/providers/model-match.ts
+++ b/src/providers/model-match.ts
@@ -94,3 +94,22 @@ export function isOpenAI(modelId: string): boolean {
 export function isGemini(modelId: string): boolean {
   return modelId.toLowerCase().includes('gemini');
 }
+
+/** Reasoning-effort capability for a given model id */
+export type ReasoningEffortMode = 'none' | 'binary' | 'levels';
+
+/**
+ * Return how a model accepts reasoning_effort:
+ * - 'levels' -> send `reasoning_effort: 'low'|'medium'|'high'` as-is.
+ * - 'binary' -> send `enable_thinking: true` (drop the level).
+ * - 'none'   -> do not forward the field.
+ */
+export function modelSupportsReasoningEffort(modelId: string): ReasoningEffortMode {
+  const lower = modelId.toLowerCase();
+  if (lower.includes('deepseek')) {
+    return 'levels';
+  }
+  // Pre-emptive carve-out for future binary-only thinking models.
+  // Add concrete model substrings here when wired into the router.
+  return 'none';
+}


### PR DESCRIPTION
Closes #819

## Summary

Replaces the unconditional `reasoning_effort` write in `buildDeepSeekRequest` with a per-model capability dispatch backed by a new `modelSupportsReasoningEffort(modelId)` helper in `src/providers/model-match.ts`.

## Changes

- **`src/providers/model-match.ts`**: Adds exported `ReasoningEffortMode` type (`'none' | 'binary' | 'levels'`) and `modelSupportsReasoningEffort(modelId)` helper. Currently returns `'levels'` for any id containing `deepseek` (case-insensitive) and `'none'` otherwise. The `'binary'` branch is wired into `buildDeepSeekRequest` so future binary-only thinking models can be carved out with one string match here.
- **`src/providers/deepseek.ts`**: `DeepSeekOptions` now accepts optional `modelId`. The `reasoning_effort` block dispatches on the helper:
  - `'levels'` -> `request.reasoning_effort = options.reasoningEffort` (existing behaviour).
  - `'binary'` -> `request.enable_thinking = true` (no `reasoning_effort`).
  - `'none'`   -> field is dropped.
  - When `modelId` is omitted, defaults to `'levels'` to keep existing DeepSeek behaviour bit-for-bit identical.
- **Tests**: New `src/providers/__tests__/deepseek.test.ts` covers all three branches (the `'binary'` branch via a `vi.mock` of `modelSupportsReasoningEffort`) plus the `modelId`-omitted default. New `src/providers/__tests__/model-match.test.ts` covers DeepSeek match, case-insensitivity (`DeepSeek-R1` -> `'levels'`), and the unknown-id default.

## Why

`buildDeepSeekRequest` previously forwarded `reasoningEffort` blindly. The moment routing-config / multi-model work (#813) lets users name arbitrary reasoning-style deployments, that blanket write would either be silently ignored or rejected by the provider. opencode learned this with GLM-4 -> 5.2 (`sst/opencode#32446`, 2026-06-20) where a `id.includes('glm')` gate silently dropped High/Max variants. Pre-empting it here in one helper + tests is cheaper than three-file refactor after a regression.

## Verification

```
npm run lint          # 0 errors
npm run typecheck     # green
npm run format:check  # green
npm run test:coverage # 192 files, 2704 tests passing
npm run build         # green
```

No `@ts-ignore`, `eslint-disable`, or new `as any` introduced.

[alexi-bot]