### PR TITLE
refactor(core): route src/mcp/client.ts console.* calls through shared logger

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -7,6 +7,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { spawn, type ChildProcess } from 'child_process';
 import path from 'path';
+import { logger } from '../utils/logger.js';
 import { loadMcpConfig, resolveEnvVars, type McpServerConfig } from './config.js';
 
 export interface McpToolInfo {
@@ -140,7 +141,7 @@ export class McpClientManager {
         throw new Error('Invalid schema structure');
       }
     } catch (error) {
-      console.warn(
+      logger.warn(
         `MCP tool schema parsing failed for ${tool.name} from ${serverName}, using permissive fallback:`,
         error
       );
@@ -203,13 +204,13 @@ export class McpClientManager {
       connection.tools = rawTools.map((tool) => this.mapToolInfo(tool, config.name));
 
       connection.status = 'connected';
-      console.log(`Connected to MCP server: ${config.name} (${connection.tools.length} tools)`);
+      logger.info(`Connected to MCP server: ${config.name} (${connection.tools.length} tools)`);
 
       return connection;
     } catch (error) {
       connection.status = 'error';
       connection.error = error instanceof Error ? error.message : String(error);
-      console.error(`Failed to connect to MCP server ${config.name}:`, connection.error);
+      logger.error(`Failed to connect to MCP server ${config.name}:`, connection.error);
       return connection;
     }
   }
@@ -268,13 +269,13 @@ export class McpClientManager {
     proc.on('exit', (code) => {
       if (connection.status === 'connected') {
         connection.status = 'disconnected';
-        console.log(`MCP server ${config.name} exited with code ${code}`);
+        logger.info(`MCP server ${config.name} exited with code ${code}`);
       }
     });
 
     // Log stderr for debugging
     proc.stderr?.on('data', (data) => {
-      console.error(`[${config.name}] ${data.toString()}`);
+      logger.warn(`[${config.name}] ${data.toString()}`);
     });
 
     // Create stdio transport - filter out undefined values from env
@@ -305,7 +306,7 @@ export class McpClientManager {
     try {
       await connection.client.close();
     } catch (error) {
-      console.warn(`Error closing MCP client ${name}:`, error);
+      logger.warn(`Error closing MCP client ${name}:`, error);
     }
 
     if (connection.process) {
@@ -313,7 +314,7 @@ export class McpClientManager {
     }
 
     this.connections.delete(name);
-    console.log(`Disconnected from MCP server: ${name}`);
+    logger.info(`Disconnected from MCP server: ${name}`);
   }
 
   /**
@@ -348,7 +349,7 @@ export class McpClientManager {
             };
           }
         } catch (error) {
-          console.warn(`Failed to initialize MCP server ${server.name}:`, error);
+          logger.warn(`Failed to initialize MCP server ${server.name}:`, error);
           return {
             server: server.name,
             status: 'failed',
@@ -368,9 +369,9 @@ export class McpClientManager {
 
     if (servers.length > 0) {
       if (failed > 0) {
-        console.warn(`MCP initialization: ${successful} connected, ${failed} failed`);
+        logger.warn(`MCP initialization: ${successful} connected, ${failed} failed`);
       } else {
-        console.log(`MCP initialization: ${successful} server(s) connected`);
+        logger.info(`MCP initialization: ${successful} server(s) connected`);
       }
     }
   }
@@ -447,7 +448,7 @@ export class McpClientManager {
         timestamp: Date.now(),
       });
     } catch (error) {
-      console.error(`Failed to refresh tools from ${serverName}:`, error);
+      logger.error(`Failed to refresh tools from ${serverName}:`, error);
     }
   }
 

--- a/tests/mcp/client-logger.test.ts
+++ b/tests/mcp/client-logger.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+const mockSpawn = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+const mockClientConnect = vi.fn().mockResolvedValue(undefined);
+const mockClientListTools = vi.fn();
+const mockClientClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class MockClient {
+    connect = mockClientConnect;
+    listTools = mockClientListTools;
+    close = mockClientClose;
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+vi.mock('../../src/mcp/config.js', () => ({
+  loadMcpConfig: vi.fn().mockReturnValue({ version: '1.0', servers: [] }),
+  resolveEnvVars: vi.fn((env?: Record<string, string>) => env ?? {}),
+}));
+
+import { McpClientManager } from '../../src/mcp/client.js';
+import type { McpServerConfig } from '../../src/mcp/config.js';
+import { logger } from '../../src/utils/logger.js';
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdin = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.pid = 12345;
+  return proc;
+}
+
+describe('McpClientManager - logger integration', () => {
+  let manager: McpClientManager;
+
+  const stdioConfig: McpServerConfig = {
+    name: 'logger-test-server',
+    transport: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+    enabled: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new McpClientManager();
+    mockSpawn.mockReturnValue(createMockProcess());
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAll();
+    vi.restoreAllMocks();
+  });
+
+  it('routes the connect success message through logger.info', async () => {
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+    mockClientListTools.mockResolvedValueOnce({ tools: [] });
+
+    const connection = await manager.connect(stdioConfig);
+
+    expect(connection.status).toBe('connected');
+    expect(infoSpy).toHaveBeenCalledWith('Connected to MCP server: logger-test-server (0 tools)');
+  });
+
+  it('routes the disconnect message through logger.info', async () => {
+    mockClientListTools.mockResolvedValueOnce({ tools: [] });
+    await manager.connect(stdioConfig);
+
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+    await manager.disconnect('logger-test-server');
+
+    expect(infoSpy).toHaveBeenCalledWith('Disconnected from MCP server: logger-test-server');
+  });
+
+  it('routes connect failures through logger.error', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    mockClientConnect.mockRejectedValueOnce(new Error('boom'));
+
+    const connection = await manager.connect(stdioConfig);
+
+    expect(connection.status).toBe('error');
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to connect to MCP server logger-test-server:',
+      'boom'
+    );
+  });
+
+  it('disconnect() on a missing server is a silent no-op', async () => {
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    await manager.disconnect('nonexistent');
+
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #943

Replace 11 direct `console.*` calls in `src/mcp/client.ts` with the shared `logger` from `src/utils/logger.ts`. Enforces the `AGENTS.md` rule that only `src/utils/logger.ts` may use `console` directly, and gives MCP lifecycle messages a proper level gate for `--quiet` runs and tests.

## Mapping

| Old                       | New            | Notes                                                    |
| ------------------------- | -------------- | -------------------------------------------------------- |
| `console.log` (5 sites)   | `logger.info`  | connect success, exit, disconnect, init summary success  |
| `console.warn` (5 sites)  | `logger.warn`  | schema fallback, close error, init failures, init mixed  |
| `console.error` on stderr | `logger.warn`  | server-side stderr is warn, not our error (line 277)     |
| `console.error` (2 sites) | `logger.error` | connect failure, refresh tools failure                   |

Import added at the top of the imports block:

```ts
import { logger } from '../utils/logger.js';
```

## Tests

Added `tests/mcp/client-logger.test.ts` with 4 cases covering:
- `connect` routes success message through `logger.info`
- `disconnect` routes message through `logger.info`
- `connect` failures route through `logger.error`
- `disconnect('nonexistent')` is a silent no-op (locks in fast-path)

## Gate verification

Locally green:
- `npm run lint` — 0 errors, 0 new warnings from `src/mcp/client.ts`
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm test` — 2883 passed, 2 skipped, 209 files
- `npm run build` — clean

## Verification

```
grep -n 'console.' src/mcp/client.ts   # 0 hits
grep -n 'utils/logger' src/mcp/client.ts   # line 10 import
```