### PR TITLE
feat(cli): show idle cwd segment in TUI StatusBar

### DIFF
--- a/.kilo/package-lock.json
+++ b/.kilo/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@kilocode/plugin": "7.4.5"
+        "@kilocode/plugin": "7.4.7"
       }
     },
     "node_modules/@kilocode/plugin": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.4.5.tgz",
-      "integrity": "sha512-MccW5SVsbuD0qAcrTF/MKdqw6hwPzIUFGoE3EBEPuzied3vFY5UtIzz3tgjxFCcLK+x48CFgo1HOdJxAMkSvGw==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.4.7.tgz",
+      "integrity": "sha512-yMtWjpTGnqpAATW6OKzqe+tAlvWa4q8+IMlDPpf1IELA9TBfrlaFvep17fExW6pxIXLlSLL98G5JBCUGm6gB0Q==",
       "license": "MIT",
       "dependencies": {
-        "@kilocode/sdk": "7.4.5",
+        "@kilocode/sdk": "7.4.7",
         "effect": "4.0.0-beta.66",
         "zod": "4.1.8"
       },
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@kilocode/sdk": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.4.5.tgz",
-      "integrity": "sha512-sJurT4oQ7aXP6eHcYhhYCm50WghkEhdZgXjTeSZfRSMJkTlf7c+kz1wkWImv7J8lCJIwPwrE3KNBKwtOMfQtyg==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.4.7.tgz",
+      "integrity": "sha512-KVUDAgmo+GosYRvDfQomlBVH3Chljqi9DZIgwIOni5fhYBEyWwOGxzyVAgJWuKw4aFq7TBPMfu5MY5VVXW1Ckg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.kilocode/package-lock.json
+++ b/.kilocode/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@kilocode/plugin": "7.4.5"
+        "@kilocode/plugin": "7.4.7"
       }
     },
     "node_modules/@kilocode/plugin": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.4.5.tgz",
-      "integrity": "sha512-MccW5SVsbuD0qAcrTF/MKdqw6hwPzIUFGoE3EBEPuzied3vFY5UtIzz3tgjxFCcLK+x48CFgo1HOdJxAMkSvGw==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.4.7.tgz",
+      "integrity": "sha512-yMtWjpTGnqpAATW6OKzqe+tAlvWa4q8+IMlDPpf1IELA9TBfrlaFvep17fExW6pxIXLlSLL98G5JBCUGm6gB0Q==",
       "license": "MIT",
       "dependencies": {
-        "@kilocode/sdk": "7.4.5",
+        "@kilocode/sdk": "7.4.7",
         "effect": "4.0.0-beta.66",
         "zod": "4.1.8"
       },
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@kilocode/sdk": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.4.5.tgz",
-      "integrity": "sha512-sJurT4oQ7aXP6eHcYhhYCm50WghkEhdZgXjTeSZfRSMJkTlf7c+kz1wkWImv7J8lCJIwPwrE3KNBKwtOMfQtyg==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.4.7.tgz",
+      "integrity": "sha512-KVUDAgmo+GosYRvDfQomlBVH3Chljqi9DZIgwIOni5fhYBEyWwOGxzyVAgJWuKw4aFq7TBPMfu5MY5VVXW1Ckg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/src/cli/tui/components/StatusBar.tsx
+++ b/src/cli/tui/components/StatusBar.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from 'ink';
 
 import { ProviderModelFellBack } from '../../../bus/index.js';
 import { useTheme } from '../context/ThemeContext.js';
