### PR TITLE
feat(providers): add enforceStrictSchema for OpenAI Responses strict-mode

### DIFF
--- a/src/providers/transform.ts
+++ b/src/providers/transform.ts
@@ -247,6 +247,138 @@ export function sanitizeOpenAISchema(value: unknown): unknown {
   return result;
 }
 
+// ============================================================================
+// OpenAI Responses strict-mode schema enforcement
+// ============================================================================
+//
+// SAP-routed OpenAI Responses deployments (`gpt-5.5`, `gpt-nano`,
+// `claude-haiku`) enforce a strict-mode JSON Schema contract on function-tool
+// parameters when the tool is registered with `strict: true`:
+//
+//   - Every object node MUST set `additionalProperties: false`.
+//   - Every object node's `required` array MUST list every key declared in
+//     `properties` (no optional properties).
+//
+// `enforceStrictSchema` recursively rewrites a JSON Schema fragment to
+// satisfy that contract. It is intentionally narrow: only nodes that have
+// a `properties` key are treated as object nodes; leaves, refs, arrays,
+// and composition wrappers are recursed into but otherwise pass through.
+//
+// Like `sanitizeOpenAISchema`, this function NEVER mutates its input. It
+// always returns a new object so the same source schema can still be used
+// for non-strict deployments in the same process.
+//
+// Callers MUST gate on `strict === true` from the tool definition (issue
+// #856 threads the flag through `ToolDefinition`/`Tool`). Applying this
+// transform unconditionally would over-constrain anthropic-routed tools
+// that accept loose schemas and reject `additionalProperties: false`.
+
+/**
+ * Enforce the OpenAI Responses strict-mode contract on a JSON Schema
+ * fragment. For every object node (any node with a `properties` key) the
+ * returned schema will have:
+ *
+ *   - `additionalProperties: false`
+ *   - `required` containing every key declared in `properties`, in the
+ *     order the keys appear in `properties`
+ *
+ * Recursion targets:
+ *   - `properties` (each value)
+ *   - `items` (single schema or tuple form)
+ *   - `additionalProperties` when it is a schema (booleans pass through;
+ *     boolean values are overwritten by the `false` injection above when
+ *     the enclosing node is an object node)
+ *   - `anyOf` / `oneOf` / `allOf` (each element)
+ *   - `$defs` / `definitions` (each value)
+ *
+ * Pass-through cases (returned by reference for primitives, deep-copied
+ * for arrays / records):
+ *   - Primitives (`string`, `number`, `boolean`, `null`, `undefined`)
+ *   - Arrays (mapped element-wise into a new array)
+ *   - Object nodes WITHOUT a `properties` key (`$ref`-only, leaves with
+ *     just `type: 'string'`, etc.) — recursed into so nested objects are
+ *     still enforced, but the node itself is not given
+ *     `additionalProperties: false` because it is not an object schema.
+ *
+ * @param value - The JSON Schema fragment to enforce
+ * @returns A new schema value satisfying the strict-mode contract on every
+ *   object node, with all other nodes passed through unchanged
+ */
+export function enforceStrictSchema(value: unknown): unknown {
+  // Primitives (string, number, boolean, null, undefined) pass through.
+  if (!isPlainObject(value) && !Array.isArray(value)) {
+    return value;
+  }
+
+  // Arrays: recurse element-wise into a new array.
+  if (Array.isArray(value)) {
+    return value.map((item) => enforceStrictSchema(item));
+  }
+
+  // Plain object: recurse into every recognised schema-bearing keyword,
+  // copying the node so the input is never mutated. We always return a
+  // new object even when no field changes, to give callers a deep,
+  // reference-distinct copy they can mutate freely downstream.
+  const result: JsonRecord = {};
+
+  for (const [key, item] of Object.entries(value)) {
+    if (key === 'properties' && isPlainObject(item)) {
+      result.properties = Object.fromEntries(
+        Object.entries(item).map(([propKey, propValue]) => [
+          propKey,
+          enforceStrictSchema(propValue),
+        ])
+      );
+      continue;
+    }
+
+    if (key === 'items') {
+      // `items` may be a single schema or a tuple-form array of schemas.
+      result.items = enforceStrictSchema(item);
+      continue;
+    }
+
+    if (key === 'additionalProperties') {
+      // Schema form recurses; boolean form passes through. If this node
+      // also has `properties`, the boolean will be overwritten to `false`
+      // below.
+      result.additionalProperties = typeof item === 'boolean' ? item : enforceStrictSchema(item);
+      continue;
+    }
+
+    if ((key === 'anyOf' || key === 'oneOf' || key === 'allOf') && Array.isArray(item)) {
+      result[key] = item.map((branch) => enforceStrictSchema(branch));
+      continue;
+    }
+
+    if ((key === '$defs' || key === 'definitions') && isPlainObject(item)) {
+      result[key] = Object.fromEntries(
+        Object.entries(item).map(([defName, defValue]) => [defName, enforceStrictSchema(defValue)])
+      );
+      continue;
+    }
+
+    // All other keys (type, description, enum, format, $ref, minimum, ...)
+    // pass through verbatim. Arrays/objects buried inside unknown keywords
+    // are not recursed — the strict contract only governs schema-bearing
+    // keywords listed above.
+    result[key] = item;
+  }
+
+  // If this node is an object schema (has a `properties` key), enforce
+  // `additionalProperties: false` and `required = keys(properties)`.
+  // The presence of `properties` is the discriminant — a node with only
+  // `$ref`, only a primitive `type`, or only composition keywords is not
+  // an object schema and must NOT be augmented (over-constraining
+  // pass-through nodes would break the upstream Codex parity contract).
+  if (isPlainObject(result.properties)) {
+    result.additionalProperties = false;
+    result.required = Object.keys(result.properties);
+  }
+
+  return result;
+}
+
 /**
  * Provider metadata hint used to detect OpenAI-shaped tool-call wire formats.
  * Mirrors opencode's `Provider.Model.api.npm` shape so the same fixtures port

--- a/tests/providers/strict-schema.test.ts
+++ b/tests/providers/strict-schema.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for `enforceStrictSchema` in `src/providers/transform.ts`.
+ *
+ * `enforceStrictSchema` is the post-#856 lowering step that rewrites a
+ * JSON Schema fragment to satisfy the OpenAI Responses strict-mode
+ * contract on every object node:
+ *   - `additionalProperties: false`
+ *   - `required` lists every key in `properties`
+ *
+ * The transform is non-mutating and only fires on nodes that have a
+ * `properties` key — leaves, refs, arrays, and composition wrappers are
+ * recursed into but otherwise pass through. Callers gate on
+ * `strict === true` from the tool definition; this suite asserts the
+ * helper's intrinsic contract, not the gating site.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { enforceStrictSchema } from '../../src/providers/transform.js';
+
+describe('enforceStrictSchema - object nodes', () => {
+  it('adds additionalProperties:false and fills required from properties', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        recursive: { type: 'boolean' },
+      },
+    };
+    const result = enforceStrictSchema(input);
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        recursive: { type: 'boolean' },
+      },
+      additionalProperties: false,
+      required: ['path', 'recursive'],
+    });
+  });
+
+  it('overwrites an existing additionalProperties:true on an object node', () => {
+    const input = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      additionalProperties: true,
+    };
+    const result = enforceStrictSchema(input) as Record<string, unknown>;
+    expect(result.additionalProperties).toBe(false);
+  });
+
+  it('replaces an existing required list with every key in properties', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'number' },
+        c: { type: 'boolean' },
+      },
+      required: ['a'],
+    };
+    const result = enforceStrictSchema(input) as Record<string, unknown>;
+    expect(result.required).toEqual(['a', 'b', 'c']);
+  });
+
+  it('preserves property declaration order in required', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        z: { type: 'string' },
+        a: { type: 'string' },
+        m: { type: 'string' },
+      },
+    };
+    const result = enforceStrictSchema(input) as Record<string, unknown>;
+    expect(result.required).toEqual(['z', 'a', 'm']);
+  });
+
+  it('emits required:[] when properties is an empty object', () => {
+    const input = { type: 'object', properties: {} };
+    const result = enforceStrictSchema(input);
+    expect(result).toEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+      required: [],
+    });
+  });
+});
+
+describe('enforceStrictSchema - recursion', () => {
+  it('recurses into nested object properties', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        outer: {
+          type: 'object',
+          properties: {
+            inner: { type: 'string' },
+          },
+        },
+      },
+    };
+    const result = enforceStrictSchema(input) as {
+      properties: { outer: Record<string, unknown> };
+    };
+    expect(result.properties.outer).toEqual({
+      type: 'object',
+      properties: { inner: { type: 'string' } },
+      additionalProperties: false,
+      required: ['inner'],
+    });
+  });
+
+  it('recurses into array `items` that is itself an object schema', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              key: { type: 'string' },
+              value: { type: 'string' },
+            },
+          },
+        },
+      },
+    };
+    const result = enforceStrictSchema(input) as {
+      properties: { tags: { items: Record<string, unknown> } };
+    };
+    expect(result.properties.tags.items).toEqual({
+      type: 'object',
+      properties: {
+        key: { type: 'string' },
+        value: { type: 'string' },
+      },
+      additionalProperties: false,
+      required: ['key', 'value'],
+    });
+  });
+
+  it('recurses into tuple-form `items` array of object schemas', () => {
+    const input = {
+      type: 'array',
+      items: [
+        { type: 'object', properties: { a: { type: 'string' } } },
+        { type: 'object', properties: { b: { type: 'number' } } },
+      ],
+    };
+    const result = enforceStrictSchema(input) as { items: Record<string, unknown>[] };
+    expect(result.items[0]).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      additionalProperties: false,
+      required: ['a'],
+    });
+    expect(result.items[1]).toEqual({
+      type: 'object',
+      properties: { b: { type: 'number' } },
+      additionalProperties: false,
+      required: ['b'],
+    });
+  });
+
+  it('recurses into each branch of a oneOf union of object schemas', () => {
+    const input = {
+      oneOf: [
+        { type: 'object', properties: { kind: { type: 'string' }, value: { type: 'string' } } },
+        { type: 'object', properties: { kind: { type: 'string' }, count: { type: 'number' } } },
+      ],
+    };
+    const result = enforceStrictSchema(input) as { oneOf: Record<string, unknown>[] };
+    expect(result.oneOf[0]).toMatchObject({
+      additionalProperties: false,
+      required: ['kind', 'value'],
+    });
+    expect(result.oneOf[1]).toMatchObject({
+      additionalProperties: false,
+      required: ['kind', 'count'],
+    });
+  });
+
+  it('recurses into anyOf and allOf branches', () => {
+    const input = {
+      anyOf: [{ type: 'object', properties: { a: { type: 'string' } } }],
+      allOf: [{ type: 'object', properties: { b: { type: 'string' } } }],
+    };
+    const result = enforceStrictSchema(input) as {
+      anyOf: Record<string, unknown>[];
+      allOf: Record<string, unknown>[];
+    };
+    expect(result.anyOf[0]).toMatchObject({
+      additionalProperties: false,
+      required: ['a'],
+    });
+    expect(result.allOf[0]).toMatchObject({
+      additionalProperties: false,
+      required: ['b'],
+    });
+  });
+
+  it('recurses into $defs and definitions values', () => {
+    const input = {
+      $defs: {
+        Point: {
+          type: 'object',
+          properties: { x: { type: 'number' }, y: { type: 'number' } },
+        },
+      },
+      definitions: {
+        Label: {
+          type: 'object',
+          properties: { text: { type: 'string' } },
+        },
+      },
+    };
+    const result = enforceStrictSchema(input) as {
+      $defs: { Point: Record<string, unknown> };
+      definitions: { Label: Record<string, unknown> };
+    };
+    expect(result.$defs.Point).toMatchObject({
+      additionalProperties: false,
+      required: ['x', 'y'],
+    });
+    expect(result.definitions.Label).toMatchObject({
+      additionalProperties: false,
+      required: ['text'],
+    });
+  });
+
+  it('recurses into additionalProperties when it is itself a schema', () => {
+    // A node with `additionalProperties` (schema form) but no `properties`
+    // is NOT treated as an object node, so the recursed schema is what we
+    // assert on. (The enclosing node remains pass-through-shaped.)
+    const input = {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        properties: { inner: { type: 'string' } },
+      },
+    };
+    const result = enforceStrictSchema(input) as {
+      additionalProperties: Record<string, unknown>;
+    };
+    expect(result.additionalProperties).toEqual({
+      type: 'object',
+      properties: { inner: { type: 'string' } },
+      additionalProperties: false,
+      required: ['inner'],
+    });
+  });
+});
+
+describe('enforceStrictSchema - pass-through cases', () => {
+  it('passes through a plain string-leaf schema unchanged', () => {
+    const input = { type: 'string', description: 'a leaf' };
+    const result = enforceStrictSchema(input);
+    expect(result).toEqual({ type: 'string', description: 'a leaf' });
+  });
+
+  it('passes through a number-leaf schema with range keywords unchanged', () => {
+    const input = { type: 'number', minimum: 0, maximum: 100 };
+    const result = enforceStrictSchema(input);
+    expect(result).toEqual({ type: 'number', minimum: 0, maximum: 100 });
+  });
+
+  it('passes through a $ref-only node without injecting additionalProperties', () => {
+    const input = { $ref: '#/$defs/Point' };
+    const result = enforceStrictSchema(input) as Record<string, unknown>;
+    expect(result).toEqual({ $ref: '#/$defs/Point' });
+    expect(result.additionalProperties).toBeUndefined();
+    expect(result.required).toBeUndefined();
+  });
+
+  it('passes through primitives (boolean, number, string, null) untouched', () => {
+    expect(enforceStrictSchema(true)).toBe(true);
+    expect(enforceStrictSchema(false)).toBe(false);
+    expect(enforceStrictSchema(42)).toBe(42);
+    expect(enforceStrictSchema('text')).toBe('text');
+    expect(enforceStrictSchema(null)).toBe(null);
+    expect(enforceStrictSchema(undefined)).toBe(undefined);
+  });
+
+  it('does NOT inject additionalProperties on a node without properties', () => {
+    // An object schema that declares `type: 'object'` but has no
+    // `properties` (e.g. a free-form map) is intentionally NOT augmented
+    // — the strict contract only governs declared property keys.
+    const input = { type: 'object' };
+    const result = enforceStrictSchema(input) as Record<string, unknown>;
+    expect(result).toEqual({ type: 'object' });
+    expect(result.additionalProperties).toBeUndefined();
+    expect(result.required).toBeUndefined();
+  });
+});
+
+describe('enforceStrictSchema - non-mutation', () => {
+  it('returns a new top-level object (reference inequality)', () => {
+    const input = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    const result = enforceStrictSchema(input);
+    expect(result).not.toBe(input);
+  });
+
+  it('returns new nested objects (reference inequality at every level)', () => {
+    const inner = { type: 'string' as const };
+    const outer = {
+      type: 'object',
+      properties: { name: inner },
+    };
+    const result = enforceStrictSchema(outer) as {
+      properties: { name: unknown };
+    };
+    expect(result.properties).not.toBe(outer.properties);
+    expect(result.properties.name).not.toBe(inner);
+  });
+
+  it('does not mutate the input properties record', () => {
+    const input = {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    };
+    const snapshot = JSON.stringify(input);
+    enforceStrictSchema(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
+    expect('additionalProperties' in input).toBe(false);
+    expect('required' in input).toBe(false);
+  });
+
+  it('does not mutate input arrays', () => {
+    const input = {
+      anyOf: [
+        { type: 'object', properties: { a: { type: 'string' } } },
+        { type: 'object', properties: { b: { type: 'number' } } },
+      ],
+    };
+    const originalLength = input.anyOf.length;
+    const originalFirst = input.anyOf[0];
+    const result = enforceStrictSchema(input) as { anyOf: unknown[] };
+    expect(input.anyOf.length).toBe(originalLength);
+    expect(input.anyOf[0]).toBe(originalFirst);
+    expect(result.anyOf).not.toBe(input.anyOf);
+    expect(result.anyOf[0]).not.toBe(input.anyOf[0]);
+  });
+});
+
+describe('enforceStrictSchema - gate sanity', () => {
+  // These tests document the caller-side gating contract: the call site
+  // that consumes the #856 `strict` flag MUST gate on `strict === true`
+  // before invoking `enforceStrictSchema`. The helper itself has no
+  // notion of the flag — it simply enforces strict-mode unconditionally
+  // on any object node it walks. The two tests below simulate the gate
+  // by NOT calling the helper at all, which is the same behaviour
+  // callers must produce when `strict !== true`.
+  it('a strict:undefined caller emits the schema verbatim (no helper call)', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    // Simulate caller gate: `strict === true` is false, so we do NOT call
+    // enforceStrictSchema. The emitted schema is the input verbatim.
+    const strict: boolean | undefined = undefined;
+    const emitted = strict === true ? enforceStrictSchema(schema) : schema;
+    expect(emitted).toBe(schema);
+    expect('additionalProperties' in (emitted as object)).toBe(false);
+  });
+
+  it('a strict:false caller emits the schema verbatim (no helper call)', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    const strict = false;
+    const emitted = strict === true ? enforceStrictSchema(schema) : schema;
+    expect(emitted).toBe(schema);
+    expect('additionalProperties' in (emitted as object)).toBe(false);
+  });
+
+  it('a strict:true caller emits the enforced schema (helper applied)', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    const strict = true;
+    const emitted = strict === true ? enforceStrictSchema(schema) : schema;
+    expect(emitted).not.toBe(schema);
+    expect(emitted).toMatchObject({
+      additionalProperties: false,
+      required: ['name'],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add `enforceStrictSchema(value: unknown): unknown` to
`src/providers/transform.ts` — the post-#856 lowering pass that
satisfies the OpenAI Responses strict-mode JSON Schema contract on
function-tool parameters.

For every object node (any node with a `properties` key) the returned
schema gets:

- `additionalProperties: false`
- `required` listing every key declared in `properties` (in declaration
  order)

The helper is non-mutating: it deep-copies at every level so the same
source schema can still be used for non-strict deployments in the same
process. Recursion covers `properties`, `items` (single + tuple form),
`additionalProperties` (schema form), `anyOf`/`oneOf`/`allOf`, and
`\$defs`/`definitions`. Nodes WITHOUT a `properties` key (`\$ref`-only,
primitive leaves, free-form object maps) are recursed into but NOT
augmented with `additionalProperties: false` — that would over-constrain
pass-through nodes and break the upstream Codex parity contract.

## Why now / dependency on #856

Issue #859 is explicitly scoped as the post-#856 enforcement layer.
It is BLOCKED on #856, which threads an optional `strict?: boolean`
flag through `ToolDefinition`/`Tool`/`createTool`/`setTools`. #856 is
currently OPEN and not yet implemented.

The call-site integration described in the issue (\"wrap `parameters`
with `enforceStrictSchema(parameters)` iff `strict === true` at the
`createTool` / `setTools` site\") has no surface to attach to until
#856 lands, because the `strict` flag does not yet exist on the tool
surface. Adding the call-site code without #856 would either silently
do nothing (no caller sets `strict`) or require inventing a parallel
flag that #856 would then have to reconcile.

This PR therefore lands the **self-contained, independently reviewable
half**: the pure helper plus its full test suite. Once #856 merges,
wiring the helper in is a one-line conditional spread:

```ts
// in createTool / setTools
parameters: tool.strict === true
  ? enforceStrictSchema(tool.parameters)
  : tool.parameters,
```

A follow-up will land that wiring as part of #859's closure.

## Before / after

**Before** (current zodToJsonSchema output for a tool with two props):

```json
{
  \"type\": \"object\",
  \"properties\": {
    \"path\":      { \"type\": \"string\" },
    \"recursive\": { \"type\": \"boolean\" }
  },
  \"required\": [\"path\"]
}
```

SAP-routed gpt-5.5 / gpt-nano / claude-haiku reject this with
\`Invalid schema: object schema missing additionalProperties: false\`.

**After** (`enforceStrictSchema` applied):

```json
{
  \"type\": \"object\",
  \"properties\": {
    \"path\":      { \"type\": \"string\" },
    \"recursive\": { \"type\": \"boolean\" }
  },
  \"additionalProperties\": false,
  \"required\": [\"path\", \"recursive\"]
}
```

Accepted by every OpenAI-shaped SAP deployment.

## Tests (24 cases, all green)

`tests/providers/strict-schema.test.ts`:

- Object nodes: adds `additionalProperties:false`, fills `required`
  with all property keys, overwrites existing `additionalProperties:true`,
  replaces existing partial `required`, preserves property declaration
  order, handles empty `properties` (emits `required: []`).
- Recursion: nested objects, array `items` of object schemas, tuple-form
  `items` array, `oneOf`/`anyOf`/`allOf` branches each enforced,
  `\$defs`/`definitions` each enforced, `additionalProperties` schema
  form recursed.
- Pass-through: string-leaf / number-leaf with range keywords,
  `\$ref`-only node (no `additionalProperties` injected), primitives
  (`true`/`false`/`42`/`'text'`/`null`/`undefined`), `type: 'object'`
  without `properties` (NOT augmented).
- Non-mutation: top-level reference inequality, nested reference
  inequality at every level, input properties record unchanged, input
  arrays unchanged.
- Gate sanity: simulates the caller-side gate for `strict ∈
  {undefined, false, true}` — only `strict === true` produces an
  enforced schema; the other two values leave the input verbatim.

## Gate

```
npm run lint          # 0 errors (1276 pre-existing warnings, unrelated)
npm run typecheck     # clean
npm run format:check  # all files formatted
npm test              # 196 files, 2770 passed
npm run build         # dist/ emitted
```

Coverage delta: +24 tests on a file that already had broad coverage;
global lines coverage is 62.18% (well above the 40% CI gate).

## Constraints honoured

- No \`.github/\` changes.
- No \`package.json\` version bump.
- No \`eslint-disable\` / \`@ts-ignore\` / \`as any\`.
- No new dependencies.
- No edits to \`zodToJsonSchema\` (per issue: \"Do NOT apply at the
  zodToJsonSchema layer\").
- No edits to \`src/tool/index.ts\` (per issue: \"#856 already owns
  that surface\").

Closes #859 once the #856-dependent call-site wiring lands in a
follow-up PR.

[alexi-bot]