### PR TITLE
docs(providers): document streaming error contract for streamComplete

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -502,6 +502,42 @@ export function getDefaultModel(): string {
 
 **Solution**: Check SAP AI Core quotas or use different resource group
 
+## Streaming Error Semantics
+
+Every provider that implements `streamComplete(messages, options):
+AsyncGenerator<StreamChunk>` MUST honor the following three rules. The
+orchestrator at `src/core/streamingOrchestrator.ts` relies on them to
+persist partial state on failure.
+
+1. **Network and transport errors surface as a rejected promise on the
+   generator.** Implementations MUST `throw` (or let the underlying
+   fetch/SSE error propagate) when the upstream stream fails. Returning
+   silently from the generator masks the failure and causes the
+   orchestrator to record a successful but truncated assistant turn.
+
+2. **Providers MAY yield a final `{ usage }` chunk before throwing.**
+   If usage metadata is observed before the failure (for example, the
+   prompt tokens were billed and emitted on the first SSE event), the
+   provider SHOULD yield one last `StreamChunk` with the usage block
+   populated so the orchestrator can record partial cost via
+   `getCostTracker().recordUsage(...)`.
+
+3. **Providers MUST NOT swallow errors and return early.** Catching a
+   transport error to log and then `return`ing from the generator is
+   forbidden; it breaks the settle path in the orchestrator. Use the
+   standard JavaScript `throw` mechanism and let the orchestrator handle
+   session persistence.
+
+A shared conformance test helper is planned at
+`src/providers/__tests__/streaming-contract.ts` (TODO). Until that
+exists, each provider's test file should include at least one case
+asserting rule 1: feed a mock transport that errors mid-stream, then
+assert the generator rejects rather than returning.
+
+The orchestrator's settle behaviour that depends on these rules is in
+`src/core/streamingOrchestrator.ts` (around the for-await loop), with
+the equivalent non-stream path in `src/core/agenticChat.ts`.
+
 ## Performance Considerations
 
 ### Token Optimization


### PR DESCRIPTION
## Summary

Adds a new `## Streaming Error Semantics` section to `docs/PROVIDERS.md` between `## Error Handling` and `## Performance Considerations`, documenting the contract every provider's `streamComplete` implementation must honor.

## Rules documented

1. **MUST** surface network/transport errors as a rejected promise on the generator (`throw`, do not `return` silently).
2. **MAY** yield a final `{ usage }` chunk before throwing.
3. **MUST NOT** swallow errors and return early from the generator.

The section cross-references `src/core/streamingOrchestrator.ts` and `src/core/agenticChat.ts`, and reserves the future helper path `src/providers/__tests__/streaming-contract.ts` as a TODO.

## Verification

- [x] New `## Streaming Error Semantics` section between `## Error Handling` and `## Performance Considerations`
- [x] Three rules included verbatim
- [x] Cross-references to streamingOrchestrator.ts and agenticChat.ts
- [x] TODO path for future conformance helper reserved
- [x] `npm run format:check` is green
- [x] No code files modified outside `docs/PROVIDERS.md`

Closes #830