### PR TITLE
fix(core): force final-turn text-only when maxIterations cap is hit

### DIFF
--- a/src/core/__tests__/agenticChat.test.ts
+++ b/src/core/__tests__/agenticChat.test.ts
@@ -426,6 +426,110 @@ describe('agenticChat', () => {
 
       expect(result.iterations).toBe(3);
       expect(mockProvider.complete).toHaveBeenCalledTimes(3);
+      // Final turn must return non-empty text even when the model kept
+      // emitting tool_calls right up to the iteration cap.
+      expect(result.text).not.toBe('');
+    });
+
+    it('should drop tools on the final iteration when the cap is hit', async () => {
+      const mockTool = {
+        name: 'loop',
+        description: 'Loop',
+        toFunctionSchema: () => ({
+          name: 'loop',
+          description: 'Loop',
+          parameters: { type: 'object', properties: {} },
+        }),
+        execute: vi.fn().mockResolvedValue({ success: true }),
+      };
+
+      mockToolRegistry.list.mockReturnValue([mockTool]);
+      mockToolRegistry.get.mockReturnValue(mockTool);
+
+      // Model keeps trying to call tools every turn.
+      mockProvider.complete.mockResolvedValue({
+        text: '',
+        toolCalls: [
+          { id: 'call_1', type: 'function', function: { name: 'loop', arguments: '{}' } },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      } satisfies CompletionResult);
+
+      await agenticChat('Loop forever', { maxIterations: 3 });
+
+      // First two turns should still advertise the tool list.
+      expect(mockProvider.complete.mock.calls[0][1]?.tools).toBeDefined();
+      expect(mockProvider.complete.mock.calls[1][1]?.tools).toBeDefined();
+      // Third (final) turn must drop the tools array entirely.
+      expect(mockProvider.complete.mock.calls[2][1]?.tools).toBeUndefined();
+    });
+
+    it('should return a non-empty fallback text when the model emits no text on the final turn', async () => {
+      const mockTool = {
+        name: 'loop',
+        description: 'Loop',
+        toFunctionSchema: () => ({
+          name: 'loop',
+          description: 'Loop',
+          parameters: { type: 'object', properties: {} },
+        }),
+        execute: vi.fn().mockResolvedValue({ success: true }),
+      };
+
+      mockToolRegistry.list.mockReturnValue([mockTool]);
+      mockToolRegistry.get.mockReturnValue(mockTool);
+
+      // Every iteration returns empty text + tool_calls — including the
+      // final tool-less call. finalText must still come back non-empty.
+      mockProvider.complete.mockResolvedValue({
+        text: '',
+        toolCalls: [
+          { id: 'call_1', type: 'function', function: { name: 'loop', arguments: '{}' } },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      } satisfies CompletionResult);
+
+      const result = await agenticChat('Loop forever', { maxIterations: 2 });
+
+      expect(result.iterations).toBe(2);
+      expect(result.text).toBe('[Max iterations reached]');
+    });
+
+    it('should inject a step-limit system-reminder before the final call', async () => {
+      const mockTool = {
+        name: 'loop',
+        description: 'Loop',
+        toFunctionSchema: () => ({
+          name: 'loop',
+          description: 'Loop',
+          parameters: { type: 'object', properties: {} },
+        }),
+        execute: vi.fn().mockResolvedValue({ success: true }),
+      };
+
+      mockToolRegistry.list.mockReturnValue([mockTool]);
+      mockToolRegistry.get.mockReturnValue(mockTool);
+
+      mockProvider.complete.mockResolvedValue({
+        text: '',
+        toolCalls: [
+          { id: 'call_1', type: 'function', function: { name: 'loop', arguments: '{}' } },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      } satisfies CompletionResult);
+
+      await agenticChat('Loop forever', { maxIterations: 2 });
+
+      // Inspect messages sent on the final (second) call.
+      const finalMessages = mockProvider.complete.mock.calls[1][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const reminder = finalMessages.find(
+        (m) => m.role === 'user' && m.content.includes('Step limit reached')
+      );
+      expect(reminder).toBeDefined();
+      expect(reminder?.content).toContain('<system-reminder>');
     });
   });
 

--- a/src/core/agenticChat.ts
+++ b/src/core/agenticChat.ts
@@ -516,6 +516,12 @@ export async function agenticChat(
   while (iterations < maxIterations) {
     iterations++;
 
+    // When the loop is about to exhaust its budget, force the final turn to
+    // be text-only: drop the tool schemas from the request and inject a
+    // system-reminder asking the model to wrap up. Mirrors the upstream
+    // fix in sst/opencode (session-runner.ts, commit 4f1a9d7a, 2026-06-20).
+    const isFinalTurn = iterations === maxIterations;
+
     options?.onProgress?.({
       type: 'iteration',
       iteration: iterations,
@@ -525,6 +531,14 @@ export async function agenticChat(
     // Check for abort
     if (options?.signal?.aborted) {
       throw new Error('Operation aborted');
+    }
+
+    if (isFinalTurn) {
+      messages.push({
+        role: 'user',
+        content:
+          '<system-reminder>Step limit reached. Summarize what you have so far and return a final answer; no further tool calls will be honored.</system-reminder>',
+      });
     }
 
     // Call LLM
@@ -554,7 +568,7 @@ export async function agenticChat(
     try {
       result = await provider.complete(messages as Array<{ role: string; content: string }>, {
         maxTokens: effortConfig.maxTokens,
-        tools: toolSchemas.length > 0 ? toolSchemas : undefined,
+        tools: isFinalTurn ? undefined : toolSchemas.length > 0 ? toolSchemas : undefined,
       });
     } catch (err) {
       // Detect context overflow and attempt compaction with reactive seeding
@@ -589,7 +603,7 @@ export async function agenticChat(
           // Retry the completion
           result = await provider.complete(messages as Array<{ role: string; content: string }>, {
             maxTokens: effortConfig.maxTokens,
-            tools: toolSchemas.length > 0 ? toolSchemas : undefined,
+            tools: isFinalTurn ? undefined : toolSchemas.length > 0 ? toolSchemas : undefined,
           });
         } else {
           throw err;
@@ -618,6 +632,13 @@ export async function agenticChat(
           'Warning: LLM output was truncated (max_tokens reached). ' +
           'Tool calls in this response may have incomplete parameters.',
       });
+    }
+
+    // Final turn: ignore any tool calls the model still tried to emit and
+    // commit whatever text it produced. Guarantees finalText is non-empty.
+    if (isFinalTurn) {
+      finalText = result.text || '[Max iterations reached]';
+      break;
     }
 
     // Check if LLM wants to use tools
@@ -714,6 +735,14 @@ export async function agenticChat(
       finalText = result.text;
       break;
     }
+  }
+
+  // Defensive fallback: any code path that drops out of the loop without
+  // assigning finalText (e.g. future early breaks) still returns a
+  // non-empty response to callers in src/command/goal.ts and
+  // src/cli/commands/agent.ts that treat empty text as success.
+  if (finalText === '') {
+    finalText = '[Max iterations reached]';
   }
 
   // Record cost


### PR DESCRIPTION
Closes #817

## Summary

`src/core/agenticChat.ts` declared `let finalText = ''` and only assigned it in the no-tool-calls branch. When the model kept emitting `tool_calls` until `iterations === maxIterations`, the `while` loop exited with `finalText` still empty, so the CLI returned a silent empty response. Downstream callers (`src/command/goal.ts:193`, `src/cli/commands/agent.ts:235`) treated that as success. opencode hit the same bug and fixed it by forcing the final turn text-only (sst/opencode#33142, commit `4f1a9d7a`).

## Changes

- **`src/core/agenticChat.ts`**
  - Compute `const isFinalTurn = iterations === maxIterations` right after `iterations++`.
  - On the final turn, push a synthetic `{ role: 'user', content: '<system-reminder>Step limit reached. Summarize what you have so far and return a final answer; no further tool calls will be honored.</system-reminder>' }` message before calling the provider.
  - Pass `tools: undefined` on the final-turn `provider.complete()` call AND on its post-compaction retry branch.
  - After the call returns on the final turn, ignore `result.toolCalls` and set `finalText = result.text || '[Max iterations reached]'`, then `break`.
  - Add a defensive fallback outside the loop: if `finalText === ''` after the loop exits for any reason, set it to `'[Max iterations reached]'`.
  - Verified `src/core/streamingOrchestrator.ts` has no equivalent `maxIterations` loop, so no edits there.

- **`src/core/__tests__/agenticChat.test.ts`**
  - Strengthen `'should stop at max iterations'` with `expect(result.text).not.toBe('')`.
  - New test asserts `mockProvider.complete.mock.calls[2][1]?.tools` is `undefined` on the final iteration (first two iterations still carry the tools array).
  - New test asserts the `'[Max iterations reached]'` fallback when the model emits empty text on the final turn.
  - New test asserts the step-limit `<system-reminder>` lands in the messages sent on the final call.

## Verification

Full gate run locally:

```
npm run lint           # 0 errors (1275 pre-existing warnings)
npm run typecheck      # clean
npm run format:check   # clean
npm run test:coverage  # 190 files, 2696 tests passing, lines 61.17%
npm run build          # clean
```

No `@ts-ignore`, no `eslint-disable`, no `as any` added. Scope is limited to the two files listed above plus the `.kilo/` / `.kilocode/` lockfile churn already present on master.

[alexi-bot]