### PR TITLE
feat(cli): --yolo/--dangerously-skip-permissions wires AllowEverythingPermission

### DIFF
--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import type { Command } from 'commander';
+import { Option, type Command } from 'commander';
 import { agenticChat, type AgenticProgressEvent } from '../../core/agenticChat.js';
 import { SessionManager } from '../../core/sessionManager.js';
 import { createAutoCommitManager } from '../../git/autoCommit.js';
@@ -20,6 +20,7 @@ import { parseEffortLevel, type EffortLevel } from '../../core/effortLevel.js';
 import { createWorktree } from '../../utils/gitWorktree.js';
 import { resolveDefaultAgent } from '../../agent/defaultAgent.js';
 import { getConfigDefaultAgent } from '../../config/userConfig.js';
+import { getPermissionManager } from '../../permission/index.js';
 
 interface AgentOptions {
   message?: string;
@@ -47,6 +48,9 @@ interface AgentOptions {
   effort?: string;
   // Custom agent slug (overrides config default)
   agent?: string;
+  // --yolo / --dangerously-skip-permissions
+  yolo?: boolean;
+  dangerouslySkipPermissions?: boolean;
 }
 
 export function registerAgentCommand(program: Command): void {
@@ -80,9 +84,14 @@ export function registerAgentCommand(program: Command): void {
       '--agent <name>',
       'Custom agent slug to dispatch (overrides `agent` field in user config)'
     )
+    .option('--yolo', 'Auto-approve all permission prompts (dangerous)')
+    .addOption(new Option('--dangerously-skip-permissions', 'Alias for --yolo').hideHelp())
     .action(async (opts: AgentOptions) => {
       let worktreeCleanup: (() => Promise<void>) | undefined;
       try {
+        if (opts.yolo || opts.dangerouslySkipPermissions) {
+          getPermissionManager().setPermissionMode('auto');
+        }
         // Get message from either --message or --message-file
         let message: string;
         if (opts.messageFile) {

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -3,7 +3,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import type { Command } from 'commander';
+import { Option, type Command } from 'commander';
 import { sendChat } from '../../core/orchestrator.js';
 import { SessionManager } from '../../core/sessionManager.js';
 import { resolveDefaultAgent } from '../../agent/defaultAgent.js';
@@ -14,6 +14,7 @@ import {
   renderSubmitPrompt,
   getCommandRegistry,
 } from '../../command/index.js';
+import { getPermissionManager } from '../../permission/index.js';
 
 /**
  * Result of running a custom command in non-interactive (chat) mode.
@@ -75,6 +76,8 @@ interface ChatOptions {
   session?: string;
   system?: string;
   agent?: string;
+  yolo?: boolean;
+  dangerouslySkipPermissions?: boolean;
 }
 
 export function registerChatCommand(program: Command): void {
@@ -91,8 +94,13 @@ export function registerChatCommand(program: Command): void {
       '--agent <name>',
       'Agent slug whose system prompt and model become defaults (overrides `agent` field in user config). Tools are not enabled in chat mode, so agent tool restrictions are ignored.'
     )
+    .option('--yolo', 'Auto-approve all permission prompts (dangerous)')
+    .addOption(new Option('--dangerously-skip-permissions', 'Alias for --yolo').hideHelp())
     .action(async (opts: ChatOptions) => {
       try {
+        if (opts.yolo || opts.dangerouslySkipPermissions) {
+          getPermissionManager().setPermissionMode('auto');
+        }
         // Get message from either --message or --message-file
         let message: string;
         if (opts.messageFile) {

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -2,10 +2,11 @@
  * Interactive command - start REPL with streaming responses
  */
 
-import type { Command } from 'commander';
+import { Option, type Command } from 'commander';
 // Fallback: import { startInteractive } from '../interactive.js';
 import { startTui } from '../tui/index.js';
 import { getDefaultModel } from '../../providers/index.js';
+import { getPermissionManager } from '../../permission/index.js';
 import { createAutoCommitManager } from '../../git/autoCommit.js';
 import { loadGitConfig } from '../../git/config.js';
 import { commitDirtyFiles } from '../../git/dirtyFiles.js';
@@ -27,6 +28,9 @@ interface InteractiveOptions {
   attributeAuthor?: boolean;
   // Repo map flags
   mapTokens?: string;
+  // --yolo / --dangerously-skip-permissions
+  yolo?: boolean;
+  dangerouslySkipPermissions?: boolean;
 }
 
 export function registerInteractiveCommand(program: Command): void {
@@ -48,9 +52,14 @@ export function registerInteractiveCommand(program: Command): void {
     .option('--attribute-author', 'Override git author for AI commits')
     // Repo map flags
     .option('--map-tokens <n>', 'Repo map token budget (default: 2000; set to 0 to disable)')
+    .option('--yolo', 'Auto-approve all permission prompts (dangerous)')
+    .addOption(new Option('--dangerously-skip-permissions', 'Alias for --yolo').hideHelp())
     .action(async (opts: InteractiveOptions) => {
       let worktreeCleanup: (() => Promise<void>) | undefined;
       try {
+        if (opts.yolo || opts.dangerouslySkipPermissions) {
+          getPermissionManager().setPermissionMode('auto');
+        }
         let workdir = process.cwd();
 
         // Create an isolated git worktree if requested

--- a/src/permission/allow-everything.test.ts
+++ b/src/permission/allow-everything.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for PermissionManager auto (yolo) mode and the AllowEverything short-circuit
+ * wired via `setPermissionMode('auto')`.
+ *
+ * Covers issue #892: --yolo / --dangerously-skip-permissions wires
+ * AllowEverythingPermission.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PermissionManager, defaultRules } from './index.js';
+import { PermissionRequested } from '../bus/index.js';
+
+describe('PermissionManager permission mode (auto/yolo)', () => {
+  let manager: PermissionManager;
+
+  beforeEach(() => {
+    manager = new PermissionManager(defaultRules);
+    // Allow external paths so the external-directory guard does not deny
+    // resources like `/tmp/x` before permissionMode is consulted.
+    manager.setAllowExternalDirectories(true);
+  });
+
+  it("defaults to 'normal' mode", () => {
+    expect(manager.getPermissionMode()).toBe('normal');
+  });
+
+  it("switches to 'auto' via setPermissionMode", () => {
+    manager.setPermissionMode('auto');
+    expect(manager.getPermissionMode()).toBe('auto');
+  });
+
+  it("allows arbitrary writes without publishing PermissionRequested in 'auto' mode", async () => {
+    manager.setPermissionMode('auto');
+
+    // If auto mode were leaking through to askUser, this handler would fire.
+    let requested = 0;
+    const unsubscribe = PermissionRequested.subscribe(() => {
+      requested += 1;
+    });
+
+    try {
+      const result = await manager.check({
+        toolName: 'write',
+        action: 'write',
+        resource: '/tmp/x',
+      });
+      expect(result.granted).toBe(true);
+      expect(result.decision).toBe('allow');
+      expect(requested).toBe(0);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("still denies .env in 'auto' mode via deny-secrets exclude list", async () => {
+    manager.setPermissionMode('auto');
+    const result = await manager.check({
+      toolName: 'read_file',
+      action: 'read',
+      resource: '/repo/.env',
+    });
+    expect(result.granted).toBe(false);
+    expect(result.decision).toBe('deny');
+  });
+
+  it("still denies secrets.* in 'auto' mode via deny-secrets exclude list", async () => {
+    manager.setPermissionMode('auto');
+    const result = await manager.check({
+      toolName: 'read_file',
+      action: 'read',
+      resource: '/repo/secrets.json',
+    });
+    expect(result.granted).toBe(false);
+    expect(result.decision).toBe('deny');
+  });
+
+  it("still denies ~/.ssh in 'auto' mode via the SSH belt-and-braces exclude", async () => {
+    // Even if a caller drops the deny-secrets rule, --yolo must not touch SSH.
+    const permissiveManager = new PermissionManager([]);
+    permissiveManager.setAllowExternalDirectories(true);
+    permissiveManager.setPermissionMode('auto');
+    const result = await permissiveManager.check({
+      toolName: 'read_file',
+      action: 'read',
+      resource: '/home/alice/.ssh/id_rsa',
+    });
+    expect(result.granted).toBe(false);
+    expect(result.decision).toBe('deny');
+  });
+
+  it("in 'normal' mode (default) falls back to rule evaluation (asks the user)", async () => {
+    // Default rule set has an `ask-write` rule that asks for write actions.
+    // In normal mode this MUST publish a PermissionRequested event (proving
+    // the check is not short-circuited); wire a subscriber that immediately
+    // publishes a granted response so the check resolves without a 60s wait.
+    const { PermissionResponse } = await import('../bus/index.js');
+    const unsub = PermissionRequested.subscribe((req) => {
+      // Defer to next tick so askUser has time to subscribe to
+      // PermissionResponse (askUser publishes the request BEFORE it
+      // awaits the response).
+      setImmediate(() => {
+        PermissionResponse.publish({
+          id: req.id,
+          granted: true,
+          remember: false,
+          timestamp: Date.now(),
+        });
+      });
+    });
+    try {
+      const result = await manager.check({
+        toolName: 'write',
+        action: 'write',
+        resource: '/tmp/x',
+      });
+      expect(result.granted).toBe(true);
+    } finally {
+      unsub();
+    }
+  });
+});

--- a/src/permission/index.ts
+++ b/src/permission/index.ts
@@ -24,6 +24,7 @@ import { ConfigProtection } from './config-paths.js';
 import { containsPath, safePathCheck } from '../utils/filesystem.js';
 import { logger } from '../utils/logger.js';
 import { getAllToolNames } from '../tool/registry.js';
+import { AllowEverythingPermission } from './allow-everything.js';
 
 // Glob characters that flag a tool entry as a pattern rather than a literal name.
 const GLOB_CHARS = /[*?]/;
@@ -42,6 +43,11 @@ export type PermissionAction = 'read' | 'write' | 'execute' | 'network' | 'admin
 
 // Permission decision
 export type PermissionDecision = 'allow' | 'deny' | 'ask';
+
+// Permission mode: 'normal' evaluates rules; 'auto' short-circuits to allow
+// (except for deny-list resources like .env, secrets, ~/.ssh) — set by
+// `--yolo` / `--dangerously-skip-permissions` CLI flags.
+export type PermissionMode = 'auto' | 'normal';
 
 // Doom loop configuration
 export interface DoomLoopConfig {
@@ -166,9 +172,62 @@ export class PermissionManager {
   private projectRoot: string = process.cwd();
   private allowExternalDirectories: boolean = false;
 
+  // Permission mode & lazy allow-everything delegate for --yolo / --dangerously-skip-permissions.
+  private permissionMode: PermissionMode = 'normal';
+  private allowEverythingDelegate: AllowEverythingPermission | null = null;
+
   constructor(rules: PermissionRule[] = []) {
     this.rules = this.sortRules(rules);
     this.warnOnUnknownDenyToolNames();
+  }
+
+  // ============ Permission Mode (yolo / dangerously-skip-permissions) ============
+
+  /**
+   * Set the global permission mode. In 'auto' mode, `check()` short-circuits
+   * to allow for every resource that does not match the built-in deny list
+   * (see `deny-secrets` rule paths). In 'normal' mode (default), rules are
+   * evaluated as usual.
+   */
+  setPermissionMode(mode: PermissionMode): void {
+    this.permissionMode = mode;
+    if (mode === 'auto') {
+      // Reset the delegate so exclude patterns are re-derived from the
+      // current rule set (defensive; supports rules changing at runtime).
+      this.allowEverythingDelegate = null;
+    }
+  }
+
+  /**
+   * Get the current permission mode.
+   */
+  getPermissionMode(): PermissionMode {
+    return this.permissionMode;
+  }
+
+  /**
+   * Build (or return cached) allow-everything delegate whose exclude patterns
+   * are the union of `paths` from the built-in `deny-secrets` rule, plus
+   * `~/.ssh` (defense-in-depth; the deny-secrets rule does not name ssh).
+   */
+  private getAllowEverythingDelegate(): AllowEverythingPermission {
+    if (this.allowEverythingDelegate) {
+      return this.allowEverythingDelegate;
+    }
+    const excludePatterns: string[] = [];
+    for (const rule of this.rules) {
+      if (rule.id === 'deny-secrets' && rule.paths) {
+        excludePatterns.push(...rule.paths);
+      }
+    }
+    // Belt-and-braces: even if the caller has stripped `deny-secrets`,
+    // never let `--yolo` reach SSH keys.
+    excludePatterns.push('**/.ssh/**', '~/.ssh/**');
+    this.allowEverythingDelegate = new AllowEverythingPermission({
+      enabled: true,
+      excludePatterns,
+    });
+    return this.allowEverythingDelegate;
   }
 
   /**
@@ -560,6 +619,24 @@ export class PermissionManager {
       // Record the attempt before returning
       this.recordOperationAttempt(ctx);
       return externalResult;
+    }
+
+    // Auto (yolo) mode: short-circuit to allow unless the resource matches
+    // the deny-list carried by the AllowEverythingPermission delegate.
+    // The delegate itself returns `granted: false` for exclude-list hits
+    // and `granted: true` otherwise; we map both cases to `PermissionResult`.
+    if (this.permissionMode === 'auto') {
+      const delegate = this.getAllowEverythingDelegate();
+      const result = await delegate.check(ctx);
+      if (result.granted) {
+        // Reset operation tracking on success (parity with the normal allow path).
+        const key = this.getOperationKey(ctx);
+        this.recentOperations.delete(key);
+      } else {
+        // Record the denied attempt (parity with the normal deny path).
+        this.recordOperationAttempt(ctx);
+      }
+      return result;
     }
 
     const { decision, rule } = this.evaluate(ctx);

--- a/tests/cli-yolo-flag.test.ts
+++ b/tests/cli-yolo-flag.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests that --yolo (and --dangerously-skip-permissions) on the chat,
+ * agent, and interactive commands flip the global PermissionManager into
+ * 'auto' mode.
+ *
+ * We stub out the heavy downstream modules (sendChat, agenticChat, startTui,
+ * SessionManager) so the command action returns quickly and only the flag
+ * plumbing under test runs.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../src/core/orchestrator.js', () => ({
+  sendChat: vi.fn(async () => ({
+    text: '',
+    usage: undefined,
+    modelUsed: undefined,
+  })),
+}));
+
+vi.mock('../src/core/agenticChat.js', () => ({
+  agenticChat: vi.fn(async () => ({
+    text: '',
+    usage: { prompt_tokens: 0, completion_tokens: 0 },
+    modelUsed: 'stub',
+    iterations: 0,
+    toolCallsExecuted: 0,
+    toolCallSummary: [],
+  })),
+}));
+
+vi.mock('../src/core/sessionManager.js', () => ({
+  SessionManager: class {
+    loadSession() {
+      return null;
+    }
+    getCurrentSession() {
+      return null;
+    }
+  },
+}));
+
+vi.mock('../src/cli/tui/index.js', () => ({
+  startTui: vi.fn(async () => undefined),
+}));
+
+vi.mock('../src/git/autoCommit.js', () => ({
+  createAutoCommitManager: vi.fn(() => undefined),
+}));
+
+vi.mock('../src/git/config.js', () => ({
+  loadGitConfig: vi.fn(async () => ({
+    dirtyCommits: false,
+    commitVerify: false,
+    attribution: { style: 'co-authored-by' },
+  })),
+}));
+
+vi.mock('../src/git/dirtyFiles.js', () => ({
+  commitDirtyFiles: vi.fn(async () => ({ committed: false, filesCommitted: [], hash: '' })),
+}));
+
+import { Command } from 'commander';
+import { registerChatCommand } from '../src/cli/commands/chat.js';
+import { registerAgentCommand } from '../src/cli/commands/agent.js';
+import { registerInteractiveCommand } from '../src/cli/commands/interactive.js';
+import {
+  getPermissionManager,
+  setPermissionManager,
+  PermissionManager,
+  defaultRules,
+} from '../src/permission/index.js';
+
+function freshProgram(): Command {
+  // exitOverride prevents Commander from calling process.exit on error.
+  return new Command().exitOverride();
+}
+
+describe('--yolo / --dangerously-skip-permissions CLI flag', () => {
+  beforeEach(() => {
+    // Reset the global manager between tests so mode leaks are visible.
+    setPermissionManager(new PermissionManager(defaultRules));
+  });
+
+  it('chat: --yolo sets permission mode to auto', async () => {
+    const program = freshProgram();
+    registerChatCommand(program);
+    await program.parseAsync(['node', 'ax', 'chat', '--yolo', '-m', 'hi']);
+    expect(getPermissionManager().getPermissionMode()).toBe('auto');
+  });
+
+  it('chat: --dangerously-skip-permissions also sets auto', async () => {
+    const program = freshProgram();
+    registerChatCommand(program);
+    await program.parseAsync(['node', 'ax', 'chat', '--dangerously-skip-permissions', '-m', 'hi']);
+    expect(getPermissionManager().getPermissionMode()).toBe('auto');
+  });
+
+  it('chat: without the flag, mode stays normal', async () => {
+    const program = freshProgram();
+    registerChatCommand(program);
+    await program.parseAsync(['node', 'ax', 'chat', '-m', 'hi']);
+    expect(getPermissionManager().getPermissionMode()).toBe('normal');
+  });
+
+  it('agent: --yolo sets permission mode to auto', async () => {
+    const program = freshProgram();
+    registerAgentCommand(program);
+    await program.parseAsync(['node', 'ax', 'agent', '--yolo', '--no-auto-commits', '-m', 'hi']);
+    expect(getPermissionManager().getPermissionMode()).toBe('auto');
+  });
+
+  it('interactive: --yolo sets permission mode to auto', async () => {
+    const program = freshProgram();
+    registerInteractiveCommand(program);
+    await program.parseAsync(['node', 'ax', 'interactive', '--yolo', '--no-auto-commits']);
+    expect(getPermissionManager().getPermissionMode()).toBe('auto');
+  });
+
+  it('--dangerously-skip-permissions is hidden from help output', () => {
+    const program = freshProgram();
+    registerChatCommand(program);
+    const chatCmd = program.commands.find((c) => c.name() === 'chat');
+    expect(chatCmd).toBeDefined();
+    const helpText = chatCmd!.helpInformation();
+    expect(helpText).toContain('--yolo');
+    expect(helpText).not.toContain('--dangerously-skip-permissions');
+  });
+});


### PR DESCRIPTION
Closes #892

## What

Adds `--yolo` (hidden alias `--dangerously-skip-permissions`) to `chat`, `agent`, and `interactive` commands. The flag flips the shared `PermissionManager` into `'auto'` mode, delegating checks to the previously dormant `AllowEverythingPermission` module.

## How

- **`src/permission/index.ts`**
  - New `PermissionMode = 'auto' | 'normal'`.
  - `setPermissionMode` / `getPermissionMode` on `PermissionManager`.
  - In `check()`, after the doom-loop and external-path guards but before rule evaluation, `'auto'` mode delegates to a lazily-constructed `AllowEverythingPermission` whose `excludePatterns` are derived from the built-in `deny-secrets` rule (`.env`, `.env.*`, `secrets.*`, `*credential*`, `*secret*`), plus a belt-and-braces `**/.ssh/**` exclude.
  - Deny path still records the operation attempt (doom-loop parity); allow path still resets tracking.
- **`src/cli/commands/{chat,agent,interactive}.ts`**
  - `.option('--yolo', ...)` and `addOption(new Option('--dangerously-skip-permissions', ...).hideHelp())`.
  - Action handler calls `getPermissionManager().setPermissionMode('auto')` when either flag is present.

## Tests

- `src/permission/allow-everything.test.ts`: 7 tests covering default mode, mode switching, allow path (no `PermissionRequested` publish), `.env` deny, `secrets.*` deny, SSH deny even with empty rule set, and normal-mode fallback to the ask flow.
- `tests/cli-yolo-flag.test.ts`: 6 tests exercising the flag on all three commands (`--yolo`, alias, default), plus a help-text assertion proving `--dangerously-skip-permissions` is hidden.

## Verification

```
npm run lint          # 0 errors
npm run typecheck     # green
npm run format:check  # green
npm run test:coverage # 62.73% lines (CI floor: 40%)
npm run build         # green
```

## Notes

- TUI `StatusBar` update is intentionally deferred per the issue's "do NOT touch the TUI in this issue" directive.
- The workflow harness `KILO_FLAGS=--auto --variant max` remains untouched; this PR only exposes the app-layer equivalent for interactive/CLI users.