### PR TITLE
feat(agent): document stripInternalOptions callsite policy and cover deny-list

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { Agent } from './index.js';
-import { getAgentRegistry, getCurrentAgent, switchAgent } from './index.js';
+import {
+  getAgentRegistry,
+  getCurrentAgent,
+  switchAgent,
+  stripInternalOptions,
+  INTERNAL_OPTION_KEYS,
+} from './index.js';
 
 describe('Agent System', () => {
   beforeEach(() => {
@@ -69,6 +75,95 @@ describe('Agent System', () => {
       // Explore agent should not have write or bash
       expect(agent.canUseTool('write')).toBe(false);
       expect(agent.canUseTool('bash')).toBe(false);
+    });
+  });
+
+  describe('stripInternalOptions', () => {
+    it('strips every key listed in INTERNAL_OPTION_KEYS', () => {
+      const input: Record<string, unknown> = {
+        // real provider option fields must survive
+        maxTokens: 4096,
+        temperature: 0.7,
+      };
+      // Inject a sentinel value for every internal key
+      for (const key of INTERNAL_OPTION_KEYS) {
+        input[key] = `internal-${key}`;
+      }
+
+      const result = stripInternalOptions(input);
+
+      // Every internal key must be gone
+      for (const key of INTERNAL_OPTION_KEYS) {
+        expect(result).not.toHaveProperty(key);
+      }
+      // Real options preserved with their original values
+      expect(result.maxTokens).toBe(4096);
+      expect(result.temperature).toBe(0.7);
+      // Result contains exactly the two real fields
+      expect(Object.keys(result).sort()).toEqual(['maxTokens', 'temperature']);
+    });
+
+    it('preserves non-internal keys with their original values', () => {
+      const signal = new AbortController().signal;
+      const headers = { 'x-request-id': 'abc' };
+      const tools = [{ type: 'function' as const, function: { name: 'read' } }];
+
+      const result = stripInternalOptions({
+        maxTokens: 2048,
+        temperature: 0.2,
+        topP: 0.95,
+        topK: 40,
+        signal,
+        headers,
+        tools,
+        toolChoice: 'auto',
+      });
+
+      expect(result.maxTokens).toBe(2048);
+      expect(result.temperature).toBe(0.2);
+      expect(result.topP).toBe(0.95);
+      expect(result.topK).toBe(40);
+      expect(result.signal).toBe(signal);
+      expect(result.headers).toBe(headers);
+      expect(result.tools).toBe(tools);
+      expect(result.toolChoice).toBe('auto');
+    });
+
+    it('returns an empty object for an empty input', () => {
+      expect(stripInternalOptions({})).toEqual({});
+    });
+
+    it('does not mutate the input object', () => {
+      const input = {
+        id: 'code',
+        source: 'user',
+        maxTokens: 1024,
+      };
+      const before = { ...input };
+      stripInternalOptions(input);
+      expect(input).toEqual(before);
+    });
+
+    it('covers all known agent-metadata deny-list entries', () => {
+      // Snapshot-style guard: if a new AgentConfig-only field is added to
+      // AgentSchema, the developer must also update INTERNAL_OPTION_KEYS (or
+      // explicitly justify why it is a legitimate provider option).
+      const expected = [
+        'id',
+        'name',
+        'displayName',
+        'description',
+        'source',
+        'reference',
+        'resolved',
+        'mode',
+        'systemPrompt',
+        'deprecated',
+        'disabledTools',
+        'aliases',
+        'preferredModel',
+      ];
+      expect([...INTERNAL_OPTION_KEYS].sort()).toEqual(expected.sort());
     });
   });
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -37,20 +37,77 @@ export const AgentSchema = z.object({
 
 export type AgentConfig = z.infer<typeof AgentSchema>;
 
+/**
+ * Agent-metadata keys that must NEVER be forwarded to `provider.complete()` or
+ * `provider.streamComplete()`. These fields describe the agent itself (its
+ * identity, prompt, mode, aliases, tool allowlist, source origin, reference
+ * resolution state) and have no meaning to SAP AI Core / SAP Orchestration.
+ *
+ * Some SAP orchestration paths reject unknown options; others silently pass
+ * them through to the model. Either way, leaking agent metadata into request
+ * options is a bug. This deny-list is the source of truth for `stripInternalOptions`.
+ *
+ * If you add a new field to `AgentSchema` that is NOT a legitimate
+ * `CompletionOptions` field (see `src/providers/sapOrchestration.ts`), add it
+ * here too and update the JSDoc on `stripInternalOptions`.
+ *
+ * Notable exclusions:
+ * - `preferredModel` on the agent is consumed by callers to pick the model
+ *   BEFORE dispatch (see `agenticChat.ts`), never as a provider option, so it
+ *   is included here as internal.
+ * - `tools` is intentionally NOT in this list: on the agent it means "allowed
+ *   tool names" (string[]) but on `CompletionOptions` it means "tool schemas"
+ *   (ChatCompletionTool[]). The two must never share an options bag; callers
+ *   must never spread `AgentConfig` into `CompletionOptions` directly.
+ */
 export const INTERNAL_OPTION_KEYS = [
   'id',
+  'name',
   'displayName',
+  'description',
   'source',
   'reference',
   'resolved',
+  'mode',
+  'systemPrompt',
+  'deprecated',
+  'disabledTools',
+  'aliases',
+  'preferredModel',
 ] as const;
 
 const internal: ReadonlySet<string> = new Set(INTERNAL_OPTION_KEYS);
 
+/**
+ * Strip agent-metadata keys from an options-like object before forwarding it to
+ * `provider.complete()` / `provider.streamComplete()`.
+ *
+ * ## When to use
+ *
+ * Call this whenever an options bag passed to a provider MIGHT contain agent
+ * metadata. That happens when a caller constructs `CompletionOptions` by
+ * merging in fields from an `AgentConfig` (for example carrying
+ * `source: 'user' | 'org'` provenance alongside real request options, or
+ * spreading an org-managed agent's `options` blob into the request).
+ *
+ * As of this writing (2026-07-04), the built-in dispatch sites in
+ * `src/core/agenticChat.ts`, `src/core/streamingOrchestrator.ts`, and
+ * `src/core/orchestrator.ts` construct `CompletionOptions` explicitly with only
+ * legitimate provider fields (`maxTokens`, `temperature`, `signal`, `tools`,
+ * `headers`), so they do NOT need to call this helper. If you introduce a new
+ * dispatch site that merges agent metadata into the options bag, you MUST call
+ * `stripInternalOptions` on the merged bag before passing it to the provider.
+ *
+ * The deny-list is `INTERNAL_OPTION_KEYS`; see its JSDoc for what is stripped
+ * and why. Non-listed keys (including all legitimate `CompletionOptions`
+ * fields) are preserved with their original values, including `undefined`.
+ */
 export function stripInternalOptions(options: Record<string, any>): Record<string, any> {
   const result: Record<string, any> = {};
   for (const key in options) {
-    if (internal.has(key)) continue;
+    if (internal.has(key)) {
+      continue;
+    }
     result[key] = options[key];
   }
   return result;


### PR DESCRIPTION
Closes #912

## Summary

Audit of runtime call sites showed the leak the issue describes is theoretical today. All dispatch sites in `agenticChat`, `streamingOrchestrator`, and `orchestrator` build `CompletionOptions` from an explicit whitelist (`maxTokens`, `temperature`, `signal`, `tools`, `headers`) and never spread `AgentConfig` metadata into the options bag. Rather than invent a fake call site, this change follows the fallback in the issue: cover the helper directly and document exactly when it must be called.

## Changes

- **Expanded `INTERNAL_OPTION_KEYS`** to cover every `AgentConfig`-only field:
  `id`, `name`, `displayName`, `description`, `source`, `reference`, `resolved`, `mode`, `systemPrompt`, `deprecated`, `disabledTools`, `aliases`, `preferredModel`. `tools` is deliberately excluded because it is also a legitimate `CompletionOptions` field with a different shape — callers must never spread `AgentConfig` into `CompletionOptions` directly.
- **Added JSDoc** to `INTERNAL_OPTION_KEYS` explaining what to add and why, and to `stripInternalOptions` documenting when callers must use it (any new dispatch site that merges agent metadata into the options bag).
- **Added 5 direct unit tests** covering: every deny-list key is stripped, non-internal keys are preserved (with identity checks for objects), empty input yields empty output, the helper does not mutate input, and a snapshot-style guard that fails if `INTERNAL_OPTION_KEYS` drifts without an accompanying test update.

## Verification

- `npm run lint` -> 0 errors
- `npm run typecheck` -> clean
- `npm run format:check` -> clean
- `npm test` -> 2859 passed, 2 skipped
- `npm run test:coverage` -> 62.99% line coverage (>= 40% CI floor)
- `npm run build` -> succeeds

[alexi-bot]