### PR TITLE
feat(cli): per-routed-model usage in /cost today and StatusBar (#868)

### DIFF
--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -1309,6 +1309,18 @@ export async function handleCommand(input: string, state: ReplState): Promise<bo
           console.log(
             c('gray', `    Output Tokens: ${summary.totalOutputTokens.toLocaleString()}`)
           );
+          if (Object.keys(summary.byModel).length > 0) {
+            console.log();
+            console.log(c('cyan', '    By Model:'));
+            for (const [model, data] of Object.entries(summary.byModel)) {
+              console.log(
+                c(
+                  'gray',
+                  `      ${model}: ${costTracker.formatCost(data.cost)} (${data.calls} calls)`
+                )
+              );
+            }
+          }
         }
         console.log();
       } else if (subCmd === 'month') {

--- a/src/cli/tui/components/StatusBar.tsx
+++ b/src/cli/tui/components/StatusBar.tsx
@@ -15,6 +15,13 @@ export interface StatusBarProps {
   tokenCount?: number;
   /** Session ID (shown abbreviated) */
   sessionId?: string;
+  /**
+   * Optional label for the highest-cost routed model today. Rendered dimmed
+   * after the cost segment so users can see which route is burning their
+   * budget when auto-routing is on. Truncated to 18 chars + ellipsis to
+   * keep the segment compact (matches the model truncation rule below).
+   */
+  topModelLabel?: string;
 }
 
 const CURRENCY_SYMBOLS: Record<string, string> = {
@@ -50,6 +57,7 @@ export function StatusBar({
   leaderActive,
   tokenCount = 0,
   sessionId,
+  topModelLabel,
 }: StatusBarProps): React.JSX.Element {
   const { theme } = useTheme();
   const { colors } = theme;
@@ -72,6 +80,12 @@ export function StatusBar({
 
   const currencySymbol = CURRENCY_SYMBOLS[cost.currency] ?? `${cost.currency} `;
   const costStr = `${currencySymbol}${cost.totalCost.toFixed(4)}`;
+  const topModelDisplay =
+    topModelLabel && topModelLabel.length > 0
+      ? topModelLabel.length > 20
+        ? topModelLabel.slice(0, 18) + '…'
+        : topModelLabel
+      : null;
 
   // Leader mode — full-width hint bar
   if (leaderActive) {
@@ -100,6 +114,12 @@ export function StatusBar({
         <Text color={colors.dimText} backgroundColor={colors.backgroundDarker}>
           {costStr}
         </Text>
+        {topModelDisplay && (
+          <Text color={colors.dimText} backgroundColor={colors.backgroundDarker}>
+            {' · '}
+            {topModelDisplay}
+          </Text>
+        )}
         {tokenCount > 0 && (
           <Text color={colors.dimText} backgroundColor={colors.backgroundDarker}>
             {' · '}

--- a/src/cli/tui/pages/ChatPage.tsx
+++ b/src/cli/tui/pages/ChatPage.tsx
@@ -11,6 +11,21 @@ import type { SlashCommand } from '../hooks/useCommands.js';
 import type { ToolCallState } from '../context/ChatContext.js';
 import type { SidebarContextValue } from '../context/SidebarContext.js';
 import { useTheme } from '../context/ThemeContext.js';
+import { getCostTracker } from '../../../core/costTracker.js';
+
+/**
+ * Pick the highest-cost routed model from today's usage. Returns `undefined`
+ * when no calls have been recorded yet so the StatusBar omits the segment.
+ */
+function pickTopModelLabel(_costSignal: number): string | undefined {
+  const summary = getCostTracker().getTodaySummary();
+  const entries = Object.entries(summary.byModel);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  entries.sort((a, b) => b[1].cost - a[1].cost);
+  return entries[0][0];
+}
 
 export interface ChatPageProps {
   messages: MessageDisplay[];
@@ -58,6 +73,10 @@ export function ChatPage({
 }: ChatPageProps): React.JSX.Element {
   const { theme } = useTheme();
   const { colors } = theme;
+  // Recompute on the same hook that already drives cost updates — when the
+  // total cost changes (i.e. a turn just recorded usage), the memo re-runs.
+  // We do not add a separate poll.
+  const topModelLabel = React.useMemo(() => pickTopModelLabel(cost.totalCost), [cost.totalCost]);
 
   return (
     <>
@@ -108,6 +127,7 @@ export function ChatPage({
           leaderActive={leaderActive}
           tokenCount={tokenCount}
           sessionId={sessionId}
+          topModelLabel={topModelLabel}
         />
       </Box>
     </>

--- a/src/cli/tui/pages/LogsPage.tsx
+++ b/src/cli/tui/pages/LogsPage.tsx
@@ -5,6 +5,21 @@ import { useTheme } from '../context/ThemeContext.js';
 import { LogViewer } from '../components/LogViewer.js';
 import { StatusBar } from '../components/StatusBar.js';
 import type { LogEntry } from '../types/props.js';
+import { getCostTracker } from '../../../core/costTracker.js';
+
+/**
+ * Pick the highest-cost routed model from today's usage. Returns `undefined`
+ * when no calls have been recorded yet so the StatusBar omits the segment.
+ */
+function pickTopModelLabel(_costSignal: number): string | undefined {
+  const summary = getCostTracker().getTodaySummary();
+  const entries = Object.entries(summary.byModel);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  entries.sort((a, b) => b[1].cost - a[1].cost);
+  return entries[0][0];
+}
 
 export interface LogsPageProps {
   entries: LogEntry[];
@@ -34,6 +49,9 @@ export function LogsPage({
   const { colors } = theme;
   const [levelFilter, setLevelFilter] = useState<LogEntry['level'] | 'all'>('all');
   const [filterQuery, setFilterQuery] = useState('');
+  // Recompute on the same hook that already drives cost updates — when the
+  // total cost changes (i.e. a turn just recorded usage), the memo re-runs.
+  const topModelLabel = React.useMemo(() => pickTopModelLabel(cost.totalCost), [cost.totalCost]);
 
   useInput((input, key) => {
     // Cycle level filter with Tab
@@ -93,6 +111,7 @@ export function LogsPage({
           cost={cost}
           isStreaming={isStreaming}
           leaderActive={leaderActive}
+          topModelLabel={topModelLabel}
         />
       </Box>
     </>

--- a/tests/cli/interactive.cost.test.ts
+++ b/tests/cli/interactive.cost.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the `/cost today` slash command's new `By Model:` block.
+ *
+ * Issue #868: when auto-routing is on, today's usage should surface the
+ * per-routed-model breakdown (not only the aggregate totals), so users can
+ * see WHICH route is burning their budget.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { handleCommand, type ReplState } from '../../src/cli/interactive.js';
+import { SessionManager } from '../../src/core/sessionManager.js';
+import { resetCostTracker } from '../../src/core/costTracker.js';
+
+// We override `getCostTracker()` so the REPL's `/cost today` handler reads
+// from a CostTracker instance pointed at a per-test temp directory. This
+// keeps the test hermetic — no writes to the real `~/.alexi/cost-data.json`.
+vi.mock('../../src/core/costTracker.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/core/costTracker.js')>(
+    '../../src/core/costTracker.js'
+  );
+  const nodeOs = await import('os');
+  const nodePath = await import('path');
+  let testTracker: InstanceType<typeof actual.CostTracker> | null = null;
+  return {
+    ...actual,
+    getCostTracker: (): InstanceType<typeof actual.CostTracker> => {
+      if (testTracker === null) {
+        testTracker = new actual.CostTracker({
+          dataDir: nodePath.join(nodeOs.tmpdir(), `alexi-cost-${Date.now()}-${Math.random()}`),
+        });
+      }
+      return testTracker;
+    },
+    __resetTestTracker: (): void => {
+      testTracker = null;
+    },
+  };
+});
+
+async function loadResetTestTracker(): Promise<void> {
+  const mod = (await import('../../src/core/costTracker.js')) as unknown as {
+    __resetTestTracker?: () => void;
+  };
+  mod.__resetTestTracker?.();
+}
+
+function buildReplState(sessionsDir: string): ReplState {
+  const sessionManager = new SessionManager({ sessionsDir });
+  sessionManager.createSession('gpt-4o');
+  return {
+    sessionManager,
+    currentModel: 'gpt-4o',
+    autoRoute: true,
+    preferCheap: false,
+    isStreaming: false,
+  };
+}
+
+describe('/cost today renders per-routed-model breakdown', () => {
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let logs: string[];
+
+  beforeEach(async () => {
+    resetCostTracker();
+    await loadResetTestTracker();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-itest-'));
+    logs = [];
+    logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((a) => String(a)).join(' '));
+    });
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    resetCostTracker();
+    await loadResetTestTracker();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('prints a By Model: block with each routed model after the totals', async () => {
+    // Record two calls under different routed model ids.
+    const { getCostTracker } = await import('../../src/core/costTracker.js');
+    const tracker = getCostTracker();
+    tracker.recordUsage('gpt-4o', 1000, 500, 'session-a');
+    tracker.recordUsage('anthropic--claude-4.5-sonnet', 2000, 800, 'session-a');
+
+    const state = buildReplState(tmpDir);
+    const handled = await handleCommand('/cost today', state);
+
+    expect(handled).toBe(true);
+    const out = logs.join('\n');
+    expect(out).toContain("Today's API Costs");
+    expect(out).toContain('By Model:');
+    expect(out).toContain('gpt-4o');
+    expect(out).toContain('anthropic--claude-4.5-sonnet');
+  });
+
+  it('omits the By Model: block when no calls have been recorded today', async () => {
+    const state = buildReplState(tmpDir);
+    const handled = await handleCommand('/cost today', state);
+
+    expect(handled).toBe(true);
+    const out = logs.join('\n');
+    expect(out).toContain("Today's API Costs");
+    expect(out).toContain('No API calls recorded today');
+    expect(out).not.toContain('By Model:');
+  });
+});

--- a/tests/cli/tui/StatusBar.test.tsx
+++ b/tests/cli/tui/StatusBar.test.tsx
@@ -86,4 +86,26 @@ describe('StatusBar', () => {
     );
     expect(lastFrame()).toContain('$0.0123');
   });
+
+  it('renders topModelLabel when provided', () => {
+    const { lastFrame } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} topModelLabel="gpt-5.5" />
+      </Wrapper>
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('gpt-5.5');
+    // Still shows the cost
+    expect(frame).toContain('$0.0123');
+  });
+
+  it('omits topModelLabel segment when not provided', () => {
+    const { lastFrame } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('gpt-5.5');
+  });
 });


### PR DESCRIPTION
Closes #868

## What

Surface per-routed-model usage in two views:

1. `/cost today` slash command now prints the same `By Model:` block already used by `/cost month` and `/cost all`, so users can see WHICH route is burning their daily budget when auto-routing is on.
2. `StatusBar` gains an optional `topModelLabel` prop, rendered dimmed in the context-info segment between cost and tokens. `ChatPage` and `LogsPage` derive it from the highest-cost entry in `getCostTracker().getTodaySummary().byModel`.

## How

- **`src/cli/interactive.ts`** (`/cost today` branch): copied the `By Model:` rendering pattern from the `month` branch, guarded with `Object.keys(summary.byModel).length > 0` so brand-new sessions do not print an empty section.
- **`src/cli/tui/components/StatusBar.tsx`**: added optional `topModelLabel?: string` prop, rendered with the same `colors.dimText` / `colors.backgroundDarker` styling as the surrounding tokens segment, truncated to 18 chars + ellipsis to match the existing model truncation rule.
- **`src/cli/tui/pages/ChatPage.tsx` + `LogsPage.tsx`**: compute `topModelLabel` via `useMemo` keyed on `cost.totalCost` — recomputes on the same hook that already drives cost updates, no new poll. Returns `undefined` (so the segment is skipped) when `byModel` is empty.

## Tests

- `tests/cli/tui/StatusBar.test.tsx`: new cases asserting the prop renders when provided and is omitted otherwise.
- `tests/cli/interactive.cost.test.ts` (NEW): records two calls under different model ids via a mocked `getCostTracker`, drives the `/cost today` handler, asserts both model names appear in captured `console.log` output, and asserts the `By Model:` block is omitted when there are no calls.

## Gate sequence

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm run test:coverage` — 199 files / 2788 passing, lines 62.37%
- `npm run build` — clean

Mirrors upstream Kilo-Org/kilocode#11608.