### PR TITLE
fix(cli): /fork copies session transcript and metadata

### DIFF
--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -706,11 +706,30 @@ export async function handleCommand(input: string, state: ReplState): Promise<bo
         return true;
       }
       const forkName = args[0] || `fork-${Date.now()}`;
-      // Create a new session with the same history
+      // Snapshot the source transcript BEFORE creating a new session — creating
+      // one flips the active session on the manager, so we must capture the
+      // originals up front.
+      const sourceMessages = session.messages.map((m) => ({
+        ...m,
+        tokens: m.tokens ? { ...m.tokens } : undefined,
+      }));
+      const sourceWorkdir = session.metadata.workdir;
+      const sourceTotalTokens = sourceMessages.reduce(
+        (sum, m) => sum + (m.tokens?.input ?? 0) + (m.tokens?.output ?? 0),
+        0
+      );
+      // Create a new session and copy the conversation state so users can
+      // continue exploring alternate branches from the forked point.
       state.sessionManager.createSession(state.currentModel);
       const newSession = state.sessionManager.getCurrentSession();
       if (newSession) {
+        newSession.messages = sourceMessages;
         newSession.metadata.title = forkName;
+        newSession.metadata.messageCount = sourceMessages.length;
+        newSession.metadata.totalTokens = sourceTotalTokens;
+        if (sourceWorkdir !== undefined) {
+          newSession.metadata.workdir = sourceWorkdir;
+        }
         console.log(
           c('green', `\n  Forked session: ${forkName} (${newSession.metadata.id.slice(0, 8)})\n`)
         );

--- a/tests/cli/interactive.fork.test.ts
+++ b/tests/cli/interactive.fork.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the `/fork` slash command.
+ *
+ * Issue #994: `/fork` must copy the message transcript (and derived metadata)
+ * from the current session into the new one, so users can explore alternate
+ * conversation branches from the current point rather than getting an empty
+ * session.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { handleCommand, type ReplState } from '../../src/cli/interactive.js';
+import { SessionManager } from '../../src/core/sessionManager.js';
+
+function buildReplState(sessionsDir: string): ReplState {
+  const sessionManager = new SessionManager({ sessionsDir });
+  sessionManager.createSession('test-model');
+  return {
+    sessionManager,
+    currentModel: 'test-model',
+    autoRoute: false,
+    preferCheap: false,
+    isStreaming: false,
+  };
+}
+
+describe('/fork copies session transcript', () => {
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-fork-test-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('duplicates messages and token metadata into a fresh session', async () => {
+    const state = buildReplState(tmpDir);
+    const original = state.sessionManager.getCurrentSession();
+    if (!original) {
+      throw new Error('expected a starting session');
+    }
+    original.messages.push({
+      role: 'user',
+      content: 'hello alexi',
+      timestamp: Date.now(),
+      tokens: { input: 10, output: 0 },
+    });
+    original.messages.push({
+      role: 'assistant',
+      content: 'hello back',
+      timestamp: Date.now(),
+      tokens: { input: 0, output: 20 },
+    });
+    original.metadata.messageCount = 2;
+    original.metadata.totalTokens = 30;
+    const originalId = original.metadata.id;
+    const originalWorkdir = original.metadata.workdir;
+
+    const handled = await handleCommand('/fork test-fork', state);
+    expect(handled).toBe(true);
+
+    const forked = state.sessionManager.getCurrentSession();
+    if (!forked) {
+      throw new Error('expected a forked session');
+    }
+    expect(forked.metadata.id).not.toBe(originalId);
+    expect(forked.metadata.title).toBe('test-fork');
+    expect(forked.messages).toHaveLength(2);
+    expect(forked.messages[0].content).toBe('hello alexi');
+    expect(forked.messages[1].content).toBe('hello back');
+    expect(forked.metadata.messageCount).toBe(2);
+    expect(forked.metadata.totalTokens).toBe(30);
+    expect(forked.metadata.workdir).toBe(originalWorkdir);
+  });
+
+  it('deep-copies messages so mutating the fork does not affect the source', async () => {
+    const state = buildReplState(tmpDir);
+    const original = state.sessionManager.getCurrentSession();
+    if (!original) {
+      throw new Error('expected a starting session');
+    }
+    // Use addMessage so the source session is persisted to disk with the
+    // message and we can reload it after the fork.
+    state.sessionManager.addMessage('user', 'immutable', { input: 5, output: 0 });
+    const originalId = original.metadata.id;
+
+    await handleCommand('/fork branch-a', state);
+    const forked = state.sessionManager.getCurrentSession();
+    if (!forked) {
+      throw new Error('expected a forked session');
+    }
+
+    // Mutate the fork's copied message and its token record.
+    forked.messages[0].content = 'mutated';
+    if (forked.messages[0].tokens) {
+      forked.messages[0].tokens.input = 999;
+    }
+
+    // Reload the original from disk to confirm it was not affected.
+    const reloaded = state.sessionManager.loadSession(originalId);
+    expect(reloaded?.messages[0].content).toBe('immutable');
+    expect(reloaded?.messages[0].tokens?.input).toBe(5);
+  });
+
+  it('generates a fallback fork name when no argument is provided', async () => {
+    const state = buildReplState(tmpDir);
+    const original = state.sessionManager.getCurrentSession();
+    if (!original) {
+      throw new Error('expected a starting session');
+    }
+
+    const handled = await handleCommand('/fork', state);
+    expect(handled).toBe(true);
+
+    const forked = state.sessionManager.getCurrentSession();
+    expect(forked?.metadata.title).toMatch(/^fork-\d+$/);
+  });
+
+  it('does not fork when there is no active session', async () => {
+    const sessionManager = new SessionManager({ sessionsDir: tmpDir });
+    const state: ReplState = {
+      sessionManager,
+      currentModel: 'test-model',
+      autoRoute: false,
+      preferCheap: false,
+      isStreaming: false,
+    };
+
+    const handled = await handleCommand('/fork orphan', state);
+    expect(handled).toBe(true);
+    expect(sessionManager.getCurrentSession()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #994

## What

Fix `/fork` slash command to copy the full message transcript from the current session into the newly-forked session.

## Why

Previously `/fork` only carried over `currentModel` and created an empty session. Users expect the fork to duplicate conversation state so they can branch off from the current point (`git checkout -b` semantics, per research finding #6).

## How

- Snapshot `session.messages` and `session.metadata.workdir` **before** calling `createSession()`, since createSession flips the active session on the manager.
- Deep-copy each message (spread + spread of `tokens`) into the new session.
- Recompute `metadata.messageCount` and `metadata.totalTokens` from the copied messages.
- Preserve `metadata.workdir` from the source when defined.

## Tests

New `tests/cli/interactive.fork.test.ts`:
- Duplicates messages + token metadata into a fresh session id.
- Deep-copy verified: mutating the fork does not affect the reloaded original on disk.
- Fallback `fork-<timestamp>` name when no argument is given.
- No-op path when there is no active session.

## Gates

```
npm run typecheck  # clean
npm run lint       # 0 errors
npm run format:check
npm test           # 2946 tests, 0 failures
npm run build      # clean
```

[alexi-bot]