### PR TITLE
feat: [mcp] Namespace MCP tools by serverName via qualified :: key (#842)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Correct MCP `qualifiedName` parsing direction in JSDoc** (commit `887c694a`, `fix(core): correct doc comment about :: split direction [alexi-bot]`): Updated the JSDoc for `McpToolInfo.qualifiedName` in `src/mcp/client.ts` (line 36) to state that parsing splits on the **FIRST** `::` occurrence, matching the actual implementation of `parseQualifiedName` (`src/mcp/client.ts:79`), which uses `qualified.indexOf('::')`. The prior comment incorrectly said "LAST", contradicting the code and the accompanying rationale that server-name escaping (`escapeServerName` at `src/mcp/client.ts:48`, which turns literal `:` into `%3A`) guarantees the server segment never contains `::`, so a first-occurrence split preserves tool names that themselves contain `::`. Pure documentation change with no behavioural, API, runtime, or type-shape impact; the round-trip guarantee described in the JSDoc block was already correct in code.
+
 ## [1.18.0] - 2026-07-13
 
 ### Added

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -33,7 +33,7 @@ export interface McpToolInfo {
    * double-escaped on the way back.
    *
    * `toolName` is passed through verbatim; a tool name that itself
-   * contains `::` still round-trips because parsing splits on the LAST
+   * contains `::` still round-trips because parsing splits on the FIRST
    * `::` occurrence.
    */
   qualifiedName: string;


### PR DESCRIPTION
## Summary

Automated implementation of #842 by **Kilo CLI** via the agent factory (role=engineering).

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 220
- **Branch**: `auto/842-mcp-namespace-mcp-tools-by-servername-via-qualifie`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #842
