### PR TITLE
fix(core): prefer recorded tokens + reserve output budget + 80% target in compaction

### DIFF
--- a/src/core/__tests__/compaction.test.ts
+++ b/src/core/__tests__/compaction.test.ts
@@ -19,6 +19,20 @@ function createMessage(role: Message['role'], content: string, timestamp?: numbe
   };
 }
 
+// Helper for messages that carry recorded token usage.
+function createMessageWithTokens(
+  role: Message['role'],
+  content: string,
+  tokens: { input?: number; output?: number }
+): Message {
+  return {
+    role,
+    content,
+    timestamp: Date.now(),
+    tokens,
+  };
+}
+
 describe('Context Compaction System', () => {
   beforeEach(() => {
     // Reset global LLM function before each test
@@ -79,6 +93,36 @@ describe('Context Compaction System', () => {
 
       expect(estimateMessagesTokens(messages)).toBe(11);
     });
+
+    it('should prefer recorded tokens over chars/4 when present', () => {
+      // Recorded tokens differ wildly from content length so we can prove the
+      // estimator is using the recorded values, not the chars/4 heuristic.
+      const messages: Message[] = [
+        createMessageWithTokens('user', 'short', { input: 1000 }), // 5 chars but 1000 recorded
+        createMessageWithTokens('assistant', 'also short', { output: 500 }), // 10 chars but 500 recorded
+      ];
+
+      // 4 (overhead) + 1000 + 4 (overhead) + 500 = 1508
+      expect(estimateMessagesTokens(messages)).toBe(1508);
+    });
+
+    it('should fall back to chars/4 when recorded tokens are missing or zero', () => {
+      const messages: Message[] = [
+        createMessage('user', '1234'), // no recorded tokens => 1 + 4 = 5
+        createMessageWithTokens('assistant', '12345678', { input: 0, output: 0 }), // zero => 2 + 4 = 6
+      ];
+
+      expect(estimateMessagesTokens(messages)).toBe(11);
+    });
+
+    it('should sum input + output when both recorded', () => {
+      const messages: Message[] = [
+        createMessageWithTokens('assistant', 'irrelevant', { input: 100, output: 200 }),
+      ];
+
+      // 4 overhead + (100 + 200) = 304
+      expect(estimateMessagesTokens(messages)).toBe(304);
+    });
   });
 
   describe('shouldCompact', () => {
@@ -119,6 +163,32 @@ describe('Context Compaction System', () => {
 
       // With 60% threshold: 54 tokens < 60% of 100 (60 tokens) = false
       expect(shouldCompact(messages, 100, 60)).toBe(false);
+    });
+
+    it('should accept an options bag with threshold and reserveOutputTokens', () => {
+      // 1500 chars = ~375 tokens + 4 overhead = 379.
+      const messages: Message[] = [createMessage('user', 'a'.repeat(1500))];
+
+      // Without reserve: 379 >= 80% of 1000 (800) => false.
+      expect(shouldCompact(messages, 1000, { threshold: 80 })).toBe(false);
+
+      // With a huge reserve, trigger budget = 100; 80% = 80; 379 >= 80 => true.
+      expect(shouldCompact(messages, 1000, { threshold: 80, reserveOutputTokens: 900 })).toBe(true);
+    });
+
+    it('should exclude reserved output budget from the trigger', () => {
+      // Conversation: 700 tokens recorded.
+      const messages: Message[] = [createMessageWithTokens('user', 'irrelevant', { input: 700 })];
+
+      // maxContextTokens=1000, threshold=80%.
+      // Without reserve: trigger budget = 1000; 80% = 800; 704 < 800 => false.
+      expect(shouldCompact(messages, 1000, { threshold: 80 })).toBe(false);
+
+      // With reserveOutputTokens=200: trigger budget = 800; 80% = 640;
+      //   704 >= 640 => true. The reserved output budget pulls the trigger
+      //   forward so we compact BEFORE the conversation collides with the
+      //   space the provider needs for its next response.
+      expect(shouldCompact(messages, 1000, { threshold: 80, reserveOutputTokens: 200 })).toBe(true);
     });
   });
 
@@ -340,6 +410,54 @@ describe('Context Compaction System', () => {
         expect(result.originalMessages).toBe(6);
         expect(result.compactedMessages).toBe(3); // summary + 2 preserved
       });
+    });
+  });
+
+  describe('post-compaction headroom (80% target)', () => {
+    it('should buy headroom so the very next turn does NOT re-trigger', async () => {
+      // Mock summarizer returns a tiny summary so we can isolate the
+      // "compact targets 80% of trigger budget" behaviour.
+      const mockLLM = vi.fn().mockResolvedValue('S'); // 1 char -> ~1 token
+      setLLMSummarizeFn(mockLLM);
+
+      const maxContextTokens = 10_000;
+      const reserveOutputTokens = 1_000;
+      const threshold = 80;
+
+      // Build a conversation that JUST crosses the trigger:
+      //   triggerTokens = 10_000 - 1_000 = 9_000
+      //   threshold     = 80% of 9_000   = 7_200
+      // Each 4-char chunk = 1 content token + 4 overhead = 5 per message.
+      // Use larger chunks so we can fit < 30 messages and compact something
+      // meaningful.
+      const head: Message[] = [];
+      for (let i = 0; i < 30; i++) {
+        // 1200 chars => 300 tokens + 4 overhead = 304 per message.
+        // 30 * 304 = 9_120 tokens > 7_200 trigger.
+        head.push(createMessage('user', 'a'.repeat(1200)));
+      }
+
+      // Sanity: pre-compaction, shouldCompact fires.
+      expect(shouldCompact(head, maxContextTokens, { threshold, reserveOutputTokens })).toBe(true);
+
+      // Compact.
+      const { messages: compacted } = await compactConversation(head, {
+        preserveLastN: 4,
+        summaryMaxTokens: 200,
+        maxContextTokens,
+        reserveOutputTokens,
+      });
+
+      expect(mockLLM).toHaveBeenCalled();
+
+      // Simulate the next turn: add one short user message after compaction.
+      const nextTurn: Message[] = [...compacted, createMessage('user', 'one short follow-up')];
+
+      // The whole point of the 80% target: shouldCompact must return false
+      // immediately after compaction. Otherwise compaction runs every turn.
+      expect(shouldCompact(nextTurn, maxContextTokens, { threshold, reserveOutputTokens })).toBe(
+        false
+      );
     });
   });
 

