### PR TITLE
feat(core): compaction progress UI in StatusBar

### DIFF
--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -283,6 +283,32 @@ export const ProviderModelFellBack = defineEvent(
   })
 );
 
+// Compaction events
+export const CompactionStarted = defineEvent(
+  'compaction.started',
+  z.object({
+    sessionId: z.string().optional(),
+    messageCount: z.number(),
+    estimatedTokens: z.number().optional(),
+    trigger: z.enum(['auto', 'manual', 'partial']).optional(),
+    timestamp: z.number(),
+  })
+);
+
+export const CompactionComplete = defineEvent(
+  'compaction.complete',
+  z.object({
+    sessionId: z.string().optional(),
+    originalMessages: z.number(),
+    compactedMessages: z.number(),
+    estimatedTokensSaved: z.number(),
+    durationMs: z.number(),
+    trigger: z.enum(['auto', 'manual', 'partial']).optional(),
+    error: z.string().optional(),
+    timestamp: z.number(),
+  })
+);
+
 // Error events
 export const ErrorOccurred = defineEvent(
   'error.occurred',

--- a/src/cli/tui/components/StatusBar.tsx
+++ b/src/cli/tui/components/StatusBar.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 
-import { ProviderModelFellBack } from '../../../bus/index.js';
+import {
+  CompactionComplete,
+  CompactionStarted,
+  ProviderModelFellBack,
+} from '../../../bus/index.js';
 import { useTheme } from '../context/ThemeContext.js';
 import { formatCwdShort } from '../utils/pathFormat.js';
 import { Spinner } from './Spinner.js';
@@ -88,6 +92,25 @@ export function StatusBar({
     return unsub;
   }, []);
 
+  // Subscribe to compaction lifecycle events so we can show a "Compacting…"
+  // spinner segment. Compaction can take multiple seconds on large sessions
+  // and previously looked like a hang. Matches the existing streaming
+  // spinner pattern.
+  const [isCompacting, setIsCompacting] = React.useState(false);
+
+  React.useEffect(() => {
+    const unsubStart = CompactionStarted.subscribe(() => {
+      setIsCompacting(true);
+    });
+    const unsubComplete = CompactionComplete.subscribe(() => {
+      setIsCompacting(false);
+    });
+    return () => {
+      unsubStart();
+      unsubComplete();
+    };
+  }, []);
+
   const currencySymbol = CURRENCY_SYMBOLS[cost.currency] ?? `${cost.currency} `;
   const costStr = `${currencySymbol}${cost.totalCost.toFixed(4)}`;
   const topModelDisplay =
@@ -159,7 +182,18 @@ export function StatusBar({
         </Box>
       )}
 
-      {/* Segment 3: Streaming indicator or agent */}
+      {/* Segment 3a: Compaction progress (only while compacting) */}
+      {isCompacting && (
+        <Box backgroundColor={colors.backgroundSecondary} paddingX={1}>
+          <Spinner />
+          <Text color={colors.warning} backgroundColor={colors.backgroundSecondary}>
+            {' '}
+            Compacting context...
+          </Text>
+        </Box>
+      )}
+
+      {/* Segment 3b: Streaming indicator or agent */}
       <Box backgroundColor={colors.backgroundSecondary} paddingX={1}>
         {isStreaming ? (
           <Box>

--- a/src/core/compaction.ts
+++ b/src/core/compaction.ts
@@ -8,6 +8,7 @@
  * - Auto-compact can be disabled via config
  */
 
+import { CompactionStarted, CompactionComplete } from '../bus/index.js';
 import type { Message } from './sessionManager.js';
 
 // ============ Types ============
@@ -358,67 +359,66 @@ export async function compactConversation(
     };
   }
 
+  // From here on we may perform real work (summary generation, potentially
+  // over the network). Publish a `CompactionStarted` event so the TUI can
+  // render a progress indicator, and always publish `CompactionComplete`
+  // via a try/finally guard — even on failure — so the UI never gets stuck
+  // showing "Compacting…" forever.
+  const compactionStartTime = Date.now();
   const originalTokens = estimateMessagesTokens(messages);
+  let compactionEmittedStart = false;
+  let compactionErrorMessage: string | undefined;
+  let compactionResultForEvent: CompactionResult | null = null;
 
-  // Separate system messages from others
-  const systemMessages = messages.filter((m) => m.role === 'system');
-  const nonSystemMessages = messages.filter((m) => m.role !== 'system');
+  const emitCompactionStart = (): void => {
+    if (compactionEmittedStart) {
+      return;
+    }
+    compactionEmittedStart = true;
+    try {
+      CompactionStarted.publish({
+        messageCount: messages.length,
+        estimatedTokens: originalTokens,
+        trigger: 'auto',
+        timestamp: compactionStartTime,
+      });
+    } catch {
+      // Never let bus errors break compaction itself.
+    }
+  };
 
-  // If non-system messages are fewer than preserveLastN, return unchanged
-  if (nonSystemMessages.length <= preserveLastN) {
-    return {
-      messages: [...messages],
-      result: {
+  const emitCompactionComplete = (): void => {
+    if (!compactionEmittedStart) {
+      return;
+    }
+    try {
+      const result = compactionResultForEvent ?? {
         originalMessages: messages.length,
         compactedMessages: messages.length,
         estimatedTokensSaved: 0,
         summary: '',
-      },
-    };
-  }
-
-  // Default split: keep last N, summarize the rest.
-  let messagesToSummarize = nonSystemMessages.slice(0, -preserveLastN);
-  let messagesToKeep = nonSystemMessages.slice(-preserveLastN);
-
-  // When the caller passes `maxContextTokens`, target ~80% of the trigger
-  // budget (context - reserved output) so the very next turn does not
-  // immediately re-cross the compaction threshold. We grow `toKeep` BACKWARDS
-  // from the tail past `preserveLastN` while the resulting kept set + the
-  // summary budget still fits under the target. Anything that does not fit is
-  // moved into `messagesToSummarize`.
-  const maxContextTokens = options?.maxContextTokens;
-  const reserveOutputTokens = options?.reserveOutputTokens ?? DEFAULT_RESERVE_OUTPUT_TOKENS;
-  if (typeof maxContextTokens === 'number' && maxContextTokens > 0) {
-    const triggerTokens = Math.max(0, maxContextTokens - reserveOutputTokens);
-    const targetTokens = Math.floor(triggerTokens * POST_COMPACT_TARGET_FRACTION);
-
-    // Always keep at least the last `preserveLastN` non-system messages
-    // (existing invariant). Grow the kept window leftwards as long as the
-    // running total (kept + system + summary budget) stays under target.
-    const systemTokens = estimateMessagesTokens(systemMessages);
-
-    let keepStart = Math.max(0, nonSystemMessages.length - preserveLastN);
-    // Token cost of the currently-kept window.
-    let keptTokens = estimateMessagesTokens(nonSystemMessages.slice(keepStart));
-
-    while (keepStart > 0) {
-      const candidate = nonSystemMessages[keepStart - 1];
-      const candidateTokens = estimateMessagesTokens([candidate]);
-      const projected = systemTokens + summaryMaxTokens + keptTokens + candidateTokens;
-      if (projected > targetTokens) {
-        break;
-      }
-      keepStart -= 1;
-      keptTokens += candidateTokens;
+      };
+      CompactionComplete.publish({
+        originalMessages: result.originalMessages,
+        compactedMessages: result.compactedMessages,
+        estimatedTokensSaved: result.estimatedTokensSaved,
+        durationMs: Date.now() - compactionStartTime,
+        trigger: 'auto',
+        error: compactionErrorMessage,
+        timestamp: Date.now(),
+      });
+    } catch {
+      // Never let bus errors break compaction itself.
     }
+  };
 
-    messagesToSummarize = nonSystemMessages.slice(0, keepStart);
-    messagesToKeep = nonSystemMessages.slice(keepStart);
+  try {
+    // Separate system messages from others
+    const systemMessages = messages.filter((m) => m.role === 'system');
+    const nonSystemMessages = messages.filter((m) => m.role !== 'system');
 
-    // If the target buffer is so generous that there is nothing left to
-    // summarize, return early with the original messages — no work to do.
-    if (messagesToSummarize.length === 0) {
+    // If non-system messages are fewer than preserveLastN, return unchanged
+    if (nonSystemMessages.length <= preserveLastN) {
       return {
         messages: [...messages],
         result: {
@@ -429,78 +429,144 @@ export async function compactConversation(
         },
       };
     }
-  }
 
-  // Generate summary
-  let summary: string;
-  const maxChunkTokens = options?.maxChunkTokens ?? DEFAULT_MAX_CHUNK_TOKENS;
+    // Default split: keep last N, summarize the rest.
+    let messagesToSummarize = nonSystemMessages.slice(0, -preserveLastN);
+    let messagesToKeep = nonSystemMessages.slice(-preserveLastN);
 
-  if (globalLLMSummarizeFn) {
-    // Check if messages exceed chunk size limit
-    const messagesToSummarizeTokens = estimateMessagesTokens(messagesToSummarize);
+    // When the caller passes `maxContextTokens`, target ~80% of the trigger
+    // budget (context - reserved output) so the very next turn does not
+    // immediately re-cross the compaction threshold. We grow `toKeep` BACKWARDS
+    // from the tail past `preserveLastN` while the resulting kept set + the
+    // summary budget still fits under the target. Anything that does not fit is
+    // moved into `messagesToSummarize`.
+    const maxContextTokens = options?.maxContextTokens;
+    const reserveOutputTokens = options?.reserveOutputTokens ?? DEFAULT_RESERVE_OUTPUT_TOKENS;
+    if (typeof maxContextTokens === 'number' && maxContextTokens > 0) {
+      const triggerTokens = Math.max(0, maxContextTokens - reserveOutputTokens);
+      const targetTokens = Math.floor(triggerTokens * POST_COMPACT_TARGET_FRACTION);
 
-    // Build target size instruction if overflowTokens is provided
-    let targetInstruction: string | undefined;
-    if (options?.overflowTokens && options.overflowTokens > 0) {
-      const targetSummaryTokens = Math.max(
-        500,
-        messagesToSummarizeTokens - Math.ceil(options.overflowTokens * 1.5)
-      );
-      targetInstruction = `Keep your summary under approximately ${targetSummaryTokens} tokens.`;
+      // Always keep at least the last `preserveLastN` non-system messages
+      // (existing invariant). Grow the kept window leftwards as long as the
+      // running total (kept + system + summary budget) stays under target.
+      const systemTokens = estimateMessagesTokens(systemMessages);
+
+      let keepStart = Math.max(0, nonSystemMessages.length - preserveLastN);
+      // Token cost of the currently-kept window.
+      let keptTokens = estimateMessagesTokens(nonSystemMessages.slice(keepStart));
+
+      while (keepStart > 0) {
+        const candidate = nonSystemMessages[keepStart - 1];
+        const candidateTokens = estimateMessagesTokens([candidate]);
+        const projected = systemTokens + summaryMaxTokens + keptTokens + candidateTokens;
+        if (projected > targetTokens) {
+          break;
+        }
+        keepStart -= 1;
+        keptTokens += candidateTokens;
+      }
+
+      messagesToSummarize = nonSystemMessages.slice(0, keepStart);
+      messagesToKeep = nonSystemMessages.slice(keepStart);
+
+      // If the target buffer is so generous that there is nothing left to
+      // summarize, return early with the original messages — no work to do.
+      if (messagesToSummarize.length === 0) {
+        return {
+          messages: [...messages],
+          result: {
+            originalMessages: messages.length,
+            compactedMessages: messages.length,
+            estimatedTokensSaved: 0,
+            summary: '',
+          },
+        };
+      }
     }
 
-    if (messagesToSummarizeTokens > maxChunkTokens) {
-      // Oversized: use chunked summarization
-      const chunks = chunkMessages(messagesToSummarize, maxChunkTokens);
-      summary = await summarizeChunks(chunks, globalLLMSummarizeFn);
-      if (targetInstruction) {
-        // For chunked summaries, append the instruction as a refinement pass
-        const refinementPrompt = `${summary}\n\n${targetInstruction}`;
-        summary = await globalLLMSummarizeFn(refinementPrompt);
+    // Real work starts here (summary generation, potentially LLM calls).
+    // This is the point where the UI should show a "Compacting…" indicator.
+    emitCompactionStart();
+
+    // Generate summary
+    let summary: string;
+    const maxChunkTokens = options?.maxChunkTokens ?? DEFAULT_MAX_CHUNK_TOKENS;
+
+    if (globalLLMSummarizeFn) {
+      // Check if messages exceed chunk size limit
+      const messagesToSummarizeTokens = estimateMessagesTokens(messagesToSummarize);
+
+      // Build target size instruction if overflowTokens is provided
+      let targetInstruction: string | undefined;
+      if (options?.overflowTokens && options.overflowTokens > 0) {
+        const targetSummaryTokens = Math.max(
+          500,
+          messagesToSummarizeTokens - Math.ceil(options.overflowTokens * 1.5)
+        );
+        targetInstruction = `Keep your summary under approximately ${targetSummaryTokens} tokens.`;
+      }
+
+      if (messagesToSummarizeTokens > maxChunkTokens) {
+        // Oversized: use chunked summarization
+        const chunks = chunkMessages(messagesToSummarize, maxChunkTokens);
+        summary = await summarizeChunks(chunks, globalLLMSummarizeFn);
+        if (targetInstruction) {
+          // For chunked summaries, append the instruction as a refinement pass
+          const refinementPrompt = `${summary}\n\n${targetInstruction}`;
+          summary = await globalLLMSummarizeFn(refinementPrompt);
+        }
+      } else {
+        // Within limit: use existing single-call path
+        let prompt = createSummaryPrompt(messagesToSummarize);
+        if (targetInstruction) {
+          prompt += `\n\n${targetInstruction}`;
+        }
+        summary = await globalLLMSummarizeFn(prompt);
+      }
+
+      // Truncate if summary exceeds max tokens
+      const summaryTokens = estimateTokens(summary);
+      if (summaryTokens > summaryMaxTokens) {
+        // Truncate to approximately summaryMaxTokens
+        const maxChars = summaryMaxTokens * 4;
+        summary = summary.slice(0, maxChars) + '...';
       }
     } else {
-      // Within limit: use existing single-call path
-      let prompt = createSummaryPrompt(messagesToSummarize);
-      if (targetInstruction) {
-        prompt += `\n\n${targetInstruction}`;
-      }
-      summary = await globalLLMSummarizeFn(prompt);
+      // Fallback: create a basic summary without LLM
+      summary = createFallbackSummary(messagesToSummarize);
     }
 
-    // Truncate if summary exceeds max tokens
-    const summaryTokens = estimateTokens(summary);
-    if (summaryTokens > summaryMaxTokens) {
-      // Truncate to approximately summaryMaxTokens
-      const maxChars = summaryMaxTokens * 4;
-      summary = summary.slice(0, maxChars) + '...';
-    }
-  } else {
-    // Fallback: create a basic summary without LLM
-    summary = createFallbackSummary(messagesToSummarize);
-  }
+    // Create summary message
+    const summaryMessage: Message = {
+      role: 'system',
+      content: `[CONVERSATION SUMMARY]\n${summary}`,
+      timestamp: Date.now(),
+    };
 
-  // Create summary message
-  const summaryMessage: Message = {
-    role: 'system',
-    content: `[CONVERSATION SUMMARY]\n${summary}`,
-    timestamp: Date.now(),
-  };
+    // Build compacted messages: system messages + summary + last N messages
+    const compactedMessages: Message[] = [...systemMessages, summaryMessage, ...messagesToKeep];
 
-  // Build compacted messages: system messages + summary + last N messages
-  const compactedMessages: Message[] = [...systemMessages, summaryMessage, ...messagesToKeep];
+    const compactedTokens = estimateMessagesTokens(compactedMessages);
+    const tokensSaved = Math.max(0, originalTokens - compactedTokens);
 
-  const compactedTokens = estimateMessagesTokens(compactedMessages);
-  const tokensSaved = Math.max(0, originalTokens - compactedTokens);
-
-  return {
-    messages: compactedMessages,
-    result: {
+    const finalResult: CompactionResult = {
       originalMessages: messages.length,
       compactedMessages: compactedMessages.length,
       estimatedTokensSaved: tokensSaved,
       summary,
-    },
-  };
+    };
+    compactionResultForEvent = finalResult;
+
+    return {
+      messages: compactedMessages,
+      result: finalResult,
+    };
+  } catch (err) {
+    compactionErrorMessage = err instanceof Error ? err.message : String(err);
+    throw err;
+  } finally {
+    emitCompactionComplete();
+  }
 }
 
 /**
@@ -533,32 +599,73 @@ export async function partialCompact(
     return [...systemMessages, ...messagesToKeep];
   }
 
-  // Generate summary
-  let summary: string;
-  const fn = summarizeFn ?? globalLLMSummarizeFn;
-
-  if (fn) {
-    const maxChunkTokens = DEFAULT_MAX_CHUNK_TOKENS;
-    const tokensToSummarize = estimateMessagesTokens(messagesToSummarize);
-
-    if (tokensToSummarize > maxChunkTokens) {
-      const chunks = chunkMessages(messagesToSummarize, maxChunkTokens);
-      summary = await summarizeChunks(chunks, fn);
-    } else {
-      const prompt = createSummaryPrompt(messagesToSummarize);
-      summary = await fn(prompt);
-    }
-  } else {
-    summary = createFallbackSummary(messagesToSummarize);
+  // Announce that a (partial) compaction is underway so the UI can show
+  // feedback. Errors from the bus must never break compaction itself.
+  const startTime = Date.now();
+  let errorMessage: string | undefined;
+  let finalCount = messages.length;
+  try {
+    CompactionStarted.publish({
+      messageCount: messages.length,
+      estimatedTokens: estimateMessagesTokens(messagesToSummarize),
+      trigger: 'partial',
+      timestamp: startTime,
+    });
+  } catch {
+    // ignore bus errors
   }
 
-  const summaryMessage: Message = {
-    role: 'system',
-    content: `[CONVERSATION SUMMARY]\n${summary}`,
-    timestamp: Date.now(),
-  };
+  try {
+    // Generate summary
+    let summary: string;
+    const fn = summarizeFn ?? globalLLMSummarizeFn;
 
-  return [...systemMessages, summaryMessage, ...messagesToKeep];
+    if (fn) {
+      const maxChunkTokens = DEFAULT_MAX_CHUNK_TOKENS;
+      const tokensToSummarize = estimateMessagesTokens(messagesToSummarize);
+
+      if (tokensToSummarize > maxChunkTokens) {
+        const chunks = chunkMessages(messagesToSummarize, maxChunkTokens);
+        summary = await summarizeChunks(chunks, fn);
+      } else {
+        const prompt = createSummaryPrompt(messagesToSummarize);
+        summary = await fn(prompt);
+      }
+    } else {
+      summary = createFallbackSummary(messagesToSummarize);
+    }
+
+    const summaryMessage: Message = {
+      role: 'system',
+      content: `[CONVERSATION SUMMARY]\n${summary}`,
+      timestamp: Date.now(),
+    };
+
+    const result = [...systemMessages, summaryMessage, ...messagesToKeep];
+    finalCount = result.length;
+    return result;
+  } catch (err) {
+    errorMessage = err instanceof Error ? err.message : String(err);
+    throw err;
+  } finally {
+    try {
+      CompactionComplete.publish({
+        originalMessages: messages.length,
+        compactedMessages: finalCount,
+        estimatedTokensSaved: Math.max(
+          0,
+          estimateMessagesTokens(messages.slice(0, boundaryIndex)) -
+            estimateMessagesTokens(systemMessages)
+        ),
+        durationMs: Date.now() - startTime,
+        trigger: 'partial',
+        error: errorMessage,
+        timestamp: Date.now(),
+      });
+    } catch {
+      // ignore bus errors
+    }
+  }
 }
 
 /**

--- a/tests/cli/tui/StatusBar.compaction.test.tsx
+++ b/tests/cli/tui/StatusBar.compaction.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+
+import { CompactionStarted, CompactionComplete } from '../../../src/bus/index.js';
+import { StatusBar } from '../../../src/cli/tui/components/StatusBar.js';
+import { ThemeProvider } from '../../../src/cli/tui/context/ThemeContext.js';
+
+function Wrapper({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+describe('StatusBar compaction progress', () => {
+  const defaultProps = {
+    agent: 'code',
+    model: 'gpt-4o',
+    cost: { totalCost: 0, currency: 'USD' },
+    isStreaming: false,
+    leaderActive: false,
+  };
+
+  it('does not render the compaction segment by default', () => {
+    const { lastFrame } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+    expect(lastFrame() ?? '').not.toContain('Compacting');
+  });
+
+  it('renders the compaction segment when CompactionStarted fires', () => {
+    const { lastFrame, rerender } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+
+    CompactionStarted.publish({
+      messageCount: 20,
+      estimatedTokens: 30000,
+      trigger: 'auto',
+      timestamp: Date.now(),
+    });
+
+    rerender(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+
+    expect(lastFrame() ?? '').toContain('Compacting');
+  });
+
+  it('hides the compaction segment after CompactionComplete fires', () => {
+    const { lastFrame, rerender } = render(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+
+    CompactionStarted.publish({
+      messageCount: 20,
+      estimatedTokens: 30000,
+      trigger: 'auto',
+      timestamp: Date.now(),
+    });
+    rerender(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+    expect(lastFrame() ?? '').toContain('Compacting');
+
+    CompactionComplete.publish({
+      originalMessages: 20,
+      compactedMessages: 6,
+      estimatedTokensSaved: 25000,
+      durationMs: 1200,
+      trigger: 'auto',
+      timestamp: Date.now(),
+    });
+    rerender(
+      <Wrapper>
+        <StatusBar {...defaultProps} />
+      </Wrapper>
+    );
+    expect(lastFrame() ?? '').not.toContain('Compacting');
+  });
+});

--- a/tests/core/compaction-events.test.ts
+++ b/tests/core/compaction-events.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { CompactionStarted, CompactionComplete, clearAllHandlers } from '../../src/bus/index.js';
+import {
+  compactConversation,
+  partialCompact,
+  setLLMSummarizeFn,
+  type LLMSummarizeFn,
+} from '../../src/core/compaction.js';
+import type { Message } from '../../src/core/sessionManager.js';
+
+function msg(role: Message['role'], content: string): Message {
+  return { role, content, timestamp: Date.now() };
+}
+
+function longMsgs(n: number): Message[] {
+  const out: Message[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push(msg(i % 2 === 0 ? 'user' : 'assistant', `Message ${i} `.repeat(20)));
+  }
+  return out;
+}
+
+describe('Compaction lifecycle events', () => {
+  beforeEach(() => {
+    // Ensure a clean bus so we do not leak subscribers between tests
+    // (defineEvent-registered subscribers persist across imports).
+    clearAllHandlers();
+    setLLMSummarizeFn(null as unknown as LLMSummarizeFn);
+  });
+
+  afterEach(() => {
+    clearAllHandlers();
+  });
+
+  describe('compactConversation', () => {
+    it('emits CompactionStarted and CompactionComplete when real work happens', async () => {
+      const started = vi.fn();
+      const complete = vi.fn();
+      CompactionStarted.subscribe(started);
+      CompactionComplete.subscribe(complete);
+
+      const messages = longMsgs(8);
+      const { result } = await compactConversation(messages, { preserveLastN: 2 });
+
+      expect(started).toHaveBeenCalledTimes(1);
+      expect(complete).toHaveBeenCalledTimes(1);
+
+      const startPayload = started.mock.calls[0][0];
+      expect(startPayload.messageCount).toBe(8);
+      expect(typeof startPayload.estimatedTokens).toBe('number');
+      expect(startPayload.trigger).toBe('auto');
+      expect(typeof startPayload.timestamp).toBe('number');
+
+      const completePayload = complete.mock.calls[0][0];
+      expect(completePayload.originalMessages).toBe(8);
+      expect(completePayload.compactedMessages).toBe(result.compactedMessages);
+      expect(completePayload.trigger).toBe('auto');
+      expect(typeof completePayload.durationMs).toBe('number');
+      expect(completePayload.durationMs).toBeGreaterThanOrEqual(0);
+      expect(completePayload.error).toBeUndefined();
+    });
+
+    it('emits complete after started (ordering)', async () => {
+      const events: string[] = [];
+      CompactionStarted.subscribe(() => events.push('start'));
+      CompactionComplete.subscribe(() => events.push('complete'));
+
+      await compactConversation(longMsgs(8), { preserveLastN: 2 });
+
+      expect(events).toEqual(['start', 'complete']);
+    });
+
+    it('does NOT emit events when compaction returns early with no work', async () => {
+      const started = vi.fn();
+      const complete = vi.fn();
+      CompactionStarted.subscribe(started);
+      CompactionComplete.subscribe(complete);
+
+      // Fewer messages than preserveLastN => early return, no work
+      await compactConversation([msg('user', 'Hi'), msg('assistant', 'Hello')], {
+        preserveLastN: 4,
+      });
+
+      expect(started).not.toHaveBeenCalled();
+      expect(complete).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit events for empty message array', async () => {
+      const started = vi.fn();
+      const complete = vi.fn();
+      CompactionStarted.subscribe(started);
+      CompactionComplete.subscribe(complete);
+
+      await compactConversation([]);
+
+      expect(started).not.toHaveBeenCalled();
+      expect(complete).not.toHaveBeenCalled();
+    });
+
+    it('emits CompactionComplete with error when summarize fn throws', async () => {
+      const started = vi.fn();
+      const complete = vi.fn();
+      CompactionStarted.subscribe(started);
+      CompactionComplete.subscribe(complete);
+
+      const failingLLM = vi.fn().mockRejectedValue(new Error('boom'));
+      setLLMSummarizeFn(failingLLM as unknown as LLMSummarizeFn);
+
+      await expect(compactConversation(longMsgs(8), { preserveLastN: 2 })).rejects.toThrow('boom');
+
+      expect(started).toHaveBeenCalledTimes(1);
+      expect(complete).toHaveBeenCalledTimes(1);
+      expect(complete.mock.calls[0][0].error).toBe('boom');
+    });
+  });
+
+  describe('partialCompact', () => {
+    it('emits CompactionStarted and CompactionComplete with trigger=partial', async () => {
+      const started = vi.fn();
+      const complete = vi.fn();
+      CompactionStarted.subscribe(started);
+      CompactionComplete.subscribe(complete);
+
+      const messages = longMsgs(6);
+      await partialCompact(messages, 3);
+
+      expect(started).toHaveBeenCalledTimes(1);
+      expect(complete).toHaveBeenCalledTimes(1);
+      expect(started.mock.calls[0][0].trigger).toBe('partial');
+      expect(complete.mock.calls[0][0].trigger).toBe('partial');
+    });
+
+    it('does NOT emit events when boundary is out of range', async () => {
+      const started = vi.fn();
+      const complete = vi.fn();
+      CompactionStarted.subscribe(started);
+      CompactionComplete.subscribe(complete);
+
+      await partialCompact(longMsgs(4), 0);
+      await partialCompact(longMsgs(4), 999);
+
+      expect(started).not.toHaveBeenCalled();
+      expect(complete).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #1007

## What

Adds visual feedback to the TUI `StatusBar` while context compaction is running so users no longer see a multi-second unexplained pause.

## How

- New typed events `CompactionStarted` and `CompactionComplete` in `src/bus/index.ts` (Zod-validated payloads: message count, token estimate, duration, trigger, optional error).
- `src/core/compaction.ts` — both `compactConversation` and `partialCompact` publish start on the entry to real work and complete via a `try/finally` guard, so the UI never gets stuck on errors and bus errors never break compaction itself. Events are NOT emitted for no-op early returns (empty array, fewer messages than preserveLastN, or when the 80% target already fits).
- `src/cli/tui/components/StatusBar.tsx` — subscribes to the events, holds an `isCompacting` flag, and renders a new spinner segment with `Compacting context...` between the context info and streaming/agent segments (matches the streaming spinner pattern at line 164-171).

## Test evidence

- New `tests/core/compaction-events.test.ts`: 7 cases covering emission ordering, no-op paths (empty array, preserved messages), error propagation via `finally`, and partial-compact trigger tagging.
- New `tests/cli/tui/StatusBar.compaction.test.tsx`: 3 cases — segment absent by default, appears on `CompactionStarted`, disappears on `CompactionComplete`.
- Full gate green locally:
  - `npm run lint` — 0 errors (warnings only, all pre-existing)
  - `npm run typecheck` — clean
  - `npm run format:check` — clean
  - `npm test` — 2956 passed, 2 skipped, 219 files
  - `npm run build` — clean

## Notes

- Only the `src/core/compaction.ts` implementation was touched (the one referenced in the issue). The alt `src/compaction/index.ts` module wasn't part of the code path referenced in `src/core/sessionManager.ts:351` and was left untouched.

[alexi-bot]