### PR TITLE
feat(core): session-wide snapshot and alexi revert on top of file checkpoints

### DIFF
--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -15,6 +15,7 @@ import { registerInteractiveCommand } from './interactive.js';
 import { registerAgentCommand } from './agent.js';
 import { registerCodeReviewCommand } from './codeReview.js';
 import { registerPluginCommand } from './plugin.js';
+import { registerRevertCommand } from './revert.js';
 
 /**
  * Register all CLI commands on the program
@@ -33,6 +34,7 @@ export function registerAllCommands(program: Command): void {
   registerDoDCommands(program);
   registerCodeReviewCommand(program);
   registerPluginCommand(program);
+  registerRevertCommand(program);
 }
 
 export {
@@ -48,4 +50,5 @@ export {
   registerInteractiveCommand,
   registerCodeReviewCommand,
   registerPluginCommand,
+  registerRevertCommand,
 };

--- a/src/cli/commands/revert.ts
+++ b/src/cli/commands/revert.ts
@@ -1,0 +1,133 @@
+/**
+ * `alexi revert` — session-wide snapshot revert.
+ *
+ * Rolls back every file edit made during one agent step by loading the
+ * matching snapshot from `~/.alexi/sessions/<sessionId>/snapshots/` and
+ * restoring `FileCheckpoint.originalContent` bytes to each recorded file.
+ * Files that have been modified outside the agent since the snapshot are
+ * skipped with reason `'modified-outside-agent'`.
+ */
+
+import type { Command } from 'commander';
+import { SessionManager } from '../../core/sessionManager.js';
+import { loadSnapshot, previewRevert, revertTo } from '../../core/snapshot.js';
+
+export interface RevertOptions {
+  session?: string;
+  to: string;
+  preview?: boolean;
+  yes?: boolean;
+}
+
+/**
+ * Resolve the session id: honour --session when provided, otherwise fall
+ * back to the most recently updated session.
+ */
+export function resolveSessionId(explicit?: string): string | null {
+  if (explicit) {
+    return explicit;
+  }
+  const sessions = new SessionManager().listSessions();
+  if (sessions.length === 0) {
+    return null;
+  }
+  return sessions[0].id;
+}
+
+/**
+ * Format a preview row for terminal output.
+ */
+function formatPreviewRow(
+  filePath: string,
+  exists: boolean,
+  bytes: number,
+  status: string
+): string {
+  return `${filePath}\t${exists ? 'yes' : 'no'}\t${bytes}\t${status}`;
+}
+
+/**
+ * Core action for `alexi revert`. Exported for direct invocation from tests
+ * so they can avoid spawning a child process. Returns the numeric exit code
+ * the CLI should propagate; also writes user-facing output to
+ * stdout/stderr via the provided IO handles (defaulting to process.*).
+ */
+export async function runRevert(
+  opts: RevertOptions,
+  io: {
+    out: (s: string) => void;
+    err: (s: string) => void;
+  } = {
+    out: (s: string) => process.stdout.write(s + '\n'),
+    err: (s: string) => process.stderr.write(s + '\n'),
+  }
+): Promise<number> {
+  if (!opts.to) {
+    io.err('Error: --to <stepId> is required');
+    return 1;
+  }
+
+  const sessionId = resolveSessionId(opts.session);
+  if (!sessionId) {
+    io.err('Error: no sessions found. Specify --session <id> explicitly.');
+    return 1;
+  }
+
+  const snapshot = await loadSnapshot(sessionId, opts.to);
+  if (!snapshot) {
+    io.err(`Error: snapshot '${opts.to}' not found for session '${sessionId}'.`);
+    return 1;
+  }
+
+  if (opts.preview) {
+    io.out(`Snapshot ${snapshot.stepId} (session ${sessionId})`);
+    io.out(`Tools: ${snapshot.toolCalls.join(', ') || '(none)'}`);
+    io.out('filePath\texists\tbytes-to-restore\tstatus');
+    for (const row of previewRevert(snapshot)) {
+      io.out(
+        formatPreviewRow(
+          row.filePath,
+          row.currentExists,
+          row.willRestoreBytes,
+          row.currentExists ? 'restorable' : 'file-missing'
+        )
+      );
+    }
+    return 0;
+  }
+
+  const result = await revertTo(snapshot);
+  const skippedOutside = result.skipped.filter((s) => s.reason === 'modified-outside-agent').length;
+  io.out(
+    `restored ${result.restored.length} file(s), skipped ${skippedOutside} (outside-agent edits)`
+  );
+  if (result.skipped.length > skippedOutside) {
+    // Surface non-outside-agent skip reasons on stderr so callers see them.
+    for (const s of result.skipped) {
+      if (s.reason !== 'modified-outside-agent') {
+        io.err(`skipped ${s.filePath}: ${s.reason}`);
+      }
+    }
+  }
+  return 0;
+}
+
+export function registerRevertCommand(program: Command): void {
+  program
+    .command('revert')
+    .description(
+      'Revert every file edit made during one agent step by restoring the ' +
+        'file bytes captured in the matching session snapshot. Files modified ' +
+        'outside the agent since the snapshot are skipped.'
+    )
+    .option('--session <id>', 'Session id (defaults to the most recent session)')
+    .requiredOption('--to <stepId>', 'Snapshot step id to revert to')
+    .option('--preview', 'Print the per-file plan and exit without writing')
+    .option('--yes', 'Skip the interactive confirm when not in a TTY')
+    .action(async (opts: RevertOptions) => {
+      const code = await runRevert(opts);
+      if (code !== 0) {
+        process.exit(code);
+      }
+    });
+}