+import { formatCwdShort } from '../utils/pathFormat.js';
 import { Spinner } from './Spinner.js';
 
 export interface StatusBarProps {
@@ -22,6 +23,14 @@ export interface StatusBarProps {
    * keep the segment compact (matches the model truncation rule below).
    */
   topModelLabel?: string;
+  /**
+   * Absolute path of the current working directory. When provided AND the
+   * session is idle (not streaming and not in leader mode), the StatusBar
+   * appends a short cwd segment (home-abbreviated to `~/...` or basename)
+   * so users can see which worktree they are writing to. Skipped while
+   * streaming to avoid segment jitter next to the spinner.
+   */
+  cwd?: string;
 }
 
 const CURRENCY_SYMBOLS: Record<string, string> = {
@@ -58,6 +67,7 @@ export function StatusBar({
   tokenCount = 0,
   sessionId,
   topModelLabel,
+  cwd,
 }: StatusBarProps): React.JSX.Element {
   const { theme } = useTheme();
   const { colors } = theme;
@@ -130,6 +140,12 @@ export function StatusBar({
           <Text color={colors.dimText} backgroundColor={colors.backgroundDarker}>
             {' · '}
             {sessionId.slice(0, 8)}
+          </Text>
+        )}
+        {!isStreaming && !leaderActive && cwd && (
+          <Text color={colors.dimText} backgroundColor={colors.backgroundDarker}>
+            {' · '}
+            {formatCwdShort(cwd)}
           </Text>
         )}
       </Box>

--- a/src/cli/tui/pages/ChatPage.tsx
+++ b/src/cli/tui/pages/ChatPage.tsx
@@ -128,6 +128,7 @@ export function ChatPage({
           tokenCount={tokenCount}
           sessionId={sessionId}
           topModelLabel={topModelLabel}
+          cwd={process.cwd()}
         />
       </Box>
     </>

--- a/src/cli/tui/pages/LogsPage.tsx
+++ b/src/cli/tui/pages/LogsPage.tsx
@@ -112,6 +112,7 @@ export function LogsPage({
           isStreaming={isStreaming}
           leaderActive={leaderActive}
           topModelLabel={topModelLabel}
+          cwd={process.cwd()}
         />
       </Box>
     </>

--- a/src/cli/tui/utils/pathFormat.test.ts
+++ b/src/cli/tui/utils/pathFormat.test.ts
@@ -8,6 +8,7 @@ import {
   formatPathRelativeToSession,
   formatPathForDisplay,
   abbreviateHomePath,
+  formatCwdShort,
 } from './pathFormat.js';
 
 describe('formatPathRelativeToSession', () => {
@@ -82,5 +83,44 @@ describe('formatPathForDisplay', () => {
 
     const result = formatPathForDisplay(filePath, sessionDir);
     expect(result).toBe('~/other/file.ts');
+  });
+});
+
+describe('formatCwdShort', () => {
+  it('returns empty string for empty input', () => {
+    expect(formatCwdShort('')).toBe('');
+  });
+
+  it('abbreviates $HOME prefix to ~', () => {
+    const home = process.env.HOME || process.env.USERPROFILE;
+    if (!home) {
+      return;
+    }
+    const cwd = path.join(home, 'projects', 'alexi');
+    expect(formatCwdShort(cwd)).toBe('~/projects/alexi');
+  });
+
+  it('returns ~ for the home directory itself', () => {
+    const home = process.env.HOME || process.env.USERPROFILE;
+    if (!home) {
+      return;
+    }
+    expect(formatCwdShort(home)).toBe('~');
+  });
+
+  it('falls back to basename for paths outside $HOME', () => {
+    expect(formatCwdShort('/var/lib/foo')).toBe('foo');
+    expect(formatCwdShort('/opt/app/bar')).toBe('bar');
+  });
+
+  it('does not abbreviate paths that only share a prefix with $HOME', () => {
+    const home = process.env.HOME || process.env.USERPROFILE;
+    if (!home) {
+      return;
+    }
+    // e.g. HOME=/home/user, but cwd=/home/userland/other
+    const sibling = `${home}land/other`;
+    // Should NOT be treated as inside $HOME -> falls back to basename
+    expect(formatCwdShort(sibling)).toBe('other');
   });
 });

--- a/src/cli/tui/utils/pathFormat.ts
+++ b/src/cli/tui/utils/pathFormat.ts
@@ -63,3 +63,24 @@ export function formatPathForDisplay(absolutePath: string, sessionDirectory: str
   // Otherwise abbreviate home directory
   return abbreviateHomePath(absolutePath);
 }
+
+/**
+ * Format a cwd for display in the StatusBar.
+ *
+ * - If the path is inside `$HOME`, replace the home prefix with `~`
+ *   (e.g. `/home/alice/projects/alexi` -> `~/projects/alexi`).
+ * - Otherwise fall back to the basename of the path so the segment stays
+ *   short (e.g. `/var/lib/foo` -> `foo`).
+ * - Empty/falsy input returns an empty string.
+ */
+export function formatCwdShort(cwd: string): string {
+  if (!cwd) {
+    return '';
+  }
+  const home = process.env.HOME || process.env.USERPROFILE;
+  if (home && (cwd === home || cwd.startsWith(home + path.sep))) {
+    const rest = cwd.slice(home.length);
+    return rest.length === 0 ? '~' : `~${rest}`;
+  }
+  return path.basename(cwd) || cwd;
+}

--- a/tests/cli/tui/StatusBar.test.tsx
+++ b/tests/cli/tui/StatusBar.test.tsx
@@ -108,4 +108,46 @@ describe('StatusBar', () => {
     const frame = lastFrame() ?? '';
     expect(frame).not.toContain('gpt-5.5');
   });
+
+  it('renders cwd basename segment when idle and cwd is provided', () => {
+    const { lastFrame } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} cwd="/var/tmp/my-cwd-basename-xyz" />
+      </Wrapper>
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('my-cwd-basename-xyz');
+  });
+
+  it('does not render cwd segment while streaming', () => {
+    const { lastFrame } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} isStreaming={true} cwd="/var/tmp/my-cwd-basename-xyz" />
+      </Wrapper>
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('my-cwd-basename-xyz');
+  });
+
+  it('does not render cwd segment in leader mode', () => {
+    const { lastFrame } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} leaderActive={true} cwd="/var/tmp/my-cwd-basename-xyz" />
+      </Wrapper>
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('my-cwd-basename-xyz');
+  });
+
+  it('omits cwd segment when cwd prop is not provided', () => {
+    const { lastFrame } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+    const frame = lastFrame() ?? '';
+    // No trailing basename should appear (we can't test absence generally,
+    // but there is no ' · ' following the sessionId slot since none set).
+    expect(frame).not.toContain('my-cwd-basename-xyz');
+  });
 });


### PR DESCRIPTION
## Summary

Shows the current working directory in the TUI `StatusBar` when the session is idle (not streaming and not in leader mode), mirroring the upstream opencode #36457 feature. Helps users track which worktree they are writing to when working under `~/.alexi/worktrees/<slug>/`.

## Changes

- `src/cli/tui/components/StatusBar.tsx`: add optional `cwd?: string` prop and render a new dimmed `' \u00b7 <cwd>'` text node inside Segment 2 only when `!isStreaming && !leaderActive && cwd`. Also imports the new formatter.
- `src/cli/tui/utils/pathFormat.ts`: add `formatCwdShort(cwd)` helper. `$HOME` prefix -> `~`, otherwise `path.basename(cwd)`. Empty input returns `''`.
- `src/cli/tui/pages/ChatPage.tsx` and `src/cli/tui/pages/LogsPage.tsx`: pass `cwd={process.cwd()}` to `StatusBar`.
- `tests/cli/tui/StatusBar.test.tsx`: new tests for idle rendering, streaming suppression, leader-mode suppression, and absence when `cwd` prop is omitted.
- `src/cli/tui/utils/pathFormat.test.ts`: unit tests for `formatCwdShort` covering home abbreviation, home itself, non-home basename fallback, and near-home prefix disambiguation.

## Verification

- `npm run typecheck`: clean
- `npm run lint`: 0 errors (existing warnings only)
- `npm run format:check`: clean
- `npm test`: 209 files, 2892 passed, 2 skipped
- `npm run build`: succeeds

## Notes

- Reading `process.cwd()` at render time is intentional; Ink re-renders on state changes and cwd effectively never changes mid-session, so no `useState`/`useEffect` is needed.
- The cwd segment is intentionally hidden while streaming to avoid segment jitter next to the spinner (matches the upstream research note).
- The `!leaderActive` guard is defensive; leader mode already short-circuits to a full-width hint bar before reaching Segment 2, but keeping the guard makes the intent explicit.

Closes #954