### PR TITLE
feat(core): auto-disable routes after N consecutive permanent failures (#863)

### DIFF
--- a/routing-config.example.json
+++ b/routing-config.example.json
@@ -80,6 +80,7 @@
     "defaultCostTier": "medium",
     "preferCheapWhenPossible": false,
     "maxCostPerRequest": null,
-    "fallbackModel": "gpt-4o"
+    "fallbackModel": "gpt-4o",
+    "routeFailureThreshold": 3
   }
 }

--- a/src/config/routingConfig.ts
+++ b/src/config/routingConfig.ts
@@ -27,6 +27,12 @@ export interface RoutingPreferences {
   preferCheapWhenPossible: boolean;
   maxCostPerRequest: number | null;
   fallbackModel: string;
+  /**
+   * Number of consecutive permanent failures (401/403/404, model_not_found,
+   * deployment_not_found) on the same route before it is auto-disabled for
+   * the rest of the session. Transient failures do NOT count. Defaults to 3.
+   */
+  routeFailureThreshold?: number;
 }
 
 export interface RoutingConfig {
@@ -95,6 +101,7 @@ const DEFAULT_CONFIG: RoutingConfig = {
     preferCheapWhenPossible: false,
     maxCostPerRequest: null,
     fallbackModel: 'gpt-4o',
+    routeFailureThreshold: 3,
   },
 };
 

--- a/src/core/__tests__/agenticChat.test.ts
+++ b/src/core/__tests__/agenticChat.test.ts
@@ -31,6 +31,8 @@ vi.mock('../router.js', () => ({
     reason: 'test routing',
     confidence: 0.9,
   })),
+  recordRouteOutcome: vi.fn(),
+  classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
 }));
 
 // Mock the cost tracker

--- a/src/core/agenticChat.ts
+++ b/src/core/agenticChat.ts
@@ -10,7 +10,7 @@
  */
 
 import { getProviderForModelWithFallback, getDefaultModel } from '../providers/index.js';
-import { routePrompt } from './router.js';
+import { routePrompt, recordRouteOutcome, classifyRouteError } from './router.js';
 import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
 import { getToolRegistry, type ToolContext, type ToolResult } from '../tool/index.js';
@@ -570,6 +570,7 @@ export async function agenticChat(
         maxTokens: effortConfig.maxTokens,
         tools: isFinalTurn ? undefined : toolSchemas.length > 0 ? toolSchemas : undefined,
       });
+      recordRouteOutcome(modelId, { kind: 'success' });
     } catch (err) {
       // Detect context overflow and attempt compaction with reactive seeding
       const compactionMessages = messages
@@ -601,14 +602,29 @@ export async function agenticChat(
           messages.push(...compactedMessages);
 
           // Retry the completion
-          result = await provider.complete(messages as Array<{ role: string; content: string }>, {
-            maxTokens: effortConfig.maxTokens,
-            tools: isFinalTurn ? undefined : toolSchemas.length > 0 ? toolSchemas : undefined,
-          });
+          try {
+            result = await provider.complete(messages as Array<{ role: string; content: string }>, {
+              maxTokens: effortConfig.maxTokens,
+              tools: isFinalTurn ? undefined : toolSchemas.length > 0 ? toolSchemas : undefined,
+            });
+            recordRouteOutcome(modelId, { kind: 'success' });
+          } catch (retryErr) {
+            const classified = classifyRouteError(retryErr);
+            if (classified.kind === 'permanent') {
+              recordRouteOutcome(modelId, classified);
+            }
+            throw retryErr;
+          }
         } else {
           throw err;
         }
       } else {
+        // Not a context-overflow error: this is the real provider failure.
+        // Record permanent failures so the route can auto-disable.
+        const classified = classifyRouteError(err);
+        if (classified.kind === 'permanent') {
+          recordRouteOutcome(modelId, classified);
+        }
         throw err;
       }
     }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,5 +1,5 @@
 import { getProviderForModelWithFallback, getDefaultModel } from '../providers/index.js';
