### PR TITLE
feat: [mcp] Split MCP timeout into startup vs request budgets (#857)

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -55,7 +55,8 @@ interface ToolCache {
 }
 
 const CACHE_TTL_MS = 30000; // 30 seconds
-const DEFAULT_TOOL_CALL_TIMEOUT_MS = 60000; // 60 seconds
+const DEFAULT_STARTUP_TIMEOUT_MS = 30000; // 30 seconds for cold `npx -y` spawn
+const DEFAULT_TOOL_CALL_TIMEOUT_MS = 60000; // 60 seconds for per-tool call
 const MAX_PAGES = 100; // Safety cap for paginated tools/list
 
 /**
@@ -291,8 +292,8 @@ export class McpClientManager {
       env: cleanEnv,
     });
 
-    const timeoutMs = this.getTimeoutForServer(config.name);
-    await connection.client.connect(transport, { timeout: timeoutMs });
+    const { startup } = this.getTimeoutsForServer(config.name);
+    await connection.client.connect(transport, { timeout: startup });
   }
 
   /**
@@ -452,24 +453,40 @@ export class McpClientManager {
   }
 
   /**
-   * Get the timeout for a specific server.
-   * Priority: per-server config > MCP_TOOL_TIMEOUT env var > default
+   * Get the startup and per-request timeouts for a specific server.
+   *
+   * Resolution order:
+   * 1. If `connection.config.timeout` is a number, use it for BOTH phases
+   *    (legacy behaviour, preserves backwards-compat).
+   * 2. If it is an object, use `startup ?? DEFAULT_STARTUP_TIMEOUT_MS`
+   *    and `request ?? DEFAULT_TOOL_CALL_TIMEOUT_MS`.
+   * 3. Otherwise fall back to `MCP_TOOL_TIMEOUT` env (applied to BOTH
+   *    phases for backwards-compat) or the two defaults.
    */
-  private getTimeoutForServer(serverName: string): number {
+  private getTimeoutsForServer(serverName: string): { startup: number; request: number } {
     const connection = this.connections.get(serverName);
-    if (connection?.config.timeout !== undefined) {
-      return connection.config.timeout;
+    const configured = connection?.config.timeout;
+
+    if (typeof configured === 'number') {
+      return { startup: configured, request: configured };
+    }
+
+    if (configured !== undefined && configured !== null && typeof configured === 'object') {
+      return {
+        startup: configured.startup ?? DEFAULT_STARTUP_TIMEOUT_MS,
+        request: configured.request ?? DEFAULT_TOOL_CALL_TIMEOUT_MS,
+      };
     }
 
     const envTimeout = process.env.MCP_TOOL_TIMEOUT;
     if (envTimeout !== undefined) {
       const parsed = Number(envTimeout);
       if (!isNaN(parsed) && parsed > 0) {
-        return parsed;
+        return { startup: parsed, request: parsed };
       }
     }
 
-    return DEFAULT_TOOL_CALL_TIMEOUT_MS;
+    return { startup: DEFAULT_STARTUP_TIMEOUT_MS, request: DEFAULT_TOOL_CALL_TIMEOUT_MS };
   }
 
   /**
@@ -490,7 +507,7 @@ export class McpClientManager {
       return { success: false, error: `Server not ready: ${serverName} (${connection.status})` };
     }
 
-    const timeoutMs = this.getTimeoutForServer(serverName);
+    const { request: timeoutMs } = this.getTimeoutsForServer(serverName);
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
 

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -28,8 +28,23 @@ export interface McpServerConfig {
   enabled: boolean;
   /** Auto-connect on startup */
   autoConnect?: boolean;
-  /** Tool call timeout in milliseconds. Default: 60000 */
-  timeout?: number;
+  /**
+   * Timeout budget(s) in milliseconds.
+   *
+   * Accepts either:
+   * - A single number applied to BOTH the stdio handshake / cold-spawn
+   *   phase (`client.connect`) and per-tool `callTool` deadlines.
+   *   This is the legacy shape and remains supported for
+   *   backwards-compatibility.
+   * - An object `{ startup?: number; request?: number }` that lets the
+   *   slow spawn phase and the fast tool-call phase have independent
+   *   budgets. Missing keys fall back to the defaults below.
+   *
+   * Defaults when unspecified:
+   * - `startup`: 30000 ms (cold `npx -y` installs routinely take 5-15s)
+   * - `request`: 60000 ms (per-tool call deadline)
+   */
+  timeout?: number | { startup?: number; request?: number };
   /**
    * Working directory for the spawned stdio server. Relative paths are
    * resolved against `options.workdir` (or `process.cwd()` if no workdir

--- a/tests/mcp/client-timeout.test.ts
+++ b/tests/mcp/client-timeout.test.ts
@@ -271,12 +271,12 @@ describe('MCP Tool Call Timeout', () => {
       );
     });
 
-    it('should use default timeout for connect when no config timeout', async () => {
+    it('should use default startup timeout for connect when no config timeout', async () => {
       await manager.connect(stdioConfig);
 
       expect(mockClientConnect).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ timeout: 60000 })
+        expect.objectContaining({ timeout: 30000 })
       );
     });
 

--- a/tests/mcp/timeout.test.ts
+++ b/tests/mcp/timeout.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock child_process.spawn
+const mockSpawn = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Mock @modelcontextprotocol/sdk
+const mockClientConnect = vi.fn().mockResolvedValue(undefined);
+const mockClientListTools = vi.fn().mockResolvedValue({ tools: [] });
+const mockClientCallTool = vi.fn();
+const mockClientClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  return {
+    Client: class MockClient {
+      connect = mockClientConnect;
+      listTools = mockClientListTools;
+      callTool = mockClientCallTool;
+      close = mockClientClose;
+    },
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+// Mock config loading
+vi.mock('../../src/mcp/config.js', () => ({
+  loadMcpConfig: vi.fn().mockReturnValue({ version: '1.0', servers: [] }),
+  resolveEnvVars: vi.fn((env?: Record<string, string>) => env ?? {}),
+}));
+
+import { McpClientManager } from '../../src/mcp/client.js';
+import type { McpServerConfig } from '../../src/mcp/config.js';
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdin = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.pid = 12345;
+  return proc;
+}
+
+/**
+ * Drive a `callTool` invocation to completion using fake timers and return
+ * the resolved value. The mocked `callTool` hangs until its `AbortSignal`
+ * fires, so we advance the timer by `advanceMs` to trip the internal
+ * `AbortController` created by the manager.
+ */
+async function runTimingCall(
+  manager: McpClientManager,
+  serverName: string,
+  advanceMs: number
+): Promise<{ success: boolean; result?: unknown; error?: string }> {
+  mockClientCallTool.mockImplementation(
+    (_params: unknown, _schema: unknown, options?: { signal?: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          options.signal.addEventListener('abort', () => {
+            const error = new Error('The operation was aborted');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        }
+      });
+    }
+  );
+
+  const promise = manager.callTool(serverName, 'some-tool', {});
+  await vi.advanceTimersByTimeAsync(advanceMs);
+  return promise;
+}
+
+describe('MCP split startup / request timeouts', () => {
+  let manager: McpClientManager;
+  const originalEnv = process.env;
+
+  const baseConfig: McpServerConfig = {
+    name: 'timeout-server',
+    transport: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+    enabled: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    manager = new McpClientManager();
+    mockSpawn.mockReturnValue(createMockProcess());
+    process.env = { ...originalEnv };
+    delete process.env.MCP_TOOL_TIMEOUT;
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await manager.disconnectAll();
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  it('legacy: bare number timeout applies to both startup and request phases', async () => {
+    const cfg: McpServerConfig = { ...baseConfig, name: 'legacy', timeout: 5000 };
+
+    await manager.connect(cfg);
+
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 5000 })
+    );
+
+    const result = await runTimingCall(manager, 'legacy', 5000);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('MCP tool call timed out after 5000ms');
+  });
+
+  it('object form: both startup and request set independently', async () => {
+    const cfg: McpServerConfig = {
+      ...baseConfig,
+      name: 'both',
+      timeout: { startup: 10000, request: 2000 },
+    };
+
+    await manager.connect(cfg);
+
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 10000 })
+    );
+
+    const result = await runTimingCall(manager, 'both', 2000);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('MCP tool call timed out after 2000ms');
+  });
+
+  it('object form: partial (startup only) uses default request', async () => {
+    const cfg: McpServerConfig = {
+      ...baseConfig,
+      name: 'startup-only',
+      timeout: { startup: 10000 },
+    };
+
+    await manager.connect(cfg);
+
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 10000 })
+    );
+
+    // Default request timeout is 60000ms
+    const result = await runTimingCall(manager, 'startup-only', 60000);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('MCP tool call timed out after 60000ms');
+  });
+
+  it('object form: partial (request only) uses default startup', async () => {
+    const cfg: McpServerConfig = {
+      ...baseConfig,
+      name: 'request-only',
+      timeout: { request: 2000 },
+    };
+
+    await manager.connect(cfg);
+
+    // Default startup timeout is 30000ms
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 30000 })
+    );
+
+    const result = await runTimingCall(manager, 'request-only', 2000);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('MCP tool call timed out after 2000ms');
+  });
+
+  it('no timeout config: both phases use their respective defaults', async () => {
+    const cfg: McpServerConfig = { ...baseConfig, name: 'defaults' };
+
+    await manager.connect(cfg);
+
+    // Default startup: 30000ms
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 30000 })
+    );
+
+    // Default request: 60000ms
+    const result = await runTimingCall(manager, 'defaults', 60000);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('MCP tool call timed out after 60000ms');
+  });
+
+  it('MCP_TOOL_TIMEOUT env var applies to BOTH phases (backwards-compat)', async () => {
+    process.env.MCP_TOOL_TIMEOUT = '7000';
+
+    const cfg: McpServerConfig = { ...baseConfig, name: 'env-both' };
+    await manager.connect(cfg);
+
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 7000 })
+    );
+
+    const result = await runTimingCall(manager, 'env-both', 7000);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('MCP tool call timed out after 7000ms');
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation of #857 by **Kilo CLI** via the agent factory (role=engineering).

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 215
- **Branch**: `auto/857-mcp-split-mcp-timeout-into-startup-vs-request-budg`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #857
