### PR TITLE
fix(tools): reap tracked background processes on SIGINT/SIGTERM

### DIFF
--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -39,6 +39,7 @@ import {
 } from '../permission/index.js';
 import { getMcpClientManager, loadMcpConfig, type McpServerConfig } from '../mcp/index.js';
 import { getDoctor } from '../doctor/index.js';
+import { killAllTracked } from '../tool/tools/background-process.js';
 import { getCostTracker } from '../core/costTracker.js';
 import { getMemoryManager } from '../core/memory.js';
 import { getDataExporter } from '../core/dataExporter.js';
@@ -2411,20 +2412,29 @@ export async function startInteractive(options: InteractiveOptions = {}): Promis
   // (goal, code-review, or a bare sendChat call) that has installed an
   // AbortController on state. Without this, non-streaming providers keep
   // burning tokens after the user cancels.
-  process.on('SIGINT', () => {
-    if (state.abortController) {
+  const shutdown = (signal: 'SIGINT' | 'SIGTERM') => {
+    if (signal === 'SIGINT' && state.abortController) {
       state.abortController.abort();
       console.log(c('yellow', '\n\n  [Cancelled]\n'));
       rl.prompt();
-    } else {
-      keypressHandler.dispose();
-      if (permissionPromptCleanup) {
-        permissionPromptCleanup();
-      }
-      console.log(c('gray', '\n\n  Goodbye!\n'));
-      process.exit(0);
+      return;
     }
-  });
+    keypressHandler.dispose();
+    if (permissionPromptCleanup) {
+      permissionPromptCleanup();
+    }
+    console.log(c('gray', '\n\n  Goodbye!\n'));
+    killAllTracked()
+      .catch(() => undefined)
+      .finally(() => process.exit(0));
+  };
+
+  // Remove the one-shot handlers installed by program.ts so the REPL owns
+  // Ctrl+C behaviour (first press aborts in-flight requests, second exits).
+  process.removeAllListeners('SIGINT');
+  process.removeAllListeners('SIGTERM');
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
 
   rl.prompt();
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -10,9 +10,23 @@ import { Command } from 'commander';
 import { createRequire } from 'module';
 import { ProviderModelFellBack } from '../bus/index.js';
 import { registerAllCommands } from './commands/index.js';
+import { killAllTracked } from '../tool/tools/background-process.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
+
+// Install SIGINT/SIGTERM handlers once so any background_process children
+// spawned during one-shot commands (e.g. `alexi chat -m "..."`) are reaped
+// on Ctrl+C or systemd/docker stop rather than orphaned. The interactive
+// REPL removes these listeners on start-up and installs its own two-stage
+// (abort-then-exit) handler.
+const oneShotShutdown = () => {
+  killAllTracked()
+    .catch(() => undefined)
+    .finally(() => process.exit(0));
+};
+process.on('SIGINT', oneShotShutdown);
+process.on('SIGTERM', oneShotShutdown);
 
 // Default fallback subscriber for non-TUI runs (CLI one-shots, scripts, tests).
 // The TUI subscribes its own handler in StatusBar.tsx and always renders,

--- a/src/tool/tools/background-process.ts
+++ b/src/tool/tools/background-process.ts
@@ -174,3 +174,64 @@ export function stopBackgroundProcess(id: string): boolean {
     return false;
   }
 }
