### PR TITLE
fix(tools): trim command before matchCommand to close leading-whitespace bypass (#904)

### DIFF
--- a/src/permission/wildcard.ts
+++ b/src/permission/wildcard.ts
@@ -152,7 +152,10 @@ function isFullCommandPattern(pattern: string): boolean {
  * string so that shapes like `find *-exec*` can catch exec-flag escapes.
  */
 export function matchCommand(command: string, allowedCommands: string[]): boolean {
-  const cmdName = command.split(/\s+/)[0]; // Get first word (the command)
+  // Trim leading/trailing whitespace so patterns like `find *-exec*` are not
+  // silently bypassed by a stray leading space in the command string.
+  const trimmed = command.trim();
+  const cmdName = trimmed.split(/\s+/)[0]; // Get first word (the command)
 
   return allowedCommands.some((allowed) => {
     if (allowed === '*') return true;
@@ -160,7 +163,7 @@ export function matchCommand(command: string, allowedCommands: string[]): boolea
 
     if (isFullCommandPattern(allowed)) {
       try {
-        return commandPatternToRegex(allowed).test(command);
+        return commandPatternToRegex(allowed).test(trimmed);
       } catch {
         return false;
       }

--- a/tests/permission/wildcard.test.ts
+++ b/tests/permission/wildcard.test.ts
@@ -101,6 +101,14 @@ describe('matchCommand', () => {
     it('matches `rm -rf /*` glob shape', () => {
       expect(matchCommand('rm -rf /home', ['rm -rf /*'])).toBe(true);
     });
+
+    it('is not bypassed by leading or trailing whitespace', () => {
+      // Regression: a stray leading space used to make the full-command
+      // regex (`^find.*-exec.*$`) miss and silently allow the command.
+      expect(matchCommand('  find . -exec sh -c whoami ;', ['find *-exec*'])).toBe(true);
+      expect(matchCommand('find . -exec sh -c whoami ;   ', ['find *-exec*'])).toBe(true);
+      expect(matchCommand('\tfind . -exec sh -c whoami ;', ['find *-exec*'])).toBe(true);
+    });
   });
 
   describe('multiple patterns', () => {


### PR DESCRIPTION
## Summary

Follow-up to #909, which layered exec-flag escapes on the read-only bash allowlist. That fix used the full command string as the regex target, but did not trim it first — so a stray leading whitespace character (`  find . -exec ...`, `\tfind ...`) would silently defeat the anchored `^find.*-exec.*$` pattern and re-open the escape.

This PR trims the command before both first-token extraction and full-command regex matching, and adds a regression test covering leading spaces, trailing spaces, and a leading tab. All prior tests remain green.

## Diff scope

- ``src/permission/wildcard.ts``: ``matchCommand`` now trims the incoming command and uses the trimmed value for both ``cmdName`` and the full-command regex test.
- ``tests/permission/wildcard.test.ts``: adds a leading/trailing whitespace regression case.

Rebased on top of current ``master``; the earlier duplicate of #909 is dropped.

## Checks

- typecheck: pass
- lint: pass
- format: pass
- tests: 206 files / 2848 pass, 2 skipped
- build: (unchanged surface)

Closes #904