### PR TITLE
feat(providers): plumb topK through SAP orchestration provider

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -342,6 +342,30 @@ await provider.sendMessageStream(
 );
 ```
 
+### Model Parameters
+
+The SAP orchestration provider plumbs the following sampling parameters
+through `OrchestrationConfig` and per-call `CompletionOptions`. Per-call
+options take precedence over config defaults.
+
+| Parameter          | `modelParams` key   | Compatibility                                                                                  |
+| ------------------ | ------------------- | ---------------------------------------------------------------------------------------------- |
+| `temperature`      | `temperature`       | Universal.                                                                                     |
+| `maxTokens`        | `max_tokens`        | Universal.                                                                                     |
+| `topP`             | `top_p`             | Universal.                                                                                     |
+| `topK`             | `top_k`             | Honored by Anthropic Claude family models; silently dropped by OpenAI-family deployments.      |
+| `frequencyPenalty` | `frequency_penalty` | OpenAI-family models. Anthropic deployments ignore the field.                                  |
+| `presencePenalty`  | `presence_penalty`  | OpenAI-family models. Anthropic deployments ignore the field.                                  |
+
+```typescript
+const provider = getProviderForModel('anthropic--claude-4.7-opus');
+
+const result = await provider.complete(
+  [{ role: 'user', content: 'Brainstorm 5 names' }],
+  { temperature: 0.9, topK: 40 }
+);
+```
+
 ### Tool Calling
 
 ```typescript

--- a/src/providers/sapOrchestration.ts
+++ b/src/providers/sapOrchestration.ts
@@ -267,6 +267,8 @@ export interface OrchestrationConfig {
   temperature?: number;
   /** Top-p sampling */
   topP?: number;
+  /** Top-k sampling (honored by Anthropic Claude; silently dropped by OpenAI-family models) */
+  topK?: number;
   /** Frequency penalty */
   frequencyPenalty?: number;
   /** Presence penalty */
@@ -302,6 +304,8 @@ export interface CompletionOptions {
   maxTokens?: number;
   temperature?: number;
   topP?: number;
+  /** Top-k sampling (honored by Anthropic Claude; silently dropped by OpenAI-family models) */
+  topK?: number;
   signal?: AbortSignal;
   /** Override tools for this call */
   tools?: ChatCompletionTool[];
@@ -610,6 +614,9 @@ export class SapOrchestrationProvider {
 
     if (options?.topP !== undefined || this.config.topP !== undefined) {
       modelParams.top_p = options?.topP ?? this.config.topP;
+    }
+    if (options?.topK !== undefined || this.config.topK !== undefined) {
+      modelParams.top_k = options?.topK ?? this.config.topK;
     }
     if (this.config.frequencyPenalty !== undefined) {
       modelParams.frequency_penalty = this.config.frequencyPenalty;

--- a/tests/providers/sapOrchestration-topK.test.ts
+++ b/tests/providers/sapOrchestration-topK.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for top-k sampling plumbing in the SAP Orchestration provider.
+ *
+ * Verifies that `topK` on either OrchestrationConfig or per-call
+ * CompletionOptions reaches `modelParams.top_k` in the module config that
+ * is handed to the SDK's OrchestrationClient, and that per-call options
+ * take precedence over config defaults. Also verifies that omitting
+ * `topK` does NOT introduce `top_k` into `modelParams`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture module configs the provider hands to OrchestrationClient
+let capturedModuleConfigs: Array<Record<string, unknown>> = [];
+
+vi.mock('@sap-ai-sdk/orchestration', () => {
+  class MockOrchestrationClient {
+    constructor(
+      public _moduleConfig: Record<string, unknown>,
+      public _deploymentConfig: unknown
+    ) {
+      capturedModuleConfigs.push(_moduleConfig);
+    }
+
+    async chatCompletion(_params: { messages: unknown[] }) {
+      return {
+        getContent: () => 'ok',
+        getFinishReason: () => 'stop',
+        getTokenUsage: () => ({
+          completion_tokens: 1,
+          prompt_tokens: 1,
+          total_tokens: 2,
+        }),
+        getToolCalls: () => [],
+        getAllMessages: () => [],
+      };
+    }
+  }
+
+  return {
+    OrchestrationClient: MockOrchestrationClient,
+    OrchestrationEmbeddingClient: vi.fn(),
+    buildAzureContentSafetyFilter: vi.fn().mockReturnValue({}),
+    buildLlamaGuard38BFilter: vi.fn().mockReturnValue({}),
+    buildDpiMaskingProvider: vi.fn().mockReturnValue({}),
+    buildDocumentGroundingConfig: vi.fn().mockReturnValue({}),
+    buildTranslationConfig: vi.fn().mockReturnValue({}),
+  };
+});
+
+vi.mock('../../src/config/env.js', () => ({
+  env: vi.fn((key: string) => {
+    if (key === 'AICORE_RESOURCE_GROUP') {
+      return 'default';
+    }
+    return undefined;
+  }),
+}));
+
+import { SapOrchestrationProvider } from '../../src/providers/sapOrchestration.js';
+
+type ModuleConfigShape = {
+  promptTemplating?: {
+    model?: {
+      name?: string;
+      version?: string;
+      params?: Record<string, unknown>;
+    };
+  };
+};
+
+function getModelParams(mc: Record<string, unknown>): Record<string, unknown> {
+  const model = (mc as ModuleConfigShape).promptTemplating?.model;
+  return (model?.params ?? {}) as Record<string, unknown>;
+}
+
+describe('SapOrchestrationProvider top_k plumbing', () => {
+  beforeEach(() => {
+    capturedModuleConfigs = [];
+  });
+
+  it('passes per-call topK into modelParams.top_k', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-4.7-opus',
+      deploymentId: 'test-deployment',
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }], { topK: 40 });
+
+    expect(capturedModuleConfigs).toHaveLength(1);
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect(modelParams.top_k).toBe(40);
+  });
+
+  it('falls back to config.topK when per-call topK is omitted', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-4.7-opus',
+      deploymentId: 'test-deployment',
+      topK: 25,
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }]);
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect(modelParams.top_k).toBe(25);
+  });
+
+  it('lets per-call topK override config.topK', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-4.7-opus',
+      deploymentId: 'test-deployment',
+      topK: 25,
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }], { topK: 80 });
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect(modelParams.top_k).toBe(80);
+  });
+
+  it('omits top_k from modelParams when neither config nor options set it', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'gpt-4o',
+      deploymentId: 'test-deployment',
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }]);
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect('top_k' in modelParams).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #818

## What

Adds `topK` to the SAP orchestration provider so users can control
top-k sampling on Anthropic Claude deployments through both
`OrchestrationConfig` and per-call `CompletionOptions`. Mirrors the
existing `topP` plumbing.

## Changes

- `src/providers/sapOrchestration.ts`
  - `OrchestrationConfig.topK?: number`
  - `CompletionOptions.topK?: number`
  - `buildModuleConfig` emits `modelParams.top_k` when set on either
    the config or per-call options, per-call taking precedence.
- `docs/PROVIDERS.md` adds a Model Parameters table documenting the
  new field and its model-family compatibility (Anthropic Claude honors
  it, OpenAI-family deployments drop it silently).
- `tests/providers/sapOrchestration-topK.test.ts` covers four cases:
  per-call only, config only, per-call overrides config, and `top_k`
  absent from `modelParams` when neither is set.

## Verification

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm run test:coverage` — 191 files, 2697 passing
- `npm run build` — clean

No new `@ts-ignore`, `eslint-disable`, or `as any`.
No `.github/` or `package.json` version changes.

[alexi-bot]