-import { routePrompt } from './router.js';
+import { routePrompt, recordRouteOutcome, classifyRouteError } from './router.js';
 import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
 
@@ -68,8 +68,22 @@ export async function sendChat(
     modelId = resolution.effectiveModelId;
   }
 
-  // Use SAP Orchestration complete() method
-  const result = await provider.complete(messages, { maxTokens: 4096 });
+  // Use SAP Orchestration complete() method.
+  // Record route outcome for auto-disable bookkeeping: permanent failures
+  // (401/403/404, model_not_found, deployment_not_found) tick the route's
+  // failure counter; success resets it. Transient errors are owned by
+  // ErrorBackoff and are intentionally NOT recorded here.
+  let result;
+  try {
+    result = await provider.complete(messages, { maxTokens: 4096 });
+  } catch (err) {
+    const classified = classifyRouteError(err);
+    if (classified.kind === 'permanent') {
+      recordRouteOutcome(modelId, classified);
+    }
+    throw err;
+  }
+  recordRouteOutcome(modelId, { kind: 'success' });
 
   const responseText = result.text;
   const usage = result.usage;

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -8,6 +8,8 @@ import {
   findMatchingRule,
   type RoutingConfig,
 } from '../config/routingConfig.js';
+import { extractStatusCode } from './error-backoff.js';
+import { c } from '../cli/utils/colors.js';
 
 export interface ModelCapability {
   id: string;
@@ -40,6 +42,108 @@ function getModelRegistry(): ModelCapability[] {
   return getConfig().models.filter(
     (m) => (m as ModelCapability & { enabled?: boolean }).enabled !== false
   );
+}
+
+// ---------------------------------------------------------------------------
+// Route auto-disable state (in-process only; NOT persisted to ~/.alexi/).
+// A route accumulates consecutive permanent failures (401/403/404 or
+// model_not_found / deployment_not_found). When the count reaches the
+// configured threshold, the route is marked disabled for the rest of the
+// session and routePrompt() filters it out of the candidate list. A single
+// success outcome resets the counter. Transient failures (5xx, network)
+// remain owned by ErrorBackoff and must NOT call recordRouteOutcome with
+// kind === 'permanent'.
+// ---------------------------------------------------------------------------
+
+interface RouteState {
+  count: number;
+  disabled: boolean;
+}
+
+const routeFailureState = new Map<string, RouteState>();
+
+function getRouteFailureThreshold(): number {
+  return getConfig().preferences.routeFailureThreshold ?? 3;
+}
+
+/**
+ * Classify a thrown error for the purpose of route auto-disable. Returns
+ * `permanent` when the error is a 401/403/404 from the provider OR the
+ * message contains `model_not_found` / `deployment_not_found` (case
+ * insensitive, on word boundaries). All other errors -- including 5xx,
+ * network, and unknown shapes -- are NOT classified here; callers should
+ * skip recordRouteOutcome for those and let ErrorBackoff manage them.
+ */
+export function classifyRouteError(
+  err: unknown
+): { kind: 'permanent'; statusCode?: number; reason?: string } | { kind: 'unknown' } {
+  const message = err instanceof Error ? err.message : String(err);
+  const statusCode = extractStatusCode(message);
+
+  if (statusCode === 401 || statusCode === 403 || statusCode === 404) {
+    return { kind: 'permanent', statusCode, reason: `HTTP ${statusCode}` };
+  }
+
+  if (/\bmodel_not_found\b/i.test(message)) {
+    return { kind: 'permanent', reason: 'model_not_found' };
+  }
+  if (/\bdeployment_not_found\b/i.test(message)) {
+    return { kind: 'permanent', reason: 'deployment_not_found' };
+  }
+
+  return { kind: 'unknown' };
+}
+
+/**
+ * Record the outcome of a provider call for the given route. `success` resets
+ * the consecutive-failure counter. `permanent` increments it and, when the
+ * threshold is reached, disables the route and prints a one-line yellow
+ * warning. Transient failures should NOT be recorded here.
+ */
+export function recordRouteOutcome(
+  modelId: string,
+  outcome: { kind: 'success' } | { kind: 'permanent'; statusCode?: number; reason?: string }
+): void {
+  if (outcome.kind === 'success') {
+    routeFailureState.set(modelId, { count: 0, disabled: false });
+    return;
+  }
+
+  const prev = routeFailureState.get(modelId) ?? { count: 0, disabled: false };
+  // Once disabled, do not keep growing the counter or re-emit warnings.
+  if (prev.disabled) {
+    return;
+  }
+
+  const nextCount = prev.count + 1;
+  const threshold = getRouteFailureThreshold();
+  if (nextCount >= threshold) {
+    routeFailureState.set(modelId, { count: nextCount, disabled: true });
+    const why = outcome.reason ? ` (${outcome.reason})` : '';
+    console.warn(
+      c(
+        'yellow',
+        `[Router] Auto-disabling '${modelId}' after ${nextCount} permanent failures${why}`
+      )
+    );
+    return;
+  }
+
+  routeFailureState.set(modelId, { count: nextCount, disabled: false });
+}
+
+/**
+ * Returns true if the route has been auto-disabled this session.
+ */
+export function isRouteDisabled(modelId: string): boolean {
+  return routeFailureState.get(modelId)?.disabled === true;
+}
+
+/**
+ * Reset all route failure state. Called by tests and by reloadConfig().
+ */
+export function resetRouteFailures(): void {
+  routeFailureState.clear();
 }
 
 /**
@@ -212,6 +316,20 @@ export function routePrompt(
   if (options?.availableModels) {
     candidates = candidates.filter((m) => options.availableModels!.includes(m.id));
   }
+  // Drop routes that have been auto-disabled this session.
+  candidates = candidates.filter((m) => !isRouteDisabled(m.id));
+
+  // Pathological case: every candidate has been auto-disabled. Fall back to
+  // the configured fallbackModel with low confidence instead of throwing, so
+  // the caller can still attempt a request (and the user can /reload).
+  if (candidates.length === 0) {
+    return {
+      modelId: config.preferences.fallbackModel,
+      reason: 'All routes auto-disabled this session; using configured fallback',
+      confidence: 0.1,
+      ruleApplied: matchedRule?.name,
+    };
+  }
 
   // Score each model
   const preferCheap = options?.preferCheap ?? config.preferences.preferCheapWhenPossible;
@@ -308,4 +426,5 @@ export async function explainRouting(prompt: string): Promise<{
  */
 export function reloadConfig(): void {
   routingConfig = null;
+  resetRouteFailures();
 }

--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -8,7 +8,7 @@ import {
   getDefaultModel,
   type StreamChunk,
 } from '../providers/index.js';
-import { routePrompt } from './router.js';
+import { routePrompt, recordRouteOutcome, classifyRouteError } from './router.js';
 import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
 import { type EffortLevel, getEffortConfig, DEFAULT_EFFORT } from './effortLevel.js';
@@ -139,17 +139,29 @@ export async function* streamChat(
   let fullText = '';
   let finalUsage: StreamingResult['usage'];
 
-  // Stream using SAP Orchestration provider
-  for await (const chunk of provider.streamComplete(messages, {
-    maxTokens: options?.maxTokens ?? effortConfig.maxTokens,
-    temperature: options?.temperature,
-    signal: options?.signal,
-    headers: extraHeaders as Record<string, string>,
-  })) {
-    fullText += chunk.text;
-    if (chunk.usage) finalUsage = chunk.usage;
-    yield chunk;
+  // Stream using SAP Orchestration provider. Wrap so permanent failures
+  // (401/403/404, model_not_found, deployment_not_found) tick the route's
+  // auto-disable counter; success resets it. Transient errors are left to
+  // ErrorBackoff.
+  try {
+    for await (const chunk of provider.streamComplete(messages, {
+      maxTokens: options?.maxTokens ?? effortConfig.maxTokens,
+      temperature: options?.temperature,
+      signal: options?.signal,
+      headers: extraHeaders as Record<string, string>,
+    })) {
+      fullText += chunk.text;
+      if (chunk.usage) finalUsage = chunk.usage;
+      yield chunk;
+    }
+  } catch (err) {
+    const classified = classifyRouteError(err);
+    if (classified.kind === 'permanent') {
+      recordRouteOutcome(modelId, classified);
+    }
+    throw err;
   }
+  recordRouteOutcome(modelId, { kind: 'success' });
 
   // Save messages to session AFTER streaming completes (not per-chunk)
   if (options?.sessionManager) {

--- a/tests/core/agenticChat.permissionLeak.test.ts
+++ b/tests/core/agenticChat.permissionLeak.test.ts
@@ -36,6 +36,8 @@ vi.mock('../../src/core/router.js', () => ({
     reason: 'test routing',
     confidence: 0.9,
   })),
+  recordRouteOutcome: vi.fn(),
+  classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
 }));
 
 vi.mock('../../src/core/costTracker.js', () => ({

--- a/tests/core/router-autodisable.test.ts
+++ b/tests/core/router-autodisable.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for the route auto-disable feature in src/core/router.ts.
+ *
+ * Covers:
+ *  - N consecutive permanent (4xx / model_not_found) failures disable a route.
+ *  - Transient (5xx) failures are NOT classified as permanent and do not count.
+ *  - A success outcome between two failures resets the counter.
+ *  - When all candidates are disabled, routePrompt falls back to
+ *    preferences.fallbackModel with confidence 0.1 (does NOT throw).
+ *  - The yellow warning is printed exactly once on first disable.
+ *  - resetRouteFailures() re-enables a disabled route.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { RoutingConfig } from '../../src/config/routingConfig.js';
+import type { ModelCapability } from '../../src/core/router.js';
+
+vi.mock('../../src/config/routingConfig.js', () => ({
+  loadRoutingConfig: vi.fn(),
+  findMatchingRule: vi.fn(),
+  evaluateRule: vi.fn(),
+}));
+
+import {
+  routePrompt,
+  reloadConfig,
+  recordRouteOutcome,
+  isRouteDisabled,
+  resetRouteFailures,
+  classifyRouteError,
+} from '../../src/core/router.js';
+import { loadRoutingConfig, findMatchingRule } from '../../src/config/routingConfig.js';
+
+describe('Router auto-disable', () => {
+  const models: ModelCapability[] = [
+    {
+      id: 'primary-model',
+      type: 'openai',
+      costTier: 'medium',
+      strengths: ['general-qa', 'coding'],
+      maxTokens: 8192,
+      reasoning: false,
+    },
+    {
+      id: 'secondary-model',
+      type: 'openai',
+      costTier: 'cheap',
+      strengths: ['general-qa', 'simple-qa'],
+      maxTokens: 4096,
+      reasoning: false,
+    },
+  ];
+
+  const baseConfig: RoutingConfig = {
+    models,
+    rules: [],
+    preferences: {
+      preferCheapWhenPossible: false,
+      defaultCostTier: 'medium',
+      maxCostPerRequest: null,
+      fallbackModel: 'fallback-model',
+      routeFailureThreshold: 3,
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(loadRoutingConfig).mockReturnValue(baseConfig);
+    vi.mocked(findMatchingRule).mockReturnValue(null);
+    reloadConfig();
+    resetRouteFailures();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    resetRouteFailures();
+  });
+
+  describe('classifyRouteError', () => {
+    it('classifies 401 / 403 / 404 status codes as permanent', () => {
+      for (const code of [401, 403, 404]) {
+        const c = classifyRouteError(new Error(`Request failed with status: ${code}`));
+        expect(c.kind).toBe('permanent');
+        if (c.kind === 'permanent') {
+          expect(c.statusCode).toBe(code);
+        }
+      }
+    });
+
+    it('classifies model_not_found / deployment_not_found as permanent', () => {
+      const a = classifyRouteError(new Error('model_not_found: gpt-9'));
+      const b = classifyRouteError(new Error('deployment_not_found for foo'));
+      expect(a.kind).toBe('permanent');
+      expect(b.kind).toBe('permanent');
+    });
+
+    it('does NOT classify 5xx or network errors as permanent', () => {
+      expect(classifyRouteError(new Error('status: 503 service unavailable')).kind).toBe('unknown');
+      expect(classifyRouteError(new Error('ECONNRESET socket hang up')).kind).toBe('unknown');
+      expect(classifyRouteError(new Error('status: 500 internal')).kind).toBe('unknown');
+    });
+
+    it('tolerates non-Error throwables', () => {
+      expect(classifyRouteError('weird string').kind).toBe('unknown');
+      expect(classifyRouteError(undefined).kind).toBe('unknown');
+      expect(classifyRouteError({ msg: 'no' }).kind).toBe('unknown');
+    });
+  });
+
+  describe('recordRouteOutcome + isRouteDisabled', () => {
+    it('disables a route after 3 consecutive permanent failures (default threshold)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      expect(isRouteDisabled('primary-model')).toBe(false);
+
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      expect(isRouteDisabled('primary-model')).toBe(false);
+
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      expect(isRouteDisabled('primary-model')).toBe(true);
+
+      // Warning printed exactly once on first disable
+      expect(warn).toHaveBeenCalledTimes(1);
+      const arg = String(warn.mock.calls[0][0]);
+      expect(arg).toContain('primary-model');
+      expect(arg).toContain('3');
+
+      // Additional permanent outcomes after disable must NOT re-emit warnings
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 403 });
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      warn.mockRestore();
+    });
+
+    it('a success outcome resets the counter (2 fails + success + 2 fails -> not disabled)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      expect(isRouteDisabled('primary-model')).toBe(false);
+
+      recordRouteOutcome('primary-model', { kind: 'success' });
+      expect(isRouteDisabled('primary-model')).toBe(false);
+
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      expect(isRouteDisabled('primary-model')).toBe(false);
+      expect(warn).not.toHaveBeenCalled();
+
+      warn.mockRestore();
+    });
+
+    it('resetRouteFailures() re-enables a disabled route', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      for (let i = 0; i < 3; i++) {
+        recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      }
+      expect(isRouteDisabled('primary-model')).toBe(true);
+
+      resetRouteFailures();
+      expect(isRouteDisabled('primary-model')).toBe(false);
+
+      warn.mockRestore();
+    });
+  });
+
+  describe('routePrompt filtering', () => {
+    it('routes around a disabled model', () => {
+      // Disable primary-model
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      for (let i = 0; i < 3; i++) {
+        recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      }
+      warn.mockRestore();
+
+      const decision = routePrompt('Write a function to sort an array');
+      expect(decision.modelId).not.toBe('primary-model');
+      expect(decision.modelId).toBe('secondary-model');
+    });
+
+    it('returns the configured fallback model with confidence 0.1 when ALL routes are disabled', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      for (let i = 0; i < 3; i++) {
+        recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      }
+      for (let i = 0; i < 3; i++) {
+        recordRouteOutcome('secondary-model', { kind: 'permanent', statusCode: 403 });
+      }
+
+      const decision = routePrompt('Write a function to sort an array');
+      expect(decision.modelId).toBe('fallback-model');
+      expect(decision.confidence).toBe(0.1);
+      expect(decision.reason.toLowerCase()).toContain('disabled');
+
+      warn.mockRestore();
+    });
+
+    it('does not throw when all routes are disabled', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      for (let i = 0; i < 3; i++) {
+        recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      }
+      for (let i = 0; i < 3; i++) {
+        recordRouteOutcome('secondary-model', { kind: 'permanent', statusCode: 403 });
+      }
+
+      expect(() => routePrompt('anything')).not.toThrow();
+
+      warn.mockRestore();
+    });
+
+    it('3 consecutive transient (503) outcomes do NOT disable the route', () => {
+      // Transient errors should not be passed to recordRouteOutcome with
+      // kind === 'permanent'. Simulate the orchestrator's call site by going
+      // through classifyRouteError first.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      for (let i = 0; i < 3; i++) {
+        const classified = classifyRouteError(new Error('status: 503 service unavailable'));
+        if (classified.kind === 'permanent') {
+          recordRouteOutcome('primary-model', classified);
+        }
+      }
+
+      expect(isRouteDisabled('primary-model')).toBe(false);
+      expect(warn).not.toHaveBeenCalled();
+
+      const decision = routePrompt('Write a function');
+      // primary-model should still be selectable
+      expect(decision.modelId === 'primary-model' || decision.modelId === 'secondary-model').toBe(
+        true
+      );
+
+      warn.mockRestore();
+    });
+  });
+
+  describe('threshold override via config', () => {
+    it('honors a custom routeFailureThreshold from config', () => {
+      vi.mocked(loadRoutingConfig).mockReturnValue({
+        ...baseConfig,
+        preferences: { ...baseConfig.preferences, routeFailureThreshold: 2 },
+      });
+      reloadConfig();
+      resetRouteFailures();
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      expect(isRouteDisabled('primary-model')).toBe(false);
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      expect(isRouteDisabled('primary-model')).toBe(true);
+      expect(warn).toHaveBeenCalledTimes(1);
+      warn.mockRestore();
+    });
+
+    it('defaults to threshold 3 when routeFailureThreshold is absent', () => {
+      vi.mocked(loadRoutingConfig).mockReturnValue({
+        ...baseConfig,
+        preferences: {
+          preferCheapWhenPossible: false,
+          defaultCostTier: 'medium',
+          maxCostPerRequest: null,
+          fallbackModel: 'fallback-model',
+          // routeFailureThreshold deliberately omitted
+        },
+      });
+      reloadConfig();
+      resetRouteFailures();
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      expect(isRouteDisabled('primary-model')).toBe(false);
+      recordRouteOutcome('primary-model', { kind: 'permanent', statusCode: 401 });
+      expect(isRouteDisabled('primary-model')).toBe(true);
+      warn.mockRestore();
+    });
+  });
+});

