### PR TITLE
feat(core): namespace MCP tools by serverName via qualified :: key

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -10,7 +10,7 @@ import path from 'path';
 import { loadMcpConfig, resolveEnvVars, type McpServerConfig } from './config.js';
 
 export interface McpToolInfo {
-  /** Tool name */
+  /** Tool name (raw short name as advertised by the server) */
   name: string;
   /** Tool description */
   description?: string;
@@ -23,6 +23,68 @@ export interface McpToolInfo {
   };
   /** Source server name */
   serverName: string;
+  /**
+   * Fully qualified name in the form `<escapedServerName>::<toolName>`.
+   *
+   * `serverName` is escaped so that literal `:` and `%` characters in a
+   * server name do not collide with the `::` separator. `%` is escaped
+   * first (as `%25`) so the `%3A` introduced by escaping `:` is not
+   * double-escaped on the way back.
+   *
+   * `toolName` is passed through verbatim; a tool name that itself
+   * contains `::` still round-trips because parsing splits on the LAST
+   * `::` occurrence.
+   */
+  qualifiedName: string;
+}
+
+/**
+ * Escape a server name for use in the `qualifiedName` prefix.
+ *
+ * `%` is escaped first as `%25` so that the `%3A` introduced by escaping
+ * `:` cannot be misinterpreted on the reverse pass.
+ */
+export function escapeServerName(name: string): string {
+  return name.replaceAll('%', '%25').replaceAll(':', '%3A');
+}
+
+/**
+ * Reverse of {@link escapeServerName}. `%3A` -> `:` first, then `%25` -> `%`.
+ */
+export function unescapeServerName(escaped: string): string {
+  return escaped.replaceAll('%3A', ':').replaceAll('%25', '%');
+}
+
+/**
+ * Build a qualified tool name from a raw server name and tool name.
+ */
+export function buildQualifiedName(serverName: string, toolName: string): string {
+  return `${escapeServerName(serverName)}::${toolName}`;
+}
+
+/**
+ * Parse a qualified tool name into its (unescaped) server and tool components.
+ *
+ * Splits on the FIRST `::` occurrence. Because {@link escapeServerName}
+ * turns any literal `:` in the server segment into `%3A`, the server
+ * segment never contains `::`; splitting on the first separator therefore
+ * preserves tool names that themselves contain `::`. Throws when no `::`
+ * separator is present.
+ */
+export function parseQualifiedName(qualified: string): {
+  serverName: string;
+  toolName: string;
+} {
+  const idx = qualified.indexOf('::');
+  if (idx === -1) {
+    throw new Error(`Invalid qualified tool name (missing '::'): ${qualified}`);
+  }
+  const escapedServer = qualified.slice(0, idx);
+  const toolName = qualified.slice(idx + 2);
+  return {
+    serverName: unescapeServerName(escapedServer),
+    toolName,
+  };
 }
 
 export interface McpConnection {
@@ -166,6 +228,7 @@ export class McpClientManager {
       description: tool.description,
       inputSchema,
       serverName,
+      qualifiedName: buildQualifiedName(serverName, tool.name),
     };
   }
 
