### PR TITLE
feat(cli): auto-switch to forked session after /fork command

### DIFF
--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -720,6 +720,10 @@ export async function handleCommand(input: string, state: ReplState): Promise<bo
       );
       // Create a new session and copy the conversation state so users can
       // continue exploring alternate branches from the forked point.
+      // `createSession` sets the new session as the manager's active session
+      // (see SessionManager.createSession), so the fork becomes the current
+      // session automatically — subsequent user messages land in the fork,
+      // matching the `git checkout -b` mental model users expect.
       state.sessionManager.createSession(state.currentModel);
       const newSession = state.sessionManager.getCurrentSession();
       if (newSession) {
@@ -731,7 +735,10 @@ export async function handleCommand(input: string, state: ReplState): Promise<bo
           newSession.metadata.workdir = sourceWorkdir;
         }
         console.log(
-          c('green', `\n  Forked session: ${forkName} (${newSession.metadata.id.slice(0, 8)})\n`)
+          c(
+            'green',
+            `\n  Forked session: ${forkName} (${newSession.metadata.id.slice(0, 8)}) - now active\n`
+          )
         );
       }
       return true;

--- a/tests/cli/interactive.fork.test.ts
+++ b/tests/cli/interactive.fork.test.ts
@@ -124,6 +124,41 @@ describe('/fork copies session transcript', () => {
     expect(forked?.metadata.title).toMatch(/^fork-\d+$/);
   });
 
+  it('switches the active session to the fork (issue #993)', async () => {
+    const state = buildReplState(tmpDir);
+    const original = state.sessionManager.getCurrentSession();
+    if (!original) {
+      throw new Error('expected a starting session');
+    }
+    original.messages.push({
+      role: 'user',
+      content: 'original message',
+      timestamp: Date.now(),
+    });
+    const originalId = original.metadata.id;
+
+    await handleCommand('/fork test-fork', state);
+
+    const active = state.sessionManager.getCurrentSession();
+    expect(active).not.toBeNull();
+    expect(active?.metadata.id).not.toBe(originalId);
+    expect(active?.metadata.title).toBe('test-fork');
+  });
+
+  it('logs "now active" in the confirmation message', async () => {
+    const state = buildReplState(tmpDir);
+    const original = state.sessionManager.getCurrentSession();
+    if (!original) {
+      throw new Error('expected a starting session');
+    }
+
+    await handleCommand('/fork switched', state);
+
+    const logged = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logged).toContain('now active');
+    expect(logged).toContain('switched');
+  });
+
   it('does not fork when there is no active session', async () => {
     const sessionManager = new SessionManager({ sessionsDir: tmpDir });
     const state: ReplState = {


### PR DESCRIPTION
Closes #993

## What

The `/fork` command already made the new session active via `SessionManager.createSession` (which sets `this.activeSession = session`), but the confirmation message did not communicate this. Users could reasonably think they still needed to run `/sessions` to switch to the fork.

## Changes

- `src/cli/interactive.ts`: document in a comment that the fork is already the active session after `createSession`, and update the confirmation message to include `- now active` so the behaviour is explicit.
- `tests/cli/interactive.fork.test.ts`: add two tests
  - `/fork` switches `getCurrentSession()` to the new session (issue #993)
  - the confirmation message contains `now active`

## Verification

All quality gates green locally:

- `npm run lint` -> 0 errors (1294 pre-existing warnings, unchanged)
- `npm run typecheck` -> clean
- `npm run format:check` -> clean
- `npm test` -> 217 files / 2946 passed / 2 skipped (adds 2 new tests)
- `npm run build` -> succeeds

[alexi-bot]