### PR TITLE
feat(providers): preserve error.cause on provider rethrow via formatProviderError

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,4 +1,5 @@
 import { getProviderForModelWithFallback, getDefaultModel } from '../providers/index.js';
+import { formatProviderError } from '../providers/format.js';
 import { routePrompt, recordRouteOutcome, classifyRouteError } from './router.js';
 import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
@@ -80,6 +81,10 @@ export async function sendChat(
     const classified = classifyRouteError(err);
     if (classified.kind === 'permanent') {
       recordRouteOutcome(modelId, classified);
+    }
+    const formatted = formatProviderError(err);
+    if (err instanceof Error && formatted !== err.message) {
+      err.message = formatted;
     }
     throw err;
   }

--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -8,6 +8,7 @@ import {
   getDefaultModel,
   type StreamChunk,
 } from '../providers/index.js';
+import { formatProviderError } from '../providers/format.js';
 import { routePrompt, recordRouteOutcome, classifyRouteError } from './router.js';
 import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
@@ -158,6 +159,10 @@ export async function* streamChat(
     const classified = classifyRouteError(err);
     if (classified.kind === 'permanent') {
       recordRouteOutcome(modelId, classified);
+    }
+    const formatted = formatProviderError(err);
+    if (err instanceof Error && formatted !== err.message) {
+      err.message = formatted;
     }
     throw err;
   }

--- a/src/providers/format.ts
+++ b/src/providers/format.ts
@@ -1,0 +1,70 @@
+/**
+ * Provider error formatting.
+ *
+ * Node/undici transport failures typically surface as
+ * `TypeError('fetch failed')` with the real reason nested on `err.cause`
+ * (e.g. `{ name: 'SocketError', message: 'other side closed',
+ * code: 'UND_ERR_SOCKET' }`). If the orchestrator rethrows the outer
+ * error unchanged, users only see `fetch failed` — the underlying cause
+ * is discarded.
+ *
+ * `formatProviderError` folds the cause chain into a single, bounded
+ * string so that transport/provider incidents are debuggable without
+ * requiring additional logging plumbing. It is intentionally
+ * depth-bounded (2 levels) to avoid pathological / self-referential
+ * chains blowing up the message width.
+ *
+ * Mirrors the upstream cline/cline fix (PR #11928, commit 263b58f).
+ */
+
+/**
+ * Minimal shape checked when deciding whether a `cause` value is
+ * error-like enough to be worth folding into the message.
+ */
+interface ErrorLike {
+  name: string;
+  message: string;
+  code?: string;
+}
+
+/**
+ * Return true if `value` looks like an `Error` (has string `name` and
+ * `message`). We do not require `instanceof Error` because undici
+ * sometimes surfaces cause objects that structurally match but are not
+ * subclasses.
+ */
+function isErrorLike(value: unknown): value is ErrorLike {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as { name?: unknown; message?: unknown };
+  return typeof candidate.name === 'string' && typeof candidate.message === 'string';
+}
+
+/**
+ * Format an error for user display, preserving `error.cause` when
+ * present.
+ *
+ * - Non-`Error` input: returns `String(err)`.
+ * - Native `Error` without a distinct `cause`: returns `err.message`.
+ * - Native `Error` whose `cause` is itself error-shaped: returns
+ *   `` `${err.message}: ${cause.name}: ${cause.message}${code ? ' (' + code + ')' : ''}` ``.
+ *
+ * Recursion is capped at depth 2; `cause.cause` is intentionally not
+ * walked so a self-referential chain cannot loop or explode the
+ * message width.
+ */
+export function formatProviderError(err: unknown): string {
+  if (!(err instanceof Error)) {
+    return String(err);
+  }
+
+  const cause = (err as Error & { cause?: unknown }).cause;
+  if (!isErrorLike(cause)) {
+    return err.message;
+  }
+
+  const codeSuffix =
+    typeof cause.code === 'string' && cause.code.length > 0 ? ` (${cause.code})` : '';
+  return `${err.message}: ${cause.name}: ${cause.message}${codeSuffix}`;
+}

--- a/tests/core/orchestrator.error.test.ts
+++ b/tests/core/orchestrator.error.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock providers module BEFORE importing the module under test.
+// vi.mock() is hoisted, but we keep the block above the import
+// explicitly for readability (matches project convention).
+vi.mock('../../src/providers/index.js', () => {
+  const getProviderForModel = vi.fn();
+  return {
+    getProviderForModel,
+    getProviderForModelWithFallback: vi.fn((modelId: string) => ({
+      provider: getProviderForModel(modelId),
+      effectiveModelId: modelId,
+      usedFallback: false,
+    })),
+    getDefaultModel: vi.fn(),
+  };
+});
+
+vi.mock('../../src/core/router.js', () => ({
+  routePrompt: vi.fn(),
+  recordRouteOutcome: vi.fn(),
+  classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
+}));
+
+import { sendChat } from '../../src/core/orchestrator.js';
+import { getProviderForModel, getDefaultModel } from '../../src/providers/index.js';
+
+describe('sendChat error formatting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDefaultModel).mockReturnValue('gpt-4o');
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rethrows with cause folded into message for undici-shape transport errors', async () => {
+    // Build the reference undici error: TypeError('fetch failed') with a
+    // SocketError-shape cause carrying a code.
+    const cause: Error & { code?: string } = new Error('other side closed');
+    cause.name = 'SocketError';
+    cause.code = 'UND_ERR_SOCKET';
+    const transport = new TypeError('fetch failed');
+    (transport as Error & { cause?: unknown }).cause = cause;
+
+    const mockProvider = {
+      complete: vi.fn().mockRejectedValue(transport),
+    };
+    vi.mocked(getProviderForModel).mockReturnValue(mockProvider as never);
+
+    let caught: unknown;
+    try {
+      await sendChat('hi');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const rethrown = caught as Error;
+
+    // Original instance is preserved so instanceof checks elsewhere
+    // continue to work.
+    expect(rethrown).toBe(transport);
+
+    // The rethrown message now carries the underlying cause: its name
+    // AND its code.
+    expect(rethrown.message).toContain('SocketError');
+    expect(rethrown.message).toContain('UND_ERR_SOCKET');
+    expect(rethrown.message).toContain('other side closed');
+  });
+
+  it('leaves the error untouched when there is no error-shaped cause', async () => {
+    const plain = new Error('plain provider failure');
+
+    const mockProvider = {
+      complete: vi.fn().mockRejectedValue(plain),
+    };
+    vi.mocked(getProviderForModel).mockReturnValue(mockProvider as never);
+
+    let caught: unknown;
+    try {
+      await sendChat('hi');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBe(plain);
+    expect((caught as Error).message).toBe('plain provider failure');
+  });
+});

