### PR TITLE
feat(providers): forward AbortSignal to SAP SDK in non-streaming complete()

### DIFF
--- a/src/providers/sapOrchestration.ts
+++ b/src/providers/sapOrchestration.ts
@@ -797,7 +797,17 @@ export class SapOrchestrationProvider {
     const client = this.createClient(options);
     const orchestrationMessages = toOrchestrationMessages(messages);
 
-    const requestConfig = options?.headers ? { headers: options.headers } : undefined;
+    // Forward AbortSignal to the SAP SDK so user-initiated Ctrl+C (or any
+    // upstream cancellation) tears down the in-flight HTTP request instead
+    // of burning tokens until the model finishes. `chatCompletion` calls
+    // `signal?.throwIfAborted()` and passes the signal through to fetch.
+    const requestConfig =
+      options?.headers || options?.signal
+        ? {
+            ...(options?.headers ? { headers: options.headers } : {}),
+            ...(options?.signal ? { signal: options.signal } : {}),
+          }
+        : undefined;
 
     const response = await client.chatCompletion(
       { messages: orchestrationMessages },


### PR DESCRIPTION
## What

Merge `options.signal` into the SAP orchestration provider's request config so `OrchestrationClient.chatCompletion` receives it. Previously the non-streaming `complete()` path in `src/providers/sapOrchestration.ts:791` built `requestConfig` from headers only and silently dropped the caller's `AbortSignal`.

## Why

The `sendChat` -> `provider.complete` plumbing was already wired end-to-end in #919 (`orchestrator.ts` accepts `signal?: AbortSignal` and forwards it in the options bag; `router.classifyRouteError` distinguishes `AbortError`; the REPL wires Ctrl+C to `state.abortController` for both `/goal` and `/code-review`). But the SAP provider never propagated `signal` to the SDK's `requestConfig`, so Ctrl+C on a non-streaming request only detached the JS caller -- the HTTP request kept running to completion and tokens kept burning.

The SAP SDK's `chatCompletion` calls `requestConfig?.signal?.throwIfAborted()` and threads the signal through to `fetch`, so surfacing it in `requestConfig` is all that's needed.

## Change

- `src/providers/sapOrchestration.ts:800-810` — merge `options.signal` alongside `options.headers` when building `requestConfig`. `requestConfig` is `undefined` iff neither is set (unchanged when both are absent).

## Verification

- `npm run lint` -> 0 errors
- `npm run typecheck` -> clean
- `npm run format:check` -> clean
- `npm test` -> 2859 passed, 2 skipped
- `npm run test:coverage` -> lines 62.98% (>= 40% floor)
- `npm run build` -> succeeds

The existing `AbortSignal handling` tests in `tests/orchestrator.test.ts:297-393` (added in #919) already assert that `provider.complete` receives the signal and that aborts do not record a route outcome. This change closes the last hop by ensuring the signal actually reaches the SDK.

Closes #918