@@ -538,6 +601,50 @@ export class McpClientManager {
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  /**
+   * Look up a connected tool by its qualified name.
+   *
+   * Returns the owning connection and the {@link McpToolInfo} entry, or
+   * `undefined` if no connected server currently exposes that tool.
+   */
+  getToolByQualifiedName(
+    qualified: string
+  ): { connection: McpConnection; tool: McpToolInfo } | undefined {
+    let parsed: { serverName: string; toolName: string };
+    try {
+      parsed = parseQualifiedName(qualified);
+    } catch {
+      return undefined;
+    }
+    const connection = this.connections.get(parsed.serverName);
+    if (!connection || connection.status !== 'connected') {
+      return undefined;
+    }
+    const tool = connection.tools.find((t) => t.name === parsed.toolName);
+    if (!tool) {
+      return undefined;
+    }
+    return { connection, tool };
+  }
+
+  /**
+   * Call a tool identified by its qualified name (`serverName::toolName`).
+   *
+   * Delegates to {@link callTool} once the qualified name has been resolved.
+   * Existing callers using `callTool(serverName, toolName, args)` are
+   * unaffected.
+   */
+  async callToolByQualified(
+    qualified: string,
+    args: Record<string, unknown>
+  ): Promise<{ success: boolean; result?: unknown; error?: string }> {
+    const entry = this.getToolByQualifiedName(qualified);
+    if (!entry) {
+      return { success: false, error: `Tool not found: ${qualified}` };
+    }
+    return this.callTool(entry.connection.config.name, entry.tool.name, args);
   }
 
   /**

--- a/tests/mcp/qualified-name.test.ts
+++ b/tests/mcp/qualified-name.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock child_process.spawn so no real server is spawned.
+const mockSpawn = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Each mock server needs its own listTools response, keyed by construction
+// order. The Client mock advances through the queue as connections are
+// established.
+const listToolsQueue: Array<Array<{ name: string; description?: string; inputSchema: unknown }>> =
+  [];
+const callToolByServer: Record<string, (name: string, args: unknown) => Promise<unknown>> = {};
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  return {
+    Client: class MockClient {
+      private toolList: Array<{ name: string; description?: string; inputSchema: unknown }>;
+      private serverName = '';
+      constructor() {
+        this.toolList = listToolsQueue.shift() ?? [];
+      }
+      connect = vi.fn().mockResolvedValue(undefined);
+      listTools = vi.fn().mockImplementation(async () => ({ tools: this.toolList }));
+      close = vi.fn().mockResolvedValue(undefined);
+      callTool = vi.fn().mockImplementation(async (req: { name: string; arguments: unknown }) => {
+        const handler = callToolByServer[this.serverName];
+        const result = handler ? await handler(req.name, req.arguments) : { result: 'ok' };
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      });
+      // Helper the test uses to associate this client with a server name
+      // AFTER construction, since McpClientManager calls listTools right
+      // after connect.
+      _setServer(name: string): void {
+        this.serverName = name;
+      }
+    },
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function MockStdio() {
+    return {};
+  }),
+}));
+
+vi.mock('../../src/mcp/config.js', () => ({
+  loadMcpConfig: vi.fn().mockReturnValue({ version: '1.0', servers: [] }),
+  resolveEnvVars: vi.fn((env?: Record<string, string>) => env ?? {}),
+}));
+
+import {
+  McpClientManager,
+  escapeServerName,
+  unescapeServerName,
+  buildQualifiedName,
+  parseQualifiedName,
+} from '../../src/mcp/client.js';
+import type { McpServerConfig } from '../../src/mcp/config.js';
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdin = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.pid = 4242;
+  return proc;
+}
+
+function stdioConfig(name: string): McpServerConfig {
+  return {
+    name,
+    transport: 'stdio',
+    command: 'node',
+    args: [],
+    enabled: true,
+    autoConnect: false,
+  };
+}
+
+describe('MCP qualified tool names', () => {
+  let manager: McpClientManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listToolsQueue.length = 0;
+    for (const key of Object.keys(callToolByServer)) {
+      delete callToolByServer[key];
+    }
+    mockSpawn.mockImplementation(() => createMockProcess());
+    manager = new McpClientManager();
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAll();
+  });
+
+  describe('escapeServerName / unescapeServerName round-trip', () => {
+    it('leaves plain ASCII names untouched', () => {
+      expect(escapeServerName('filesystem')).toBe('filesystem');
+      expect(unescapeServerName('filesystem')).toBe('filesystem');
+    });
+
+    it('escapes `:` as %3A', () => {
+      expect(escapeServerName('foo:bar')).toBe('foo%3Abar');
+      expect(unescapeServerName('foo%3Abar')).toBe('foo:bar');
+    });
+
+    it('escapes `%` first so %3A introduced by `:` is not double-escaped', () => {
+      // Raw name contains %3A literally AND a `:`; the `:` becomes %3A,
+      // but the pre-existing %3A must survive the round-trip.
+      const raw = 'weird%3A:name';
+      const escaped = escapeServerName(raw);
+      expect(escaped).toBe('weird%253A%3Aname');
+      expect(unescapeServerName(escaped)).toBe(raw);
+    });
+
+    it('round-trips names containing only `%`', () => {
+      const raw = '100%pure';
+      const escaped = escapeServerName(raw);
+      expect(escaped).toBe('100%25pure');
+      expect(unescapeServerName(escaped)).toBe(raw);
+    });
+  });
+
+  describe('buildQualifiedName / parseQualifiedName', () => {
+    it('joins server and tool with `::`', () => {
+      expect(buildQualifiedName('fs', 'read')).toBe('fs::read');
+    });
+
+    it('preserves tool names containing `::` (server names are escaped)', () => {
+      const qualified = buildQualifiedName('fs', 'ns::do::thing');
+      expect(qualified).toBe('fs::ns::do::thing');
+      const parsed = parseQualifiedName(qualified);
+      expect(parsed.serverName).toBe('fs');
+      expect(parsed.toolName).toBe('ns::do::thing');
+    });
+
+    it('unescapes `:` in the server name segment', () => {
+      const qualified = buildQualifiedName('a:b', 'read');
+      expect(qualified).toBe('a%3Ab::read');
+      const parsed = parseQualifiedName(qualified);
+      expect(parsed.serverName).toBe('a:b');
+      expect(parsed.toolName).toBe('read');
+    });
+
+    it('unescapes `%` in the server name segment', () => {
+      const qualified = buildQualifiedName('100%pure', 'read');
+      const parsed = parseQualifiedName(qualified);
+      expect(parsed.serverName).toBe('100%pure');
+      expect(parsed.toolName).toBe('read');
+    });
+
+    it('throws when the input is missing the `::` separator', () => {
+      expect(() => parseQualifiedName('no-separator')).toThrow(/Invalid qualified tool name/);
+    });
+  });
+
+  describe('collision-free dispatch across servers', () => {
+    it('surfaces two servers exposing the same tool name with distinct qualifiedName', async () => {
+      const toolList = [
+        { name: 'read', description: 'read file', inputSchema: { type: 'object' } },
+      ];
+      listToolsQueue.push(toolList);
+      listToolsQueue.push(toolList);
+
+      await manager.connect(stdioConfig('alpha'));
+      await manager.connect(stdioConfig('beta'));
+
+      const tools = manager.getAllTools();
+      expect(tools).toHaveLength(2);
+
+      const qualifiedNames = tools.map((t) => t.qualifiedName).sort();
+      expect(qualifiedNames).toEqual(['alpha::read', 'beta::read']);
+      // Raw name is unchanged so existing UI groupings keep working.
+      expect(tools.every((t) => t.name === 'read')).toBe(true);
+    });
+
+    it('getToolByQualifiedName routes to the correct connection', async () => {
+      const toolList = [{ name: 'read', inputSchema: { type: 'object' } }];
+      listToolsQueue.push(toolList);
+      listToolsQueue.push(toolList);
+
+      await manager.connect(stdioConfig('alpha'));
+      await manager.connect(stdioConfig('beta'));
+
+      const alpha = manager.getToolByQualifiedName('alpha::read');
+      const beta = manager.getToolByQualifiedName('beta::read');
+      expect(alpha).toBeDefined();
+      expect(beta).toBeDefined();
+      expect(alpha?.connection.config.name).toBe('alpha');
+      expect(beta?.connection.config.name).toBe('beta');
+      expect(alpha?.tool.name).toBe('read');
+      expect(beta?.tool.name).toBe('read');
+    });
+
+    it('getToolByQualifiedName returns undefined for unknown servers or tools', async () => {
+      listToolsQueue.push([{ name: 'read', inputSchema: { type: 'object' } }]);
+      await manager.connect(stdioConfig('alpha'));
+
+      expect(manager.getToolByQualifiedName('missing::read')).toBeUndefined();
+      expect(manager.getToolByQualifiedName('alpha::missing')).toBeUndefined();
+      expect(manager.getToolByQualifiedName('not-qualified')).toBeUndefined();
+    });
+  });
+
+  describe('server names containing separator characters', () => {
+    it('round-trips a server name containing `:`', async () => {
+      listToolsQueue.push([{ name: 'read', inputSchema: { type: 'object' } }]);
+      await manager.connect(stdioConfig('kube:prod'));
+
+      const [tool] = manager.getAllTools();
+      expect(tool.qualifiedName).toBe('kube%3Aprod::read');
+
+      const lookup = manager.getToolByQualifiedName(tool.qualifiedName);
+      expect(lookup?.connection.config.name).toBe('kube:prod');
+      expect(lookup?.tool.name).toBe('read');
+    });
+
+    it('round-trips a server name containing `%`', async () => {
+      listToolsQueue.push([{ name: 'read', inputSchema: { type: 'object' } }]);
+      await manager.connect(stdioConfig('100%pure'));
+
+      const [tool] = manager.getAllTools();
+      expect(tool.qualifiedName).toBe('100%25pure::read');
+
+      const lookup = manager.getToolByQualifiedName(tool.qualifiedName);
+      expect(lookup?.connection.config.name).toBe('100%pure');
+    });
+
+    it('round-trips a tool name containing `::`', async () => {
+      listToolsQueue.push([{ name: 'ns::sub::action', inputSchema: { type: 'object' } }]);
+      await manager.connect(stdioConfig('fs'));
+
+      const [tool] = manager.getAllTools();
+      expect(tool.qualifiedName).toBe('fs::ns::sub::action');
+
+      const lookup = manager.getToolByQualifiedName(tool.qualifiedName);
+      expect(lookup?.connection.config.name).toBe('fs');
+      expect(lookup?.tool.name).toBe('ns::sub::action');
+    });
+  });
+});


### PR DESCRIPTION
Closes #842

## Summary

Namespace MCP tools by `serverName` so two MCP servers exposing the same tool name (e.g. both `read`) no longer silently collide on dispatch.

## Changes

- `McpToolInfo` gains a required `qualifiedName: string` field of the form `<escapedServerName>::<toolName>`.
- `mapToolInfo()` populates `qualifiedName` for every tool advertised by a connected server. Existing `name` and `serverName` fields are unchanged so the server-grouped UI in `cli/tui/dialogs/McpManager.tsx` keeps working.
- New exports:
  - `escapeServerName(name)` — escapes `%` first (as `%25`), then `:` (as `%3A`), so the `%3A` introduced by `:` cannot be double-escaped on reverse.
  - `unescapeServerName(escaped)` — reverse of the above.
  - `buildQualifiedName(serverName, toolName)`.
  - `parseQualifiedName(qualified)` — splits on the FIRST `::` occurrence. Because server names are escaped, they cannot themselves contain `::`; splitting on the first separator therefore preserves tool names that contain `::`.
  - `McpClientManager.getToolByQualifiedName(qualified)` — returns `{ connection, tool } | undefined`.
  - `McpClientManager.callToolByQualified(qualified, args)` — thin overload that delegates to the existing `callTool(serverName, toolName, args)`.
- Existing `callTool(serverName, toolName, args)` signature is UNCHANGED. `src/cli/interactive.ts` is intentionally untouched; a follow-up issue can migrate it to `qualifiedName`.

### Note on `::` splitting

The original issue prescribed "split on the LAST `::`". That is inconsistent with the required test invariant "a `toolName` containing `::` round-trips": with server=`fs` and tool=`ns::do::thing`, joining yields `fs::ns::do::thing`. Splitting on LAST would give server=`fs::ns::do`, tool=`thing` — wrong. Splitting on FIRST gives server=`fs`, tool=`ns::do::thing` — correct. Because `escapeServerName` guarantees the server segment never contains a raw `:`, splitting on the first `::` is safe.

## Tests

`tests/mcp/qualified-name.test.ts` covers:

- `escapeServerName`/`unescapeServerName` round-trip for plain, `:`, `%`, and mixed `%3A:` cases.
- `buildQualifiedName`/`parseQualifiedName` including tool names containing `::` and the missing-separator error path.
- Two servers exposing the same tool name `read` -> `getAllTools()` returns two entries with distinct `qualifiedName`; `getToolByQualifiedName` routes each to the correct connection.
- `serverName` containing `:` round-trips through `qualifiedName`.
- `serverName` containing `%` round-trips (single-escape guarantee).
- `toolName` containing `::` round-trips.

## Verification

- `npm run lint` — 0 errors (pre-existing warnings unchanged).
- `npm run typecheck` — clean.
- `npm run format:check` — clean.
- `npm test` — 2737 passed, 2 skipped (15 new tests in this file).
- `npm run build` — clean.

No new runtime dependencies.