--- a/tests/providers/format.test.ts
+++ b/tests/providers/format.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { formatProviderError } from '../../src/providers/format.js';
+
+describe('formatProviderError', () => {
+  it('formats the undici fetch failed / SocketError reference case', () => {
+    // Reproduce the undici shape:
+    //   TypeError: fetch failed
+    //     [cause]: SocketError { message: 'other side closed', code: 'UND_ERR_SOCKET' }
+    const cause: Error & { code?: string } = new Error('other side closed');
+    cause.name = 'SocketError';
+    cause.code = 'UND_ERR_SOCKET';
+
+    const outer = new TypeError('fetch failed');
+    (outer as Error & { cause?: unknown }).cause = cause;
+
+    expect(formatProviderError(outer)).toBe(
+      'fetch failed: SocketError: other side closed (UND_ERR_SOCKET)'
+    );
+  });
+
+  it('returns message unchanged for a plain Error with no cause', () => {
+    expect(formatProviderError(new Error('boom'))).toBe('boom');
+  });
+
+  it('coerces non-Error input via String()', () => {
+    expect(formatProviderError(42)).toBe('42');
+  });
+
+  it('caps recursion at depth 2 and does not walk cause.cause', () => {
+    // Build a 3-level chain: outer -> middle -> inner
+    const inner: Error & { code?: string } = new Error('inner message');
+    inner.name = 'InnerError';
+    inner.code = 'INNER_CODE';
+
+    const middle: Error & { cause?: unknown; code?: string } = new Error('middle message');
+    middle.name = 'MiddleError';
+    middle.code = 'MIDDLE_CODE';
+    middle.cause = inner;
+
+    const outer = new Error('outer message');
+    (outer as Error & { cause?: unknown }).cause = middle;
+
+    const formatted = formatProviderError(outer);
+
+    // First two levels are folded in.
+    expect(formatted).toBe('outer message: MiddleError: middle message (MIDDLE_CODE)');
+    // Third level (cause.cause) is NOT included.
+    expect(formatted).not.toContain('InnerError');
+    expect(formatted).not.toContain('inner message');
+    expect(formatted).not.toContain('INNER_CODE');
+  });
+
+  it('omits the code suffix when cause has no code', () => {
+    const cause = new Error('some reason');
+    cause.name = 'GenericError';
+    const outer = new Error('wrapper');
+    (outer as Error & { cause?: unknown }).cause = cause;
+
+    expect(formatProviderError(outer)).toBe('wrapper: GenericError: some reason');
+  });
+
+  it('ignores non-error-shaped cause values', () => {
+    const outer = new Error('wrapper');
+    (outer as Error & { cause?: unknown }).cause = 'a plain string';
+
+    expect(formatProviderError(outer)).toBe('wrapper');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `formatProviderError(err)` in a new `src/providers/format.ts` and
uses it at the two provider rethrow sites so that Node/undici
transport failures preserve `error.cause` instead of collapsing to
`other side closed` with no wrapper name / code / provider context.

- New: `src/providers/format.ts`
- Wired at `src/core/orchestrator.ts:84` and
  `src/core/streamingOrchestrator.ts:162`
- Tests:
  - `tests/providers/format.test.ts` — unit coverage: undici reference
    case, plain `Error`, non-Error input, 3-level depth cap, missing
    code, non-error-shaped cause.
  - `tests/core/orchestrator.error.test.ts` — integration; mocks the
    provider to reject with the undici shape and asserts the rethrown
    `.message` contains `SocketError` AND `UND_ERR_SOCKET` while the
    original Error identity is preserved (`instanceof` checks elsewhere
    keep working).

## Behaviour

- Non-Error input → `String(err)`.
- Native `Error` with no distinct cause → `err.message` (unchanged).
- Native `Error` with an error-shaped cause →
  `${msg}: ${cause.name}: ${cause.message}${code ? ' (code)' : ''}`.
- Recursion is capped at depth 2 — `cause.cause` is NOT walked, so
  pathological / self-referential chains cannot blow up the message
  width.

Mirrors upstream cline/cline#11928 (commit `263b58f`, 2026-06-27).

## Gates

Ran locally and all pass:

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm run test:coverage` — 200 files / 2792 passed (2 skipped),
  62.29% line coverage (well above the 40% CI threshold)
- `npm run build` — clean

Closes #867

[alexi-bot]