### PR TITLE
fix(core): wire stripInternalOptions into agenticChat and streamingOrchestrator dispatch

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -90,13 +90,17 @@ const internal: ReadonlySet<string> = new Set(INTERNAL_OPTION_KEYS);
  * `source: 'user' | 'org'` provenance alongside real request options, or
  * spreading an org-managed agent's `options` blob into the request).
  *
- * As of this writing (2026-07-04), the built-in dispatch sites in
- * `src/core/agenticChat.ts`, `src/core/streamingOrchestrator.ts`, and
- * `src/core/orchestrator.ts` construct `CompletionOptions` explicitly with only
+ * As of 2026-07-14, the runtime dispatch paths in `src/core/agenticChat.ts`
+ * and `src/core/streamingOrchestrator.ts` call this helper defense-in-depth
+ * on every `provider.complete(...)` / `provider.streamComplete(...)`
+ * invocation. Even though those sites currently construct options with only
  * legitimate provider fields (`maxTokens`, `temperature`, `signal`, `tools`,
- * `headers`), so they do NOT need to call this helper. If you introduce a new
- * dispatch site that merges agent metadata into the options bag, you MUST call
- * `stripInternalOptions` on the merged bag before passing it to the provider.
+ * `headers`), the strip guarantees that any future merge accidentally pulling
+ * in agent metadata will not leak through to SAP AI Core / SAP Orchestration.
+ *
+ * If you introduce a new dispatch site, you MUST call `stripInternalOptions`
+ * on the merged options bag before passing it to the provider — the JSDoc on
+ * `INTERNAL_OPTION_KEYS` describes what is stripped and why.
  *
  * The deny-list is `INTERNAL_OPTION_KEYS`; see its JSDoc for what is stripped
  * and why. Non-listed keys (including all legitimate `CompletionOptions`

--- a/src/core/__tests__/agenticChat.test.ts
+++ b/src/core/__tests__/agenticChat.test.ts
@@ -62,6 +62,7 @@ import { agenticChat } from '../agenticChat.js';
 import { getProviderForModel, getProviderForModelWithFallback } from '../../providers/index.js';
 import { getMemoryManager } from '../memory.js';
 import { getSessionContextString } from '../sessionContext.js';
+import { INTERNAL_OPTION_KEYS } from '../../agent/index.js';
 
 describe('agenticChat', () => {
   let mockProvider: {
@@ -908,6 +909,50 @@ describe('agenticChat', () => {
         expect(result.text).toBe('Response');
         expect(result.iterations).toBe(1);
       });
+    });
+  });
+
+  describe('provider dispatch strips internal agent-metadata options', () => {
+    it('never forwards INTERNAL_OPTION_KEYS to provider.complete', async () => {
+      mockProvider.complete.mockResolvedValue({
+        text: 'ok',
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        toolCalls: undefined,
+      } satisfies CompletionResult);
+
+      await agenticChat('hi');
+
+      // provider.complete is called with (messages, options)
+      expect(mockProvider.complete).toHaveBeenCalledTimes(1);
+      const [, opts] = mockProvider.complete.mock.calls[0];
+      const optsObj = opts as Record<string, unknown>;
+
+      // Legitimate CompletionOptions fields must be preserved
+      expect(optsObj).toHaveProperty('maxTokens');
+
+      // No agent-metadata key from the deny-list may leak through
+      for (const key of INTERNAL_OPTION_KEYS) {
+        expect(
+          optsObj,
+          `internal key '${key}' leaked into provider.complete opts`
+        ).not.toHaveProperty(key);
+      }
+    });
+
+    it('preserves legitimate keys even if the options bag is a plain object without internal keys', async () => {
+      // Sanity: with no upstream contamination the strip is a no-op on
+      // legitimate keys. The primary guarantee is the assertion above.
+      mockProvider.complete.mockResolvedValue({
+        text: 'ok',
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        toolCalls: undefined,
+      } satisfies CompletionResult);
+
+      await agenticChat('hi');
+
+      const [, opts] = mockProvider.complete.mock.calls[0];
+      const optsObj = opts as Record<string, unknown>;
+      expect(typeof optsObj['maxTokens']).toBe('number');
     });
   });
 });