--- a/src/core/compaction.ts
+++ b/src/core/compaction.ts
@@ -19,6 +19,30 @@ export interface CompactionOptions {
   keepPruned?: boolean; // Keep pruned messages in history, default false
   maxChunkTokens?: number; // Max tokens per chunk for oversized payloads, default 80000
   overflowTokens?: number; // Tokens that triggered overflow — seeds target summary size
+  /**
+   * Number of tokens to reserve for the next provider response. When provided
+   * along with `maxContextTokens`, compaction targets ~80% of
+   * `(maxContextTokens - reserveOutputTokens)` so a freshly compacted turn
+   * does not immediately re-cross the trigger threshold. Callers should pass
+   * the provider-specific `maxTokens` (e.g. 4096 for the SAP Orchestration
+   * default in `src/core/orchestrator.ts`). Default 4096.
+   */
+  reserveOutputTokens?: number;
+  /**
+   * Total context window for the model. Required for the 80% target buffer in
+   * `compactConversation` to apply; when omitted, compaction falls back to the
+   * legacy "drop everything except last N" behaviour.
+   */
+  maxContextTokens?: number;
+}
+
+/**
+ * Options bag accepted by the (new) form of `shouldCompact`. The legacy
+ * positional `threshold?: number` argument is still supported.
+ */
+export interface ShouldCompactOptions {
+  threshold?: number;
+  reserveOutputTokens?: number;
 }
 
 export interface CompactionResult {
@@ -37,6 +61,17 @@ const DEFAULT_PRESERVE_LAST_N = 4;
 const DEFAULT_SUMMARY_MAX_TOKENS = 2000;
 const DEFAULT_TRIGGER_THRESHOLD = 90; // percent
 const DEFAULT_MAX_CHUNK_TOKENS = 80000;
+/**
+ * Default reservation for the next provider response. Mirrors the
+ * `maxTokens: 4096` used by the SAP Orchestration call in
+ * `src/core/orchestrator.ts`.
+ */
+const DEFAULT_RESERVE_OUTPUT_TOKENS = 4096;
+/**
+ * Fraction of the trigger budget that `compactConversation` aims to land at
+ * after compacting. Mirrors the upstream cline/cline three-part fix.
+ */
+const POST_COMPACT_TARGET_FRACTION = 0.8;
 const MAX_TOOL_OUTPUT_LENGTH = 50000; // 50KB threshold
 const PRUNED_TOOL_MARKER = '[Output truncated due to size]';
 
@@ -66,7 +101,13 @@ export function estimateTokens(text: string): number {
 }
 
 /**
- * Estimate total tokens for a list of messages
+ * Estimate total tokens for a list of messages.
+ *
+ * When a message has a recorded `tokens` field (populated on the hot path by
+ * `orchestrator.ts` / `sessionManager.ts`), the recorded value is preferred
+ * over the chars/4 heuristic. Falls back to chars/4 only when neither
+ * `tokens.input` nor `tokens.output` is set. The +4 per-message structural
+ * overhead is kept either way.
  */
 export function estimateMessagesTokens(messages: Message[]): number {
   if (!messages || messages.length === 0) {
@@ -77,7 +118,18 @@ export function estimateMessagesTokens(messages: Message[]): number {
   for (const message of messages) {
     // Add overhead for role/structure (~4 tokens per message)
     total += 4;
-    total += estimateTokens(message.content);
+
+    const recordedInput = message.tokens?.input;
+    const recordedOutput = message.tokens?.output;
+    const hasRecorded =
+      (typeof recordedInput === 'number' && recordedInput > 0) ||
+      (typeof recordedOutput === 'number' && recordedOutput > 0);
+
+    if (hasRecorded) {
+      total += (recordedInput ?? 0) + (recordedOutput ?? 0);
+    } else {
+      total += estimateTokens(message.content);
+    }
   }
 
   return total;
@@ -86,20 +138,34 @@ export function estimateMessagesTokens(messages: Message[]): number {
 // ============ Core Functions ============
 
 /**
- * Check if compaction is needed based on current token usage
+ * Check if compaction is needed based on current token usage.
+ *
+ * Accepts either the legacy positional `threshold?: number` form or an
+ * options bag with `{ threshold, reserveOutputTokens }`. When
+ * `reserveOutputTokens` is supplied, it is subtracted from
+ * `maxContextTokens` BEFORE applying the percentage threshold so the
+ * reserved output budget never trips the trigger.
  */
 export function shouldCompact(
   messages: Message[],
   maxContextTokens: number,
-  threshold?: number
+  thresholdOrOptions?: number | ShouldCompactOptions
 ): boolean {
   if (!messages || messages.length === 0) {
     return false;
   }
 
-  const thresholdPercent = threshold ?? DEFAULT_TRIGGER_THRESHOLD;
+  const opts: ShouldCompactOptions =
+    typeof thresholdOrOptions === 'number'
+      ? { threshold: thresholdOrOptions }
+      : (thresholdOrOptions ?? {});
+
+  const thresholdPercent = opts.threshold ?? DEFAULT_TRIGGER_THRESHOLD;
+  const reserveOutputTokens = opts.reserveOutputTokens ?? 0;
+  const triggerTokens = Math.max(0, maxContextTokens - reserveOutputTokens);
+
   const currentTokens = estimateMessagesTokens(messages);
-  const thresholdTokens = (maxContextTokens * thresholdPercent) / 100;
+  const thresholdTokens = (triggerTokens * thresholdPercent) / 100;
 
   return currentTokens >= thresholdTokens;
 }
@@ -311,9 +377,59 @@ export async function compactConversation(
     };
   }
 
-  // Split: messages to summarize vs messages to keep
-  const messagesToSummarize = nonSystemMessages.slice(0, -preserveLastN);
-  const messagesToKeep = nonSystemMessages.slice(-preserveLastN);
+  // Default split: keep last N, summarize the rest.
+  let messagesToSummarize = nonSystemMessages.slice(0, -preserveLastN);
+  let messagesToKeep = nonSystemMessages.slice(-preserveLastN);
+
+  // When the caller passes `maxContextTokens`, target ~80% of the trigger
+  // budget (context - reserved output) so the very next turn does not
+  // immediately re-cross the compaction threshold. We grow `toKeep` BACKWARDS
+  // from the tail past `preserveLastN` while the resulting kept set + the
+  // summary budget still fits under the target. Anything that does not fit is
+  // moved into `messagesToSummarize`.
+  const maxContextTokens = options?.maxContextTokens;
+  const reserveOutputTokens = options?.reserveOutputTokens ?? DEFAULT_RESERVE_OUTPUT_TOKENS;
+  if (typeof maxContextTokens === 'number' && maxContextTokens > 0) {
+    const triggerTokens = Math.max(0, maxContextTokens - reserveOutputTokens);
+    const targetTokens = Math.floor(triggerTokens * POST_COMPACT_TARGET_FRACTION);
+
+    // Always keep at least the last `preserveLastN` non-system messages
+    // (existing invariant). Grow the kept window leftwards as long as the
+    // running total (kept + system + summary budget) stays under target.
+    const systemTokens = estimateMessagesTokens(systemMessages);
+
+    let keepStart = Math.max(0, nonSystemMessages.length - preserveLastN);
+    // Token cost of the currently-kept window.
+    let keptTokens = estimateMessagesTokens(nonSystemMessages.slice(keepStart));
+
+    while (keepStart > 0) {
+      const candidate = nonSystemMessages[keepStart - 1];
+      const candidateTokens = estimateMessagesTokens([candidate]);
+      const projected = systemTokens + summaryMaxTokens + keptTokens + candidateTokens;
+      if (projected > targetTokens) {
+        break;
+      }
+      keepStart -= 1;
+      keptTokens += candidateTokens;
+    }
+
+    messagesToSummarize = nonSystemMessages.slice(0, keepStart);
+    messagesToKeep = nonSystemMessages.slice(keepStart);
+
+    // If the target buffer is so generous that there is nothing left to
+    // summarize, return early with the original messages — no work to do.
+    if (messagesToSummarize.length === 0) {
+      return {
+        messages: [...messages],
+        result: {
+          originalMessages: messages.length,
+          compactedMessages: messages.length,
+          estimatedTokensSaved: 0,
+          summary: '',
+        },
+      };
+    }
+  }
 
   // Generate summary
   let summary: string;


### PR DESCRIPTION
## What

Fixes `src/core/compaction.ts` so that:

1. **`estimateMessagesTokens` prefers recorded tokens** — it now uses
   `Message.tokens.input + Message.tokens.output` (already populated on the
   orchestrator hot path in `src/core/orchestrator.ts:93-98` and
   `src/core/sessionManager.ts:141`) instead of re-estimating from
   `content.length / 4`. Falls back to chars/4 only when neither recorded
   value is set. +4 structural overhead per message preserved.

2. **`shouldCompact` reserves provider `maxTokens`** — accepts either the
   legacy positional `threshold?: number` argument or a new options bag
   `{ threshold?: number; reserveOutputTokens?: number }`. When the reserve
   is supplied, it is subtracted from `maxContextTokens` BEFORE applying the
   percentage threshold so the reserved output budget never trips the
   trigger.

3. **`compactConversation` targets 80% of the trigger budget** — when the
   caller passes `maxContextTokens` (and optionally `reserveOutputTokens`),
   compaction grows the kept window backwards from `preserveLastN` while
   the resulting kept set + summary budget still fits under
   `0.8 * (maxContextTokens - reserveOutputTokens)`. Default
   `reserveOutputTokens` is 4096 to match the SAP Orchestration call in
   `src/core/orchestrator.ts:78`. When `maxContextTokens` is not supplied,
   the legacy "drop everything except last N" behaviour is preserved.

## Why

`Message.tokens` was already populated but ignored. Combined with
`shouldCompact` comparing chars/4 against the same budget that
`compactConversation` targets (it only sliced off `preserveLastN`), every
next turn re-crossed the threshold and compaction ran every turn. Mirrors
the upstream three-part fix in cline/cline#11894.

## Tests

Added in `src/core/__tests__/compaction.test.ts`:

- `estimateMessagesTokens` prefers recorded tokens (and falls back to
  chars/4 when missing/zero, and sums `input + output`).
- `shouldCompact` accepts the new options bag and the reserve correctly
  pulls the trigger forward.
- A two-call sequence: build messages just over the trigger,
  `compactConversation`, replace messages with the compacted result plus
  one new short user turn, call `shouldCompact` again — expect `false`
  (proves the 80% target buys headroom).
- All previously passing `compaction.test.ts` cases still pass — legacy
  `shouldCompact(messages, max, 80)` signature still works.

## Gates

```
npm run lint           # 0 errors
npm run typecheck      # clean
npm run format:check   # clean
npm test               # 2790 passed, 2 skipped
npm run build          # clean
```

## Scope

No changes to call sites in this PR. A follow-up will wire
`reserveOutputTokens` through `SessionManager.checkAndCompact`.

Closes #869