--- a/tests/core/streamingOrchestrator.fallback.test.ts
+++ b/tests/core/streamingOrchestrator.fallback.test.ts
@@ -8,6 +8,8 @@ vi.mock('../../src/providers/index.js', () => ({
 
 vi.mock('../../src/core/router.js', () => ({
   routePrompt: vi.fn(),
+  recordRouteOutcome: vi.fn(),
+  classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
 }));
 
 // Import after mocking

--- a/tests/hooks/continueOnBlock.test.ts
+++ b/tests/hooks/continueOnBlock.test.ts
@@ -41,6 +41,8 @@ vi.mock('../../src/core/router.js', () => ({
     reason: 'test routing',
     confidence: 0.9,
   })),
+  recordRouteOutcome: vi.fn(),
+  classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
 }));
 
 // Mock the cost tracker

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -18,6 +18,8 @@ vi.mock('../src/providers/index.js', () => {
 
 vi.mock('../src/core/router.js', () => ({
   routePrompt: vi.fn(),
+  recordRouteOutcome: vi.fn(),
+  classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
 }));
 
 // Import after mocking

--- a/tests/streamingOrchestratorHeaders.test.ts
+++ b/tests/streamingOrchestratorHeaders.test.ts
@@ -18,6 +18,8 @@ vi.mock('../src/providers/index.js', () => {
 
 vi.mock('../src/core/router.js', () => ({
   routePrompt: vi.fn(),
+  recordRouteOutcome: vi.fn(),
+  classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
 }));
 
 // Import after mocking


### PR DESCRIPTION
Closes #863.

## Summary

Adds a session-scoped consecutive-permanent-failure counter to `src/core/router.ts` so a stale routing entry (deleted deployment, expired token, model id typo) auto-disables after N (default **3**) back-to-back permanent failures. The next-priority route then gets the budget, instead of every turn burning on the same 401/403.

Mirrors kilocode#11703's sandbox self-disable (commit `c153d17`, 2026-06-26), ported to our routing surface since alexi has no sandbox.

## What's new in `src/core/router.ts`

```ts
export function recordRouteOutcome(
  modelId: string,
  outcome: { kind: 'success' } | { kind: 'permanent'; statusCode?: number; reason?: string }
): void;
export function isRouteDisabled(modelId: string): boolean;
export function resetRouteFailures(): void;
export function classifyRouteError(err: unknown):
  | { kind: 'permanent'; statusCode?: number; reason?: string }
  | { kind: 'unknown' };
```

- `permanent` = HTTP **401 / 403 / 404** OR error message matches `\bmodel_not_found\b` / `\bdeployment_not_found\b` (case-insensitive).
- Anything else (5xx, network, unknown) returns `{ kind: 'unknown' }` and is **not** recorded -- that path stays owned by `ErrorBackoff`.
- Status extraction reuses `extractStatusCode` from `error-backoff.ts`; no duplicated regex.

## Behaviour

- A single yellow warning is printed via `console.warn(c('yellow', ...))` on first disable -- one line under 100 cols, no emojis, no extra ANSI.
- `routePrompt` filters disabled routes from `getModelRegistry()` before scoring, so the next-priority match wins naturally.
- If **every** candidate is disabled, `routePrompt` returns the configured `preferences.fallbackModel` with `confidence: 0.1` and a reason that names the all-disabled state -- it does **not** throw.
- `reloadConfig()` now also calls `resetRouteFailures()` so a config hot-reload clears the disable state.
- State is in-process only -- nothing is persisted to `~/.alexi/`.

## Config

`RoutingPreferences.routeFailureThreshold?: number` added with default `3`. `routing-config.example.json` documents the new field.

## Call sites wired

- `src/core/orchestrator.ts` -- around `provider.complete`.
- `src/core/streamingOrchestrator.ts` -- around the `streamComplete` async iterator.
- `src/core/agenticChat.ts` -- around the per-iteration `provider.complete`, including the context-overflow compaction retry path.

Each site classifies the thrown error via `classifyRouteError` and records only `permanent` outcomes. Success path records `{ kind: 'success' }` to reset the counter.

## Tests

New: `tests/core/router-autodisable.test.ts` covers the six scenarios from the issue:

- 3 consecutive 401s disable the route; `routePrompt` then picks another.
- 3 consecutive 503s do **not** disable (transient class).
- Success between failures resets the counter (2 fails + success + 2 fails -> still enabled).
- All-disabled -> `fallbackModel` with confidence 0.1, no throw.
- Yellow warning fires exactly once on first disable.
- `resetRouteFailures()` re-enables a disabled route.

Also added: custom-threshold and default-threshold (omitted from config) cases, plus `classifyRouteError` smoke tests for non-`Error` throwables.

Existing router-mock test files (`tests/orchestrator.test.ts`, `streamingOrchestratorHeaders.test.ts`, `tests/core/streamingOrchestrator.fallback.test.ts`, `tests/core/agenticChat.permissionLeak.test.ts`, `tests/hooks/continueOnBlock.test.ts`, `src/core/__tests__/agenticChat.test.ts`) were extended to expose the two new exports (`recordRouteOutcome`, `classifyRouteError`) on their `vi.mock('../.../router.js', ...)` factories. No test-level behaviour changes.

## Verification

All local gates green:

```
npm run lint           # 0 errors
npm run typecheck      # clean
npm run format:check   # clean
npm run test:coverage  # 2783 passed, 2 skipped; lines 62.35% (>= 40%)
npm run build          # ok
```

No `@ts-ignore`, no `eslint-disable`, no `as any` introduced. No `.github/` files touched. No `package.json` version bump. No new npm dependencies.