### PR TITLE
feat(agent): stamp <agent_switch/> marker on next user turn after switchTo

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -167,6 +167,69 @@ describe('Agent System', () => {
     });
   });
 
+  describe('pendingSwitchMarker', () => {
+    beforeEach(() => {
+      // Drain any leftover marker from prior tests so each case starts clean
+      getAgentRegistry().consumePendingSwitchMarker();
+      switchAgent('code');
+      // switchAgent('code') above stamped a fresh marker; consume it so the
+      // per-test cases below start from a null baseline.
+      getAgentRegistry().consumePendingSwitchMarker();
+    });
+
+    it('switchTo stamps a pending marker with the previous and new agent ids', () => {
+      const registry = getAgentRegistry();
+      expect(registry.peekPendingSwitchMarker()).toBeNull();
+
+      registry.switchTo('debug');
+      expect(registry.peekPendingSwitchMarker()).toEqual({ from: 'code', to: 'debug' });
+    });
+
+    it('consumePendingSwitchMarker returns the marker once then null', () => {
+      const registry = getAgentRegistry();
+      registry.switchTo('debug');
+
+      const first = registry.consumePendingSwitchMarker();
+      expect(first).toEqual({ from: 'code', to: 'debug' });
+
+      const second = registry.consumePendingSwitchMarker();
+      expect(second).toBeNull();
+    });
+
+    it('last-writer-wins: two switches before a consume surface only the second', () => {
+      const registry = getAgentRegistry();
+      registry.switchTo('debug');
+      registry.switchTo('plan');
+
+      const marker = registry.consumePendingSwitchMarker();
+      // `from` on the second switch is 'debug' (the prev current at that time),
+      // NOT 'code' (the original). This is intentional — see setter JSDoc.
+      expect(marker).toEqual({ from: 'debug', to: 'plan' });
+    });
+
+    it('peekPendingSwitchMarker is non-destructive', () => {
+      const registry = getAgentRegistry();
+      registry.switchTo('debug');
+
+      expect(registry.peekPendingSwitchMarker()).toEqual({ from: 'code', to: 'debug' });
+      expect(registry.peekPendingSwitchMarker()).toEqual({ from: 'code', to: 'debug' });
+
+      // consume clears
+      registry.consumePendingSwitchMarker();
+      expect(registry.peekPendingSwitchMarker()).toBeNull();
+    });
+
+    it('an unknown target does not clear or replace a pending marker', () => {
+      const registry = getAgentRegistry();
+      registry.switchTo('debug');
+      const result = registry.switchTo('does-not-exist');
+
+      expect(result).toBeNull();
+      // Marker from the successful switch is still there
+      expect(registry.peekPendingSwitchMarker()).toEqual({ from: 'code', to: 'debug' });
+    });
+  });
+
   describe('Agent mode filtering', () => {
     it('lists primary agents', () => {
       const registry = getAgentRegistry();

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -195,6 +195,21 @@ class AgentRegistry {
   private agents: Map<string, Agent> = new Map();
   private aliasMap: Map<string, string> = new Map();
   private currentAgentId: string = 'code';
+  /**
+   * Marker describing the most recent unconsumed `switchTo` call. On the next
+   * outbound user turn, orchestrators consume this marker and prepend a
+   * `<agent_switch from="X" to="Y"/>` tag to the user message content so the
+   * destination agent's model can see that a handover happened.
+   *
+   * Semantics:
+   * - `switchTo(...)` REPLACES the pending marker (last-writer-wins). If two
+   *   switches happen back-to-back with no consume in between, only the
+   *   second switch's `from`/`to` are surfaced. This intentionally collapses
+   *   rapid ping-pong into a single marker on the first upcoming user turn.
+   * - `consumePendingSwitchMarker()` atomically returns and clears the value.
+   * - In-memory only. A process restart clears the pending state naturally.
+   */
+  private pendingSwitchMarker: { from: string; to: string } | null = null;
 
   constructor() {
     // Register built-in agents
@@ -258,6 +273,11 @@ class AgentRegistry {
     const fromId = this.currentAgentId;
     this.currentAgentId = agent.id;
 
+    // Stamp a pending marker so the next outbound user turn can inform the
+    // destination model that a handover happened. Last-writer-wins: if a
+    // previous marker is unconsumed, it is overwritten (see field JSDoc).
+    this.pendingSwitchMarker = { from: fromId, to: agent.id };
+
     // Publish event
     AgentSwitched.publish({
       from: fromId,
@@ -267,6 +287,28 @@ class AgentRegistry {
     });
 
     return agent;
+  }
+
+  /**
+   * Atomically return the pending switch marker and clear it. Callers
+   * (agenticChat, streamingOrchestrator) invoke this immediately before
+   * appending the outbound user message, and if the return value is
+   * non-null they prepend `<agent_switch from="X" to="Y"/>\n\n` to the
+   * user content.
+   */
+  consumePendingSwitchMarker(): { from: string; to: string } | null {
+    const marker = this.pendingSwitchMarker;
+    this.pendingSwitchMarker = null;
+    return marker;
+  }
+
+  /**
+   * Non-destructive peek at the pending switch marker. Intended for tests
+   * and diagnostics; production callers should use `consumePendingSwitchMarker`
+   * to guarantee the marker is emitted only once per switch.
+   */
+  peekPendingSwitchMarker(): { from: string; to: string } | null {
+    return this.pendingSwitchMarker;
   }
 
   /**

--- a/src/agent/stripInternalWrappers.test.ts
+++ b/src/agent/stripInternalWrappers.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { stripInternalWrappers } from './stripInternalWrappers.js';
+
+describe('stripInternalWrappers', () => {
+  it('removes a self-closing <agent_switch/> marker', () => {
+    const input = '<agent_switch from="code" to="debug"/>\n\nHello there';
+    expect(stripInternalWrappers(input)).toBe('\n\nHello there');
+  });
+
+  it('removes a <system-reminder>...</system-reminder> block', () => {
+    const input = '<system-reminder>Step limit reached.</system-reminder>';
+    expect(stripInternalWrappers(input)).toBe('');
+  });
+
+  it('removes multi-line <system-reminder> bodies', () => {
+    const input =
+      'Prefix\n' +
+      '<system-reminder source="apps/foo/AGENTS.md">\n' +
+      'Line 1\n' +
+      'Line 2\n' +
+      'Line 3\n' +
+      '</system-reminder>\n' +
+      'Suffix';
+    const out = stripInternalWrappers(input);
+    expect(out).not.toContain('system-reminder');
+    expect(out).not.toContain('Line 1');
+    expect(out.startsWith('Prefix')).toBe(true);
+    expect(out.endsWith('Suffix')).toBe(true);
+  });
+
+  it('preserves normal user prose around the wrappers', () => {
+    const input =
+      '<agent_switch from="code" to="debug"/>\n\n' +
+      'Please look at src/foo.ts and\n' +
+      '<system-reminder>ignore me</system-reminder>\n' +
+      'tell me what happens.';
+    const out = stripInternalWrappers(input);
+    expect(out).toContain('Please look at src/foo.ts and');
+    expect(out).toContain('tell me what happens.');
+    expect(out).not.toContain('agent_switch');
+    expect(out).not.toContain('system-reminder');
+  });
+
+  it('is idempotent on already-clean input', () => {
+    const clean = 'Just a normal user message.';
+    expect(stripInternalWrappers(clean)).toBe(clean);
+    expect(stripInternalWrappers(stripInternalWrappers(clean))).toBe(clean);
+  });
+
+  it('is idempotent when applied twice to wrapped input', () => {
+    const wrapped =
+      '<agent_switch from="code" to="debug"/>\n\n' +
+      'hi <system-reminder>x</system-reminder> there';
+    const once = stripInternalWrappers(wrapped);
+    const twice = stripInternalWrappers(once);
+    expect(twice).toBe(once);
+  });
+
+  it('handles multiple consecutive <system-reminder> blocks without merging bodies', () => {
+    const input =
+      '<system-reminder>A</system-reminder>' + 'MIDDLE' + '<system-reminder>B</system-reminder>';
+    expect(stripInternalWrappers(input)).toBe('MIDDLE');
+  });
+
+  it('handles empty and non-string-like inputs safely', () => {
+    expect(stripInternalWrappers('')).toBe('');
+  });
+
+  it('leaves other angle-bracket tokens untouched', () => {
+    const input = 'Compare a < b and c > d in <not-a-reminder>text</not-a-reminder>.';
+    expect(stripInternalWrappers(input)).toBe(input);
+  });
+});

--- a/src/agent/stripInternalWrappers.ts
+++ b/src/agent/stripInternalWrappers.ts
@@ -1,0 +1,50 @@
+/**
+ * Helpers for stripping Alexi-internal message wrappers from user-facing text.
+ *
+ * Two kinds of wrappers may appear in stored message content:
+ *
+ * - `<agent_switch from="X" to="Y"/>` — a self-closing marker prepended to
+ *   the first outbound user turn after a `switchTo(...)` call. Signals the
+ *   destination agent's model that a handover happened. Emitted by
+ *   `agenticChat` and `streamingOrchestrator`.
+ *
+ * - `<system-reminder>...</system-reminder>` — a block wrapper used for
+ *   AGENTS.md reminders, step-limit hints, and similar per-turn signals
+ *   sent to the model. Emitted by `agenticChat`.
+ *
+ * These wrappers are useful for the model but should never be shown to a
+ * human user (TUI display) or included in exported transcripts (session
+ * export). This module provides a single `stripInternalWrappers(text)`
+ * entrypoint used by both call sites.
+ *
+ * The stripper is IDEMPOTENT and preserves surrounding prose. It uses a
+ * pair of single-shot regexes rather than an HTML parser to avoid pulling
+ * in a dependency.
+ */
+
+// Match self-closing `<agent_switch ... />` markers with any attribute set.
+// Case-sensitive on the tag name; attributes may span multiple lines.
+const AGENT_SWITCH_RE = /<agent_switch\b[^>]*\/>/g;
+
+// Match `<system-reminder ...>...</system-reminder>` blocks including
+// multi-line bodies. Non-greedy body so consecutive blocks aren't merged.
+const SYSTEM_REMINDER_RE = /<system-reminder\b[^>]*>[\s\S]*?<\/system-reminder>/g;
+
+/**
+ * Remove `<agent_switch/>` self-closing markers and
+ * `<system-reminder>...</system-reminder>` blocks from `text`.
+ *
+ * - Idempotent: calling it on already-clean text returns the input.
+ * - Preserves whitespace around removed wrappers; the caller is responsible
+ *   for any secondary trimming they need.
+ * - Non-mutating: returns a new string.
+ *
+ * @param text The raw message content (may include wrappers).
+ * @returns The same text with internal wrappers removed.
+ */
+export function stripInternalWrappers(text: string): string {
+  if (!text) {
+    return text;
+  }
+  return text.replace(AGENT_SWITCH_RE, '').replace(SYSTEM_REMINDER_RE, '');
+}

--- a/src/cli/tui/components/MessageBubble.tsx
+++ b/src/cli/tui/components/MessageBubble.tsx
@@ -5,6 +5,7 @@ import type { MessageBubbleProps } from '../types/props.js';
 import { MarkdownRenderer } from './MarkdownRenderer.js';
 import { useTheme } from '../context/ThemeContext.js';
 import { formatSize } from '../../../utils/imageValidation.js';
+import { stripInternalWrappers } from '../../../agent/stripInternalWrappers.js';
 
 export type { MessageBubbleProps };
 
@@ -78,7 +79,7 @@ export function MessageBubble({
           <Text color={colors.dimText}> {timeStr}</Text>
         </Box>
         <Box paddingLeft={2}>
-          <Text wrap="wrap">{content}</Text>
+          <Text wrap="wrap">{stripInternalWrappers(content)}</Text>
         </Box>
       </Box>
     );

--- a/src/cli/tui/dialogs/RewindDialog.tsx
+++ b/src/cli/tui/dialogs/RewindDialog.tsx
@@ -4,6 +4,7 @@ import { Box, Text, useInput } from 'ink';
 import { useDialog } from '../context/DialogContext.js';
 import { useTheme } from '../context/ThemeContext.js';
 import type { MessageDisplay } from '../components/MessageArea.js';
+import { stripInternalWrappers } from '../../../agent/stripInternalWrappers.js';
 
 export interface RewindDialogProps {
   messages: MessageDisplay[];
@@ -32,7 +33,7 @@ function extractTurnBoundaries(messages: MessageDisplay[]): TurnBoundary[] {
     const msg = messages[i];
     if (msg.role === 'user') {
       turnNumber++;
-      const firstLine = msg.content.split('\n')[0].slice(0, 60);
+      const firstLine = stripInternalWrappers(msg.content).trim().split('\n')[0].slice(0, 60);
       boundaries.push({
         index: i,
         turnNumber,

--- a/src/core/__tests__/agenticChat.test.ts
+++ b/src/core/__tests__/agenticChat.test.ts
@@ -909,5 +909,72 @@ describe('agenticChat', () => {
         expect(result.iterations).toBe(1);
       });
     });
+
+    describe('agent_switch marker prepend', () => {
+      it('prepends <agent_switch/> to the next user turn after switchTo, once', async () => {
+        const { getAgentRegistry, switchAgent } = await import('../../agent/index.js');
+        // Drain any pre-existing marker and reset baseline to 'code'
+        getAgentRegistry().consumePendingSwitchMarker();
+        switchAgent('code');
+        getAgentRegistry().consumePendingSwitchMarker();
+
+        // Perform a real switch so the marker is stamped
+        switchAgent('debug');
+
+        mockProvider.complete.mockResolvedValueOnce({
+          text: 'Ack.',
+          usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+        } satisfies CompletionResult);
+
+        await agenticChat('First turn after switch');
+
+        expect(mockProvider.complete).toHaveBeenCalledTimes(1);
+        const firstCallMessages = mockProvider.complete.mock.calls[0][0] as Array<{
+          role: string;
+          content: string;
+        }>;
+        const lastUser = [...firstCallMessages].reverse().find((m) => m.role === 'user')!;
+        expect(lastUser.content).toContain('<agent_switch from="code" to="debug"/>');
+        expect(lastUser.content).toContain('First turn after switch');
+
+        // Second turn (no new switch) must NOT get another marker
+        mockProvider.complete.mockClear();
+        mockProvider.complete.mockResolvedValueOnce({
+          text: 'Ack again.',
+          usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+        } satisfies CompletionResult);
+
+        await agenticChat('Second turn without switch');
+
+        const secondCallMessages = mockProvider.complete.mock.calls[0][0] as Array<{
+          role: string;
+          content: string;
+        }>;
+        const secondUser = [...secondCallMessages].reverse().find((m) => m.role === 'user')!;
+        expect(secondUser.content).not.toContain('agent_switch');
+        expect(secondUser.content).toContain('Second turn without switch');
+      });
+
+      it('does not prepend when no switchTo has happened', async () => {
+        const { getAgentRegistry } = await import('../../agent/index.js');
+        // Ensure a clean baseline
+        getAgentRegistry().consumePendingSwitchMarker();
+
+        mockProvider.complete.mockResolvedValueOnce({
+          text: 'Ack.',
+          usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+        } satisfies CompletionResult);
+
+        await agenticChat('Plain turn');
+
+        const messages = mockProvider.complete.mock.calls[0][0] as Array<{
+          role: string;
+          content: string;
+        }>;
+        const lastUser = [...messages].reverse().find((m) => m.role === 'user')!;
+        expect(lastUser.content).not.toContain('agent_switch');
+        expect(lastUser.content).toBe('Plain turn');
+      });
+    });
   });
 });

--- a/src/core/agenticChat.ts
+++ b/src/core/agenticChat.ts
@@ -480,7 +480,22 @@ export async function agenticChat(
     }
   }
 
-  messages.push({ role: 'user', content: message });
+  // If a `switchTo(...)` happened since the last outbound user turn, stamp
+  // an `<agent_switch from="X" to="Y"/>` marker on this user message so the
+  // destination agent's model can see the handover. Prepend to the same
+  // content string (not a separate message) to keep message count stable.
+  let outboundUserContent = message;
+  try {
+    const { getAgentRegistry } = await import('../agent/index.js');
+    const marker = getAgentRegistry().consumePendingSwitchMarker();
+    if (marker) {
+      outboundUserContent = `<agent_switch from="${marker.from}" to="${marker.to}"/>\n\n${message}`;
+    }
+  } catch {
+    // Agent registry not available in this environment — no-op.
+  }
+
+  messages.push({ role: 'user', content: outboundUserContent });
 
   // Tracking
   let iterations = 0;
@@ -788,9 +803,13 @@ export async function agenticChat(
     );
   }
 
-  // Save to session if provided
+  // Save to session if provided.
+  // Persist the raw outbound user content (including any `<agent_switch/>`
+  // marker) so session replay preserves the handover context. The TUI and
+  // `sessions export` strip wrappers on the display path via
+  // `stripInternalWrappers`.
   if (options?.sessionManager) {
-    options.sessionManager.addMessage('user', message, {
+    options.sessionManager.addMessage('user', outboundUserContent, {
       input: totalUsage.prompt_tokens,
     });
     options.sessionManager.addMessage('assistant', finalText, {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'crypto';
 import { shouldCompact, compactConversation, estimateMessagesTokens } from './compaction.js';
 import { closeSession } from './sessionClose.js';
 import { clearRuleCommandCache } from '../plugin/index.js';
+import { stripInternalWrappers } from '../agent/stripInternalWrappers.js';
 
 /**
  * Normalize a workdir for comparison. Resolves `.`, `..`, and trailing
@@ -324,7 +325,11 @@ export class SessionManager {
     for (const message of session.messages) {
       const timestamp = new Date(message.timestamp).toLocaleString();
       markdown += `## ${message.role.toUpperCase()} (${timestamp})\n\n`;
-      markdown += `${message.content}\n\n`;
+      // Strip Alexi-internal wrappers (`<agent_switch/>`,
+      // `<system-reminder>...</system-reminder>`) from the exported view.
+      // The on-disk session store keeps the raw markers so replay still
+      // sees the handover context.
+      markdown += `${stripInternalWrappers(message.content)}\n\n`;
 
       if (message.tokens) {
         markdown += `*Tokens: ${message.tokens.input || 0} in / ${message.tokens.output || 0} out*\n\n`;

--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -116,8 +116,27 @@ export async function* streamChat(
     }
   }
 
+  // If a `switchTo(...)` happened since the last outbound user turn, stamp
+  // an `<agent_switch from="X" to="Y"/>` marker on this user message so the
+  // destination agent's model can see the handover. Only text messages get
+  // the prefix; multimodal content arrays are passed through unchanged
+  // because prepending to an array item is ambiguous.
+  let outboundContent: string | unknown[] = message;
+  let outboundTextForSession = messageText;
+  try {
+    const { getAgentRegistry } = await import('../agent/index.js');
+    const marker = getAgentRegistry().consumePendingSwitchMarker();
+    if (marker && !isMultimodal && typeof message === 'string') {
+      const prefixed = `<agent_switch from="${marker.from}" to="${marker.to}"/>\n\n${message}`;
+      outboundContent = prefixed;
+      outboundTextForSession = prefixed;
+    }
+  } catch {
+    // Agent registry not available in this environment — no-op.
+  }
+
   // Add current user message
-  messages.push({ role: 'user', content: message });
+  messages.push({ role: 'user', content: outboundContent });
 
   // Get SAP Orchestration provider for this model, falling back to
   // routingConfig.preferences.fallbackModel if the primary id is not recognized.
@@ -163,9 +182,12 @@ export async function* streamChat(
   }
   recordRouteOutcome(modelId, { kind: 'success' });
 
-  // Save messages to session AFTER streaming completes (not per-chunk)
+  // Save messages to session AFTER streaming completes (not per-chunk).
+  // Persist the raw outbound content (including any `<agent_switch/>`
+  // marker) so session replay preserves the handover context. TUI display
+  // and `sessions export` strip the wrappers.
   if (options?.sessionManager) {
-    options.sessionManager.addMessage('user', messageText, {
+    options.sessionManager.addMessage('user', outboundTextForSession, {
       input: finalUsage?.prompt_tokens,
     });
     options.sessionManager.addMessage('assistant', fullText, {


### PR DESCRIPTION
Closes #925

## Summary

- Adds `pendingSwitchMarker` state on `AgentRegistry` with `consumePendingSwitchMarker` (atomic, single-shot) and `peekPendingSwitchMarker` (non-destructive) accessors. Every `switchTo(...)` call stamps a marker (last-writer-wins if two switches race a consume).
- `agenticChat` and `streamingOrchestrator` consume the marker right before appending the next outbound user turn and prepend `<agent_switch from=\"X\" to=\"Y\"/>\n\n` to that user message's content. Only prepends once per switch; not re-emitted on subsequent turns.
- New `stripInternalWrappers(text)` helper in `src/agent/stripInternalWrappers.ts` removes `<agent_switch/>` markers and `<system-reminder>...</system-reminder>` blocks. Idempotent, single-shot regex, no HTML parser dep.
- TUI (`MessageBubble`, `RewindDialog`) and `sessions export` (via `SessionManager.exportToMarkdown`) run user content through `stripInternalWrappers` on the display path. On-disk session persistence keeps the raw marker so replay preserves handover context.

## Verification

- `npm run lint` -> 0 errors
- `npm run typecheck` -> clean
- `npm run format:check` -> clean
- `npm test` -> 208 files / 2879 passed
- `npm run test:coverage` -> lines 63.16% (well above 40%)
- `npm run build` -> succeeds
- `grep -rn 'agent_switch' src/` returns 23 matches across agent, core, tui and the two new test files.

## Non-goals respected

- Pending marker is in-memory only; process restart clears naturally.
- No emission for the initial agent — only real `switchTo` calls set state.
- `AgentSwitched` bus event shape is unchanged.

[alexi-bot]