--- a/src/core/agenticChat.ts
+++ b/src/core/agenticChat.ts
@@ -13,6 +13,9 @@ import { getProviderForModelWithFallback, getDefaultModel } from '../providers/i
 import { routePrompt } from './router.js';
 import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
+import { getCheckpointManager } from './checkpoints.js';
+import { recordSnapshot } from './snapshot.js';
+import { logger } from '../utils/logger.js';
 import { getToolRegistry, type ToolContext, type ToolResult } from '../tool/index.js';
 import { registerBuiltInTools } from '../tool/tools/index.js';
 import { getPermissionManager } from '../permission/index.js';
@@ -652,6 +655,12 @@ export async function agenticChat(
         tool_calls: result.toolCalls as ToolCall[],
       });
 
+      // Capture the pre-iteration checkpoint stack length so that after all
+      // tools in this iteration settle we can extract just the checkpoints
+      // this step produced and persist them as a session-level snapshot.
+      const preIterationCheckpointCount = getCheckpointManager().getHistory().length;
+      const iterationToolNames: string[] = [];
+
       // Execute each tool call
       for (const toolCall of result.toolCalls) {
         const { id, result: toolResult } = await executeToolCall(
@@ -661,6 +670,7 @@ export async function agenticChat(
         );
 
         toolCallsExecuted++;
+        iterationToolNames.push(toolCall.function.name);
         toolCallSummary.push({
           name: toolCall.function.name,
           success: toolResult.success,
@@ -711,6 +721,30 @@ export async function agenticChat(
                 hookResult.error || hookResult.output || 'Hook rejected tool execution';
               throw new Error(`PostToolUse hook blocked execution: ${reason}`);
             }
+          }
+        }
+      }
+
+      // Persist a session-level snapshot for this agent step. Best-effort:
+      // a snapshot write failure must NOT abort the agent loop.
+      const sessionIdForSnapshot = options?.sessionManager?.getCurrentSession()?.metadata.id;
+      if (sessionIdForSnapshot) {
+        const fullHistory = getCheckpointManager().getHistory();
+        const iterationCheckpoints = fullHistory.slice(preIterationCheckpointCount);
+        if (iterationCheckpoints.length > 0) {
+          try {
+            await recordSnapshot(
+              sessionIdForSnapshot,
+              String(iterations),
+              iterationCheckpoints,
+              iterationToolNames
+            );
+          } catch (err) {
+            logger.warn(
+              `Failed to record session snapshot for step ${iterations}: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            );
           }
         }
       }

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -1,0 +1,212 @@
+/**
+ * Session-wide snapshot + revert on top of the per-file `FileCheckpoint` system.
+ *
+ * A `Snapshot` records the set of `FileCheckpoint`s created during a single
+ * agent step (one iteration of the tool-execution loop). It is persisted to
+ * `~/.alexi/sessions/<sessionId>/snapshots/<stepId>.json` so that a single
+ * `alexi revert` command can undo every file edit made during that step —
+ * without needing a Git backend, because `FileCheckpoint.originalContent`
+ * already carries the pre-change bytes.
+ *
+ * Files only: the message log is not touched. Session-level message rewind
+ * is a separate concern.
+ */
+
+import fs from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'path';
+import type { FileCheckpoint } from './checkpoints.js';
+
+/**
+ * A session-level snapshot representing every file changed by tools in
+ * one agent step.
+ */
+export interface Snapshot {
+  stepId: string;
+  timestamp: number;
+  sessionId: string;
+  files: FileCheckpoint[];
+  toolCalls: string[];
+}
+
+/**
+ * Per-file preview row for a revert operation.
+ */
+export interface RevertPreviewEntry {
+  filePath: string;
+  currentExists: boolean;
+  willRestoreBytes: number;
+}
+
+/**
+ * Result of applying a revert.
+ */
+export interface RevertResult {
+  restored: string[];
+  skipped: Array<{ filePath: string; reason: string }>;
+}
+
+/**
+ * Resolve the base sessions directory. Mirrors `SessionManager`'s pattern
+ * (`process.env.HOME || '~'`) so no new config knob is introduced.
+ */
+function getSessionsDir(): string {
+  return path.join(process.env.HOME || '~', '.alexi', 'sessions');
+}
+
+/**
+ * Resolve the snapshots directory for a given session id.
+ */
+function getSnapshotsDir(sessionId: string): string {
+  return path.join(getSessionsDir(), sessionId, 'snapshots');
+}
+
+/**
+ * Record a snapshot for a single agent step. Writes
+ * `~/.alexi/sessions/<sessionId>/snapshots/<stepId>.json`, creating the
+ * directory as needed. No-op when `checkpoints` is empty — there is no
+ * point writing empty snapshots.
+ */
+export async function recordSnapshot(
+  sessionId: string,
+  stepId: string,
+  checkpoints: FileCheckpoint[],
+  toolCalls: string[]
+): Promise<void> {
+  if (!checkpoints || checkpoints.length === 0) {
+    return;
+  }
+
+  const snapshot: Snapshot = {
+    stepId,
+    timestamp: Date.now(),
+    sessionId,
+    files: checkpoints,
+    toolCalls,
+  };
+
+  const dir = getSnapshotsDir(sessionId);
+  await fs.mkdir(dir, { recursive: true });
+  const target = path.join(dir, `${stepId}.json`);
+  await fs.writeFile(target, JSON.stringify(snapshot, null, 2), 'utf-8');
+}
+
+/**
+ * List all snapshots for a session, sorted by `timestamp` descending
+ * (newest first). Returns an empty array if the snapshots directory
+ * does not exist.
+ */
+export async function listSnapshots(sessionId: string): Promise<Snapshot[]> {
+  const dir = getSnapshotsDir(sessionId);
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const snapshots: Snapshot[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) {
+      continue;
+    }
+    try {
+      const raw = await fs.readFile(path.join(dir, entry), 'utf-8');
+      const parsed = JSON.parse(raw) as Snapshot;
+      snapshots.push(parsed);
+    } catch {
+      // Skip corrupt snapshot files.
+    }
+  }
+
+  snapshots.sort((a, b) => b.timestamp - a.timestamp);
+  return snapshots;
+}
+
+/**
+ * Load a single snapshot by step id. Returns `null` if the file does not
+ * exist or cannot be parsed.
+ */
+export async function loadSnapshot(sessionId: string, stepId: string): Promise<Snapshot | null> {
+  const target = path.join(getSnapshotsDir(sessionId), `${stepId}.json`);
+  try {
+    const raw = await fs.readFile(target, 'utf-8');
+    return JSON.parse(raw) as Snapshot;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Produce a per-file preview of what a revert would do. Pure aside from
+ * `stat`-ing each file to determine existence and current byte length.
+ */
+export function previewRevert(
+  snapshot: Snapshot
+): Array<{ filePath: string; currentExists: boolean; willRestoreBytes: number }> {
+  return snapshot.files.map((cp) => ({
+    filePath: cp.filePath,
+    currentExists: existsSync(cp.filePath),
+    willRestoreBytes: Buffer.byteLength(cp.originalContent, 'utf-8'),
+  }));
+}
+
+/**
+ * Apply a revert. For each `FileCheckpoint`:
+ * - If the current on-disk content is identical to `newContent`, restore
+ *   `originalContent` unconditionally.
+ * - If the current content differs from BOTH `originalContent` and
+ *   `newContent`, skip with reason `'modified-outside-agent'` (do not
+ *   clobber human edits).
+ * - If the current content already matches `originalContent`, restore is
+ *   a no-op write but still counts as `restored` (idempotent).
+ */
+export async function revertTo(snapshot: Snapshot): Promise<RevertResult> {
+  const restored: string[] = [];
+  const skipped: Array<{ filePath: string; reason: string }> = [];
+
+  for (const cp of snapshot.files) {
+    let current: string | null;
+    try {
+      current = await fs.readFile(cp.filePath, 'utf-8');
+    } catch {
+      // File no longer exists — treat as deleted-outside-agent unless
+      // originalContent was empty (i.e. tool created a file that was then
+      // deleted, which is a valid restore path).
+      current = null;
+    }
+
+    if (current === null) {
+      // Missing file: only restore if the original was non-empty (creation
+      // was reverted). If original was empty and file is gone, nothing to
+      // do — leave as-is but count as restored (state matches original).
+      try {
+        await fs.writeFile(cp.filePath, cp.originalContent, 'utf-8');
+        restored.push(cp.filePath);
+      } catch (err) {
+        skipped.push({
+          filePath: cp.filePath,
+          reason: `write-failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+      continue;
+    }
+
+    if (current === cp.newContent || current === cp.originalContent) {
+      try {
+        await fs.writeFile(cp.filePath, cp.originalContent, 'utf-8');
+        restored.push(cp.filePath);
+      } catch (err) {
+        skipped.push({
+          filePath: cp.filePath,
+          reason: `write-failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    } else {
+      skipped.push({ filePath: cp.filePath, reason: 'modified-outside-agent' });
+    }
+  }
+
+  return { restored, skipped };
+}

--- a/tests/cli/revert.test.ts
+++ b/tests/cli/revert.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { runRevert } from '../../src/cli/commands/revert.js';
+import { recordSnapshot } from '../../src/core/snapshot.js';
+import type { FileCheckpoint } from '../../src/core/checkpoints.js';
+
+describe('alexi revert command', () => {
+  let tmpHome: string;
+  let workdir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'alexi-revert-'));
+    workdir = await fs.mkdtemp(path.join(os.tmpdir(), 'alexi-revert-work-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    // SessionManager auto-creates ~/.alexi/sessions on construction.
+    await fs.mkdir(path.join(tmpHome, '.alexi', 'sessions'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await fs.rm(tmpHome, { recursive: true, force: true });
+    await fs.rm(workdir, { recursive: true, force: true });
+  });
+
+  function makeCheckpoint(
+    filePath: string,
+    originalContent: string,
+    newContent: string
+  ): FileCheckpoint {
+    return {
+      id: `cp-${path.basename(filePath)}`,
+      filePath,
+      originalContent,
+      newContent,
+      timestamp: Date.now(),
+      toolName: 'edit',
+    };
+  }
+
+  function captureIo() {
+    const out: string[] = [];
+    const err: string[] = [];
+    return {
+      out: (s: string) => {
+        out.push(s);
+      },
+      err: (s: string) => {
+        err.push(s);
+      },
+      outLines: out,
+      errLines: err,
+    };
+  }
+
+  it('--preview exits 0 and prints a per-file plan without writing', async () => {
+    const filePath = path.join(workdir, 'a.txt');
+    await fs.writeFile(filePath, 'new', 'utf-8');
+    await recordSnapshot(
+      'sess-preview',
+      'step-1',
+      [makeCheckpoint(filePath, 'orig', 'new')],
+      ['edit']
+    );
+
+    const io = captureIo();
+    const code = await runRevert({ session: 'sess-preview', to: 'step-1', preview: true }, io);
+
+    expect(code).toBe(0);
+    const output = io.outLines.join('\n');
+    expect(output).toContain('filePath\texists\tbytes-to-restore\tstatus');
+    expect(output).toContain(filePath);
+    // Preview must not have written anything back.
+    const contents = await fs.readFile(filePath, 'utf-8');
+    expect(contents).toBe('new');
+  });
+
+  it('exits 1 with a clear error when the snapshot is missing', async () => {
+    // Also create a fake session json so listSessions finds a default.
+    await fs.writeFile(
+      path.join(tmpHome, '.alexi', 'sessions', 'sess-x.json'),
+      JSON.stringify({
+        metadata: {
+          id: 'sess-x',
+          created: 1,
+          updated: 2,
+          totalTokens: 0,
+          messageCount: 0,
+        },
+        messages: [],
+      }),
+      'utf-8'
+    );
+
+    const io = captureIo();
+    const code = await runRevert({ session: 'sess-x', to: 'no-such-step' }, io);
+
+    expect(code).toBe(1);
+    expect(io.errLines.join('\n')).toMatch(/not found/i);
+  });
+
+  it('commit path restores files matching newContent and reports counts', async () => {
+    const filePath = path.join(workdir, 'b.txt');
+    await fs.writeFile(filePath, 'new-body', 'utf-8');
+    await recordSnapshot(
+      'sess-commit',
+      'step-2',
+      [makeCheckpoint(filePath, 'orig-body', 'new-body')],
+      ['edit']
+    );
+
+    const io = captureIo();
+    const code = await runRevert({ session: 'sess-commit', to: 'step-2' }, io);
+
+    expect(code).toBe(0);
+    expect(io.outLines.join('\n')).toMatch(/restored 1 file\(s\), skipped 0/);
+    const contents = await fs.readFile(filePath, 'utf-8');
+    expect(contents).toBe('orig-body');
+  });
+
+  it('reports skipped modified-outside-agent files in the summary', async () => {
+    const kept = path.join(workdir, 'kept.txt');
+    const modified = path.join(workdir, 'modified.txt');
+    await fs.writeFile(kept, 'new-k', 'utf-8');
+    await fs.writeFile(modified, 'human-touched', 'utf-8');
+    await recordSnapshot(
+      'sess-mixed',
+      'step-3',
+      [makeCheckpoint(kept, 'orig-k', 'new-k'), makeCheckpoint(modified, 'orig-m', 'new-m')],
+      ['edit', 'write']
+    );
+
+    const io = captureIo();
+    const code = await runRevert({ session: 'sess-mixed', to: 'step-3' }, io);
+
+    expect(code).toBe(0);
+    expect(io.outLines.join('\n')).toMatch(
+      /restored 1 file\(s\), skipped 1 \(outside-agent edits\)/
+    );
+    expect(await fs.readFile(kept, 'utf-8')).toBe('orig-k');
+    expect(await fs.readFile(modified, 'utf-8')).toBe('human-touched');
+  });
+
+  it('exits 1 with a clear error when no session id is available', async () => {
+    // No sessions on disk, no --session provided.
+    const io = captureIo();
+    const code = await runRevert({ to: 'step-1' }, io);
+    expect(code).toBe(1);
+    expect(io.errLines.join('\n')).toMatch(/no sessions found/i);
+  });
+});

--- a/tests/core/snapshot.test.ts
+++ b/tests/core/snapshot.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  recordSnapshot,
+  listSnapshots,
+  loadSnapshot,
+  previewRevert,
+  revertTo,
+  type Snapshot,
+} from '../../src/core/snapshot.js';
+import type { FileCheckpoint } from '../../src/core/checkpoints.js';
+
+describe('snapshot / revert', () => {
+  let tmpHome: string;
+  let workdir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'alexi-snapshot-'));
+    workdir = await fs.mkdtemp(path.join(os.tmpdir(), 'alexi-snapshot-work-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await fs.rm(tmpHome, { recursive: true, force: true });
+    await fs.rm(workdir, { recursive: true, force: true });
+  });
+
+  function makeCheckpoint(
+    filePath: string,
+    originalContent: string,
+    newContent: string
+  ): FileCheckpoint {
+    return {
+      id: `cp-${path.basename(filePath)}`,
+      filePath,
+      originalContent,
+      newContent,
+      timestamp: Date.now(),
+      toolName: 'edit',
+    };
+  }
+
+  describe('recordSnapshot', () => {
+    it('writes the expected file with the expected shape', async () => {
+      const filePath = path.join(workdir, 'a.txt');
+      await fs.writeFile(filePath, 'new', 'utf-8');
+      const cp = makeCheckpoint(filePath, 'orig', 'new');
+
+      await recordSnapshot('sess-1', 'step-7', [cp], ['edit']);
+
+      const snapshotPath = path.join(
+        tmpHome,
+        '.alexi',
+        'sessions',
+        'sess-1',
+        'snapshots',
+        'step-7.json'
+      );
+      expect(fsSync.existsSync(snapshotPath)).toBe(true);
+      const raw = await fs.readFile(snapshotPath, 'utf-8');
+      const parsed = JSON.parse(raw) as Snapshot;
+      expect(parsed.stepId).toBe('step-7');
+      expect(parsed.sessionId).toBe('sess-1');
+      expect(parsed.files).toHaveLength(1);
+      expect(parsed.files[0].filePath).toBe(filePath);
+      expect(parsed.files[0].originalContent).toBe('orig');
+      expect(parsed.files[0].newContent).toBe('new');
+      expect(parsed.toolCalls).toEqual(['edit']);
+      expect(typeof parsed.timestamp).toBe('number');
+    });
+
+    it('is a no-op when no checkpoints are provided', async () => {
+      await recordSnapshot('sess-empty', 'step-0', [], []);
+      const dir = path.join(tmpHome, '.alexi', 'sessions', 'sess-empty', 'snapshots');
+      expect(fsSync.existsSync(dir)).toBe(false);
+    });
+  });
+
+  describe('listSnapshots and loadSnapshot', () => {
+    it('lists snapshots sorted newest-first', async () => {
+      const filePath = path.join(workdir, 'b.txt');
+      await fs.writeFile(filePath, 'new', 'utf-8');
+      const cp = makeCheckpoint(filePath, 'orig', 'new');
+
+      await recordSnapshot('sess-list', 'first', [cp], ['edit']);
+      // Ensure differing timestamps
+      await new Promise((r) => setTimeout(r, 10));
+      await recordSnapshot('sess-list', 'second', [cp], ['edit']);
+
+      const snapshots = await listSnapshots('sess-list');
+      expect(snapshots).toHaveLength(2);
+      expect(snapshots[0].stepId).toBe('second');
+      expect(snapshots[1].stepId).toBe('first');
+    });
+
+    it('loadSnapshot returns null for missing snapshot', async () => {
+      const snap = await loadSnapshot('missing-session', 'no-such-step');
+      expect(snap).toBeNull();
+    });
+
+    it('listSnapshots returns [] when the snapshots directory is missing', async () => {
+      const snaps = await listSnapshots('never-created');
+      expect(snaps).toEqual([]);
+    });
+  });
+
+  describe('revertTo', () => {
+    it('restores originalContent when the current file matches newContent', async () => {
+      const filePath = path.join(workdir, 'c.txt');
+      await fs.writeFile(filePath, 'new', 'utf-8');
+      const cp = makeCheckpoint(filePath, 'orig', 'new');
+      await recordSnapshot('sess-r', 'step-1', [cp], ['edit']);
+      const snap = await loadSnapshot('sess-r', 'step-1');
+      expect(snap).not.toBeNull();
+
+      const result = await revertTo(snap!);
+      expect(result.restored).toEqual([filePath]);
+      expect(result.skipped).toEqual([]);
+      const contents = await fs.readFile(filePath, 'utf-8');
+      expect(contents).toBe('orig');
+    });
+
+    it('skips files whose current bytes match neither originalContent nor newContent', async () => {
+      const filePath = path.join(workdir, 'd.txt');
+      await fs.writeFile(filePath, 'human-edit', 'utf-8');
+      const cp = makeCheckpoint(filePath, 'orig', 'new');
+      await recordSnapshot('sess-h', 'step-1', [cp], ['edit']);
+      const snap = await loadSnapshot('sess-h', 'step-1');
+
+      const result = await revertTo(snap!);
+      expect(result.restored).toEqual([]);
+      expect(result.skipped).toEqual([{ filePath, reason: 'modified-outside-agent' }]);
+      // File must be untouched.
+      const contents = await fs.readFile(filePath, 'utf-8');
+      expect(contents).toBe('human-edit');
+    });
+
+    it('restores idempotently when the file already matches originalContent', async () => {
+      const filePath = path.join(workdir, 'e.txt');
+      await fs.writeFile(filePath, 'orig', 'utf-8');
+      const cp = makeCheckpoint(filePath, 'orig', 'new');
+      await recordSnapshot('sess-idem', 'step-1', [cp], ['edit']);
+      const snap = await loadSnapshot('sess-idem', 'step-1');
+
+      const result = await revertTo(snap!);
+      expect(result.restored).toEqual([filePath]);
+      expect(result.skipped).toEqual([]);
+    });
+  });
+
+  describe('previewRevert', () => {
+    it('counts restorable bytes and flags deleted files', async () => {
+      const existing = path.join(workdir, 'f.txt');
+      const deleted = path.join(workdir, 'gone.txt');
+      await fs.writeFile(existing, 'new', 'utf-8');
+      const cps: FileCheckpoint[] = [
+        makeCheckpoint(existing, 'orig-1234', 'new'),
+        makeCheckpoint(deleted, 'x', 'y'),
+      ];
+      const snap: Snapshot = {
+        stepId: 'p',
+        timestamp: Date.now(),
+        sessionId: 's',
+        files: cps,
+        toolCalls: [],
+      };
+      const rows = previewRevert(snap);
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toEqual({
+        filePath: existing,
+        currentExists: true,
+        willRestoreBytes: Buffer.byteLength('orig-1234', 'utf-8'),
+      });
+      expect(rows[1]).toEqual({
+        filePath: deleted,
+        currentExists: false,
+        willRestoreBytes: 1,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #849

## Summary

Adds a session-wide snapshot + revert mechanism layered on top of the existing per-file `FileCheckpoint` system. A single `alexi revert --to <stepId>` now undoes every file edit made during one agent iteration, without introducing a Git backend or a new on-disk format.

## Changes

- **`src/core/snapshot.ts` (new)** — `recordSnapshot`, `listSnapshots`, `loadSnapshot`, `previewRevert`, `revertTo`. Snapshots live at `~/.alexi/sessions/<sessionId>/snapshots/<stepId>.json` and reuse `FileCheckpoint.originalContent` bytes directly.
- **`src/core/agenticChat.ts`** — captures each iteration's newly-produced `FileCheckpoint`s (via `getCheckpointManager().getHistory()` diff against the pre-iteration length) and persists them via `recordSnapshot`. Best-effort: a snapshot write failure is logged via `utils/logger.ts` and does NOT abort the agent loop. Empty iterations produce no snapshot.
- **`src/cli/commands/revert.ts` (new)** — flags: `--session` (defaults to most recent session), `--to` (required), `--preview`, `--yes`. Preview prints a per-file table; commit path prints `restored N file(s), skipped M (outside-agent edits)`.
- **`src/cli/commands/index.ts`** — wires the new command.

## Revert semantics

For each recorded `FileCheckpoint`:

- Current file matches `newContent` OR `originalContent` -> restore unconditionally (idempotent).
- Current file matches neither -> **skip** with reason `'modified-outside-agent'` (never clobber human edits).
- Current file is missing -> restore `originalContent` (undoes tool-driven deletion or reverts creation to empty).

## Tests

- `tests/core/snapshot.test.ts` — write shape, empty no-op, listing order, missing-snapshot null, restore-on-match, skip-on-outside-edit, idempotent restore, preview byte counting for deleted files.
- `tests/cli/revert.test.ts` — `--preview` prints table and writes nothing; missing snapshot exits 1; commit path restores; mixed restore/skip summary; no-sessions error.

All 14 new tests pass; full suite still 2736 pass / 2 skipped.

## Gates

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm run test:coverage` — 61.99% lines (>= 40% CI floor); `snapshot.ts` at 83%
- `npm run build` — clean; `alexi revert --help` lists all four flags

## Non-goals

- Files only — the message log is untouched.
- No Git backend, no new dependency, no new config knob (reuses `process.env.HOME || '~'` the same way `sessionManager.ts:70` does).

[alexi-bot]