### PR TITLE
feat(providers): adaptive reasoning_effort dispatch for Claude Opus 4.7+ / Sonnet 5+

### DIFF
--- a/src/providers/__tests__/model-match.test.ts
+++ b/src/providers/__tests__/model-match.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { modelSupportsReasoningEffort } from '../model-match.js';
+import { modelSupportsReasoningEffort, supportsReasoning } from '../model-match.js';
 
 describe('modelSupportsReasoningEffort', () => {
   it('returns "levels" for deepseek model ids', () => {
@@ -11,11 +11,37 @@ describe('modelSupportsReasoningEffort', () => {
     expect(modelSupportsReasoningEffort('sap-ai-core/DEEPSEEK-V3')).toBe('levels');
   });
 
-  it('returns "none" for an unknown model id', () => {
-    expect(modelSupportsReasoningEffort('anthropic--claude-4.7-opus')).toBe('none');
-  });
-
   it('returns "none" for an empty model id', () => {
     expect(modelSupportsReasoningEffort('')).toBe('none');
+  });
+
+  it('returns "levels" for Anthropic Opus 4.7 (pinned AGENT_MODEL)', () => {
+    expect(modelSupportsReasoningEffort('sap-ai-core/anthropic--claude-4.7-opus')).toBe('levels');
+  });
+
+  it('returns "levels" for Anthropic Sonnet 5+', () => {
+    expect(modelSupportsReasoningEffort('anthropic--claude-5-sonnet')).toBe('levels');
+  });
+
+  it('returns "none" for Opus below the 4.7 gate', () => {
+    expect(modelSupportsReasoningEffort('claude-4.6-opus')).toBe('none');
+  });
+
+  it('returns "none" for Sonnet below the 5 gate', () => {
+    expect(modelSupportsReasoningEffort('claude-4-sonnet')).toBe('none');
+  });
+
+  it('returns "none" for Claude 3.5 Sonnet (regression guard)', () => {
+    expect(modelSupportsReasoningEffort('claude-3.5-sonnet')).toBe('none');
+  });
+
+  it('is case-insensitive when matching Anthropic Opus 4.7', () => {
+    expect(modelSupportsReasoningEffort('SAP-AI-CORE/ANTHROPIC--CLAUDE-4.7-OPUS')).toBe('levels');
+  });
+});
+
+describe('supportsReasoning (Claude family unchanged)', () => {
+  it('still returns true for Anthropic Claude ids', () => {
+    expect(supportsReasoning('sap-ai-core/anthropic--claude-4.7-opus')).toBe(true);
   });
 });

--- a/src/providers/model-match.ts
+++ b/src/providers/model-match.ts
@@ -109,6 +109,26 @@ export function modelSupportsReasoningEffort(modelId: string): ReasoningEffortMo
   if (lower.includes('deepseek')) {
     return 'levels';
   }
+  // Anthropic Opus 4.7+ accepts adaptive reasoning_effort levels natively.
+  // Match either "opus-<major>[.<minor>]" or "claude-<major>[.<minor>]-opus".
+  const opusMatch =
+    lower.match(/opus-(\d+)(?:\.(\d+))?/) ?? lower.match(/claude-(\d+)(?:\.(\d+))?-opus/);
+  if (opusMatch) {
+    const major = Number(opusMatch[1]);
+    const minor = opusMatch[2] !== undefined ? Number(opusMatch[2]) : 0;
+    if (major > 4 || (major === 4 && minor >= 7)) {
+      return 'levels';
+    }
+  }
+  // Anthropic Sonnet 5+ accepts adaptive reasoning_effort levels natively.
+  // Match either "sonnet-<major>" or "claude-<major>-sonnet".
+  const sonnetMatch = lower.match(/sonnet-(\d+)/) ?? lower.match(/claude-(\d+)-sonnet/);
+  if (sonnetMatch) {
+    const major = Number(sonnetMatch[1]);
+    if (major >= 5) {
+      return 'levels';
+    }
+  }
   // Pre-emptive carve-out for future binary-only thinking models.
   // Add concrete model substrings here when wired into the router.
   return 'none';


### PR DESCRIPTION
## Summary

Extend `modelSupportsReasoningEffort` in `src/providers/model-match.ts` so Anthropic **Opus 4.7+** and **Sonnet 5+** report `'levels'` instead of `'none'`. Previously every Claude id — including our pinned `sap-ai-core/anthropic--claude-4.7-opus` `AGENT_MODEL` — silently dropped the `reasoning_effort` field.

`src/providers/deepseek.ts:49-56` already dispatches on the return value and forwards `reasoning_effort: 'low' | 'medium' | 'high'` when the mode is `'levels'`. This PR wires up the missing model-family branch.

## Changes

- `src/providers/model-match.ts`: add regex branches for `opus-<major>[.<minor>]` / `claude-<major>[.<minor>]-opus` (gate: major > 4 || (major == 4 && minor >= 7)) and `sonnet-<major>` / `claude-<major>-sonnet` (gate: major >= 5). Order preserved: DeepSeek first, then Opus, then Sonnet, then trailing `return 'none'`.
- `src/providers/__tests__/model-match.test.ts`: six new / regression assertions plus a `supportsReasoning` reassertion:
  - `sap-ai-core/anthropic--claude-4.7-opus` -> `'levels'`
  - `anthropic--claude-5-sonnet` -> `'levels'`
  - `claude-4.6-opus` -> `'none'` (below the 4.7 gate)
  - `claude-4-sonnet` -> `'none'` (below the 5 gate)
  - `claude-3.5-sonnet` -> `'none'` (regression guard)
  - upper-case Opus 4.7 variant -> `'levels'`
  - `supportsReasoning('...claude-4.7-opus')` -> `true` (unchanged)

Existing `deepseek-r1 -> 'levels'` case retained.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run format:check` — clean
- `npm test` — 2810 passed, 2 skipped (202 files)
- `npm run build` — clean

## Source

sst/opencode#34673 (`3a669d5`, 2026-06-30). See `.github/research/2026-07-01-research.md` item #1.

Closes #894

[alexi-bot]