+
+/**
+ * Terminate every tracked background process using SIGTERM, wait up to
+ * `timeoutMs` for graceful exit, then escalate to SIGKILL for stragglers.
+ *
+ * Intended for process-wide shutdown handlers (SIGINT / SIGTERM on the parent)
+ * so `detached: true` + `child.unref()` children do not survive the CLI.
+ *
+ * Always resolves; per-process kill failures are reported via `killed: false`
+ * in the result array rather than thrown.
+ */
+export async function killAllTracked(
+  timeoutMs = 1000
+): Promise<{ id: string; pid: number; killed: boolean }[]> {
+  const results: { id: string; pid: number; killed: boolean }[] = [];
+
+  for (const proc of runningProcesses.values()) {
+    try {
+      process.kill(proc.pid, 'SIGTERM');
+    } catch {
+      // already dead
+    }
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    let allDone = true;
+    for (const proc of runningProcesses.values()) {
+      try {
+        process.kill(proc.pid, 0);
+        allDone = false;
+      } catch {
+        // dead
+      }
+    }
+    if (allDone) {
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  for (const proc of runningProcesses.values()) {
+    let killed = true;
+    try {
+      process.kill(proc.pid, 0);
+      // still alive -> SIGKILL
+      try {
+        process.kill(proc.pid, 'SIGKILL');
+      } catch {
+        killed = false;
+      }
+    } catch {
+      // already dead
+    }
+    proc.status = 'stopped';
+    results.push({ id: proc.id, pid: proc.pid, killed });
+  }
+
+  runningProcesses.clear();
+  return results;
+}

--- a/tests/tool/tools/background-process.test.ts
+++ b/tests/tool/tools/background-process.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for background_process shutdown teardown (killAllTracked).
+ *
+ * Skipped on Windows — SIGTERM / SIGKILL semantics and `process.kill(pid, 0)`
+ * behaviour differ enough there to warrant a separate implementation.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the tool index module to bypass permission checks (mirror write.test.ts pattern).
+vi.mock('../../../src/tool/index.js', async () => {
+  const actual = await vi.importActual('../../../src/tool/index.js');
+  return {
+    ...actual,
+    defineTool: (def: {
+      name: string;
+      description: string;
+      execute: (...args: unknown[]) => unknown;
+    }) => ({
+      ...def,
+      execute: def.execute,
+      executeUnsafe: def.execute,
+      toFunctionSchema: () => ({
+        name: def.name,
+        description: def.description,
+        parameters: {},
+      }),
+    }),
+  };
+});
+
+import {
+  backgroundProcessTool,
+  killAllTracked,
+  listBackgroundProcesses,
+} from '../../../src/tool/tools/background-process.js';
+import type { ToolContext } from '../../../src/tool/index.js';
+
+const isWindows = process.platform === 'win32';
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForDead(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return !isAlive(pid);
+}
+
+describe('killAllTracked', () => {
+  it.skipIf(isWindows)('terminates every tracked child within 2s', async () => {
+    const context: ToolContext = {
+      workdir: process.cwd(),
+      sessionId: 'test-session',
+    };
+
+    // Ensure a clean starting state — other suites may have left entries around.
+    await killAllTracked();
+
+    const result = await backgroundProcessTool.execute({ command: 'sleep 30' }, context);
+
+    expect(result.success).toBe(true);
+    const pid = result.data?.pid;
+    expect(typeof pid).toBe('number');
+    expect(pid).toBeGreaterThan(0);
+
+    // Confirm the process is actually alive before we tear it down.
+    expect(isAlive(pid as number)).toBe(true);
+    expect(listBackgroundProcesses().length).toBe(1);
+
+    const killResults = await killAllTracked();
+
+    expect(listBackgroundProcesses().length).toBe(0);
+    expect(killResults.length).toBe(1);
+    expect(killResults[0].pid).toBe(pid);
+
+    // sleep is trivially killable, so SIGTERM (or the SIGKILL fallback) must
+    // have taken it out within the escalation window plus a small buffer.
+    const dead = await waitForDead(pid as number, 2000);
+    expect(dead).toBe(true);
+  });
+
+  it('is a no-op when there are no tracked processes', async () => {
+    // Drain anything a prior test may have left behind first.
+    await killAllTracked();
+    const results = await killAllTracked();
+    expect(results).toEqual([]);
+    expect(listBackgroundProcesses().length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Installs SIGINT/SIGTERM shutdown handlers that terminate every child tracked by
the `background_process` tool before the CLI exits, using a
SIGTERM -> 1s wait -> SIGKILL escalation. Without this, `spawn(..., { detached: true })` +
`child.unref()` left dev servers, `docker-compose up`, and other long-running
commands orphaned after Ctrl+C, holding ports until manually pkilled. Mirrors the
kilocode upstream fix in commit e0bfed3.

## Changes

- **src/tool/tools/background-process.ts** - exports new
  \`killAllTracked(timeoutMs = 1000)\` that SIGTERMs every entry in
  \`runningProcesses\`, polls with \`process.kill(pid, 0)\` until they exit or the
  deadline passes, then SIGKILLs any stragglers. Always resolves; per-pid
  failures show up as \`killed: false\` in the returned results array.
  \`stopBackgroundProcess()\` is untouched.
- **src/cli/interactive.ts** - SIGINT still aborts an in-flight request on the
  first press; the exit branch (and a new SIGTERM handler) now awaits
  \`killAllTracked()\` before \`process.exit(0)\`. Removes the one-shot listeners
  program.ts installed so the REPL fully owns Ctrl+C.
- **src/cli/program.ts** - installs SIGINT + SIGTERM handlers at module load so
  one-shot commands (\`alexi chat -m '...'\`) also reap children.
- **tests/tool/tools/background-process.test.ts** - spawns \`sleep 30\`, asserts
  \`runningProcesses.size === 1\`, calls \`killAllTracked()\`, and verifies the pid
  is reaped within 2s. Adds an empty-map no-op case. Skipped on win32.

## Verification

\`\`\`
npm run typecheck  # ok
npm run lint       # 0 errors
npm run format:check  # clean
npm test           # 2885 passed / 2 skipped (2 new tests)
npm run test:coverage  # lines 63.39% (>= 40% threshold)
npm run build      # ok
\`\`\`

Closes #953