--- a/src/core/agenticChat.ts
+++ b/src/core/agenticChat.ts
@@ -21,6 +21,7 @@ import type { AutoCommitManager } from '../git/autoCommit.js';
 import type { RepoMapManager } from '../context/repoMap.js';
 import { type EffortLevel, getEffortConfig, DEFAULT_EFFORT } from './effortLevel.js';
 import { buildAssembledSystemPromptAsync } from '../agent/system.js';
+import { stripInternalOptions } from '../agent/index.js';
 import { initReferenceService, getReferenceService } from '../reference/reference.js';
 import { initRepositoryCache } from '../reference/repository-cache.js';
 import {
@@ -566,10 +567,20 @@ export async function agenticChat(
 
     let result: CompletionResult;
     try {
-      result = await provider.complete(messages as Array<{ role: string; content: string }>, {
+      // Build the completion-options bag and strip any agent-metadata keys
+      // before dispatch. Keys defined in `INTERNAL_OPTION_KEYS` (agent id,
+      // displayName, source, reference, resolved, mode, aliases, ...) must
+      // never reach SAP AI Core / SAP Orchestration; see
+      // `stripInternalOptions` in `src/agent/index.ts`.
+      const merged = {
         maxTokens: effortConfig.maxTokens,
         tools: isFinalTurn ? undefined : toolSchemas.length > 0 ? toolSchemas : undefined,
-      });
+      };
+      const providerOpts = stripInternalOptions(merged);
+      result = await provider.complete(
+        messages as Array<{ role: string; content: string }>,
+        providerOpts
+      );
       recordRouteOutcome(modelId, { kind: 'success' });
     } catch (err) {
       // Detect context overflow and attempt compaction with reactive seeding
@@ -603,10 +614,16 @@ export async function agenticChat(
 
           // Retry the completion
           try {
-            result = await provider.complete(messages as Array<{ role: string; content: string }>, {
+            // Same defense-in-depth strip as the primary dispatch above.
+            const mergedRetry = {
               maxTokens: effortConfig.maxTokens,
               tools: isFinalTurn ? undefined : toolSchemas.length > 0 ? toolSchemas : undefined,
-            });
+            };
+            const retryOpts = stripInternalOptions(mergedRetry);
+            result = await provider.complete(
+              messages as Array<{ role: string; content: string }>,
+              retryOpts
+            );
             recordRouteOutcome(modelId, { kind: 'success' });
           } catch (retryErr) {
             const classified = classifyRouteError(retryErr);

--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -13,7 +13,9 @@ import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
 import { type EffortLevel, getEffortConfig, DEFAULT_EFFORT } from './effortLevel.js';
 import { buildAssembledSystemPromptAsync } from '../agent/system.js';
+import { stripInternalOptions } from '../agent/index.js';
 import { buildSessionHeaders } from '../providers/sessionHeaders.js';
+import type { CompletionOptions } from '../providers/sapOrchestration.js';
 
 export interface StreamingOptions {
   modelOverride?: string;
@@ -144,12 +146,19 @@ export async function* streamChat(
   // auto-disable counter; success resets it. Transient errors are left to
   // ErrorBackoff.
   try {
-    for await (const chunk of provider.streamComplete(messages, {
+    // Build the completion-options bag and strip any agent-metadata keys
+    // before dispatch. Keys defined in `INTERNAL_OPTION_KEYS` (agent id,
+    // displayName, source, reference, resolved, mode, aliases, ...) must
+    // never reach SAP AI Core / SAP Orchestration; see
+    // `stripInternalOptions` in `src/agent/index.ts`.
+    const merged: CompletionOptions = {
       maxTokens: options?.maxTokens ?? effortConfig.maxTokens,
       temperature: options?.temperature,
       signal: options?.signal,
       headers: extraHeaders as Record<string, string>,
-    })) {
+    };
+    const providerOpts = stripInternalOptions(merged) as CompletionOptions;
+    for await (const chunk of provider.streamComplete(messages, providerOpts)) {
       fullText += chunk.text;
       if (chunk.usage) finalUsage = chunk.usage;
       yield chunk;

--- a/tests/core/streamingOrchestrator.fallback.test.ts
+++ b/tests/core/streamingOrchestrator.fallback.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../src/core/router.js', () => ({
 // Import after mocking
 import { streamChat } from '../../src/core/streamingOrchestrator.js';
 import { getProviderForModelWithFallback, getDefaultModel } from '../../src/providers/index.js';
+import { INTERNAL_OPTION_KEYS } from '../../src/agent/index.js';
 
 // Helper to create a mock provider that yields a single chunk
 function createMockStreamProvider(chunks: Array<{ text: string; usage?: Record<string, number> }>) {
@@ -86,5 +87,58 @@ describe('streamChat fallback model resolution', () => {
     expect(result.modelUsed).toBe('anthropic--claude-4-sonnet');
     expect(getProviderForModelWithFallback).toHaveBeenCalledWith('anthropic--claude-4-sonnet');
     expect(mockProvider.streamComplete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('streamChat provider dispatch strips internal agent-metadata options', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDefaultModel).mockReturnValue('gpt-4o');
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('never forwards INTERNAL_OPTION_KEYS to provider.streamComplete', async () => {
+    const mockProvider = createMockStreamProvider([
+      { text: 'hi', usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ]);
+
+    vi.mocked(getProviderForModelWithFallback).mockImplementation((modelId: string) => ({
+      provider: mockProvider as never,
+      effectiveModelId: modelId,
+      usedFallback: false,
+    }));
+
+    const gen = streamChat('hi', {
+      modelOverride: 'anthropic--claude-4-sonnet',
+      maxTokens: 512,
+      temperature: 0.4,
+      agentId: 'code',
+    });
+
+    let next = await gen.next();
+    while (!next.done) {
+      next = await gen.next();
+    }
+
+    // provider.streamComplete is called with (messages, options)
+    expect(mockProvider.streamComplete).toHaveBeenCalledTimes(1);
+    const [, opts] = mockProvider.streamComplete.mock.calls[0];
+    const optsObj = opts as Record<string, unknown>;
+
+    // Legitimate CompletionOptions fields must be preserved
+    expect(optsObj).toHaveProperty('maxTokens', 512);
+    expect(optsObj).toHaveProperty('temperature', 0.4);
+    expect(optsObj).toHaveProperty('headers');
+
+    // No agent-metadata key from the deny-list may leak through
+    for (const key of INTERNAL_OPTION_KEYS) {
+      expect(
+        optsObj,
+        `internal key '${key}' leaked into provider.streamComplete opts`
+      ).not.toHaveProperty(key);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Both runtime dispatch paths — `src/core/agenticChat.ts` and `src/core/streamingOrchestrator.ts` — now call `stripInternalOptions(...)` on the options bag before every `provider.complete(...)` / `provider.streamComplete(...)` invocation, so agent-metadata keys (`id`, `displayName`, `source`, `reference`, `resolved`, plus any `INTERNAL_OPTION_KEYS` extensions) can never leak to SAP AI Core / SAP Orchestration.

## Changes

- `src/core/agenticChat.ts`: import `stripInternalOptions`, pull the inline options literal into a `const merged`, then pass `stripInternalOptions(merged)` to `provider.complete(...)`. Same treatment on the compaction-retry path.
- `src/core/streamingOrchestrator.ts`: import `stripInternalOptions` and `CompletionOptions`, wrap the options bag passed to `provider.streamComplete(...)` with `stripInternalOptions(merged)`. `signal`, `headers`, `maxTokens`, `temperature` are preserved.
- `src/agent/index.ts`: audited `INTERNAL_OPTION_KEYS` (already covers every key called out in the issue plus every `AgentSchema` field that is not a legitimate `CompletionOptions` field). Updated the JSDoc on `stripInternalOptions` to reflect that the two runtime dispatch sites now call it as defense-in-depth.

## Tests (spy-based, no real provider)

- `src/core/__tests__/agenticChat.test.ts`: new `describe('provider dispatch strips internal agent-metadata options')` block asserts `mockProvider.complete`'s recorded options never contain any key from `INTERNAL_OPTION_KEYS`.
- `tests/core/streamingOrchestrator.fallback.test.ts`: new `describe(...)` block does the same for `provider.streamComplete`, verifying legitimate fields (`maxTokens`, `temperature`, `headers`) still pass through.
- Existing `src/agent/index.test.ts` unit tests on `stripInternalOptions` (from #912) still pass.

## Verification

```
npm run lint          # 0 errors
npm run typecheck     # clean
npm run format:check  # clean
npm test              # 2866 passed | 2 skipped (207 files)
npm run test:coverage # Lines 62.98%
npm run build         # ok
```

`grep -rn 'stripInternalOptions' src/ | wc -l` -> `17` (definition + 2 runtime callers + 3 invocations + test import + JSDoc references).

Closes #926