### PR TITLE
fix(core): strip UTF-8 BOM from frontmatter files for Windows compatibility

### DIFF
--- a/src/agent/customAgentLoader.ts
+++ b/src/agent/customAgentLoader.ts
@@ -28,6 +28,7 @@ import fsPromises from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import matter from 'gray-matter';
+import { readUtf8FileSyncStripBom } from '../utils/frontmatter.js';
 import { AgentSchema, type AgentConfig } from './index.js';
 
 export type AgentSource = 'built-in' | 'user-global' | 'project-local' | 'config';
@@ -96,7 +97,9 @@ export async function loadAgentFromFile(
   source: AgentSource
 ): Promise<CustomAgentConfig | null> {
   try {
-    const content = fs.readFileSync(filePath, 'utf-8');
+    // Strip UTF-8 BOM (Windows Notepad "UTF-8 with BOM") so gray-matter
+    // sees `---` at byte offset 0. See src/utils/frontmatter.ts.
+    const content = readUtf8FileSyncStripBom(filePath);
     const { data, content: promptContent } = matter(content);
 
     const id = data.slug || data.id || path.basename(filePath, path.extname(filePath));

--- a/src/agent/system.ts
+++ b/src/agent/system.ts
@@ -25,6 +25,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
+import { stripUtf8Bom } from '../utils/frontmatter.js';
 import {
   getEnabledPluginRules,
   resolvePluginRulesForPrompt,
@@ -149,10 +150,16 @@ function buildEnvBlock(info: EnvInfo): string {
 // Instruction file loading (AGENTS.md, ALEXI.md, .alexi/rules/)
 // ---------------------------------------------------------------------------
 
-/** Load a single text file, returning empty string on failure. */
+/**
+ * Load a single text file, returning empty string on failure.
+ *
+ * Strips a leading UTF-8 BOM (U+FEFF) so files saved with Windows Notepad's
+ * default "UTF-8 with BOM" encoding do not inject an invisible marker into
+ * the assembled system prompt.
+ */
 function loadTextFile(filePath: string): string {
   try {
-    return fs.readFileSync(filePath, 'utf-8').trim();
+    return stripUtf8Bom(fs.readFileSync(filePath, 'utf-8')).trim();
   } catch {
     return '';
   }

--- a/src/command/index.ts
+++ b/src/command/index.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import { execSync } from 'child_process';
 import os from 'os';
 import matter from 'gray-matter';
+import { readUtf8FileSyncStripBom } from '../utils/frontmatter.js';
 
 // ============ Schema Definitions ============
 
@@ -312,7 +313,9 @@ function applyDefaults(command: Command, args: string[]): string[] {
  */
 export function loadCommandFromFile(filePath: string): Command | null {
   try {
-    const content = fs.readFileSync(filePath, 'utf-8');
+    // Strip UTF-8 BOM (Windows Notepad "UTF-8 with BOM") so gray-matter
+    // sees `---` at byte offset 0. See src/utils/frontmatter.ts.
+    const content = readUtf8FileSyncStripBom(filePath);
     const { data, content: templateContent } = matter(content);
 
     // Parse and validate arguments if present

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
 import { getGlobalPaths } from '../utils/global.js';
+import { readUtf8FileSyncStripBom } from '../utils/frontmatter.js';
 import { defineEvent } from '../bus/index.js';
 
 // ============ Events ============
@@ -109,7 +110,10 @@ export function defineSkill(definition: SkillDefinition): Skill {
  */
 export function loadSkillFromFile(filePath: string): Skill | null {
   try {
-    const content = fs.readFileSync(filePath, 'utf-8');
+    // Strip UTF-8 BOM (Windows Notepad "UTF-8 with BOM") so gray-matter
+    // sees `---` at byte offset 0. Otherwise the frontmatter is silently
+    // ignored — see src/utils/frontmatter.ts.
+    const content = readUtf8FileSyncStripBom(filePath);
     const { data, content: promptContent } = matter(content);
 
     const skill: Skill = {

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,0 +1,62 @@
+/**
+ * Frontmatter loading helpers with UTF-8 BOM tolerance.
+ *
+ * Windows Notepad saves files as "UTF-8 with BOM" by default, which prepends
+ * a byte-order mark (U+FEFF) to the file. YAML frontmatter parsers such as
+ * `gray-matter` and simple regex-style parsers require the opening `---`
+ * delimiter to appear at byte offset 0 — with a BOM in the way, they silently
+ * treat the file as having no frontmatter, and the loader ends up with an
+ * empty metadata object (no error, the skill/command/agent just doesn't
+ * load correctly).
+ *
+ * These helpers strip a leading BOM before the content is handed to
+ * `gray-matter` or any other frontmatter parser, so files saved with
+ * Windows Notepad's default encoding are handled the same as LF-only files.
+ *
+ * See: https://github.com/cline/cline/pull/12277 for the original report.
+ */
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+
+/** UTF-8 BOM code point (U+FEFF) as a JavaScript string. */
+const BOM = '\uFEFF';
+
+/**
+ * Remove a leading UTF-8 BOM (U+FEFF) from `content` if present.
+ * No-op when the string does not start with a BOM.
+ *
+ * Note: only the FIRST character is inspected. A BOM in the middle of a file
+ * is left untouched — that would be a genuine data character, not an encoding
+ * marker.
+ */
+export function stripUtf8Bom(content: string): string {
+  if (content.length > 0 && content.charCodeAt(0) === 0xfeff) {
+    return content.slice(1);
+  }
+  return content;
+}
+
+/**
+ * Read a UTF-8 encoded text file and strip a leading BOM if present.
+ *
+ * Use this in place of `fs.promises.readFile(path, 'utf-8')` when the file is
+ * about to be handed to a frontmatter parser (or any other parser that
+ * requires known content at byte offset 0).
+ */
+export async function readUtf8FileStripBom(path: string): Promise<string> {
+  const content = await fsPromises.readFile(path, 'utf-8');
+  return stripUtf8Bom(content);
+}
+
+/**
+ * Synchronous variant of {@link readUtf8FileStripBom}. Prefer the async
+ * version in new code; this exists to plug into legacy call sites that
+ * already use `fs.readFileSync`.
+ */
+export function readUtf8FileSyncStripBom(path: string): string {
+  const content = fs.readFileSync(path, 'utf-8');
+  return stripUtf8Bom(content);
+}
+
+// Internal export for tests.
+export const _BOM = BOM;

--- a/tests/skill/bom.test.ts
+++ b/tests/skill/bom.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { loadSkillFromFile, loadSkillsFromDirectory } from '../../src/skill/index.js';
+
+const BOM_BYTES = Buffer.from([0xef, 0xbb, 0xbf]);
+
+/**
+ * Regression coverage for issue #1025: a SKILL.md saved with a UTF-8 BOM
+ * (Windows Notepad's default "UTF-8 with BOM" encoding) must be loaded
+ * correctly. Without the BOM strip, gray-matter silently returns empty
+ * frontmatter data because the `---` marker no longer sits at byte 0.
+ */
+describe('skill loader: UTF-8 BOM tolerance', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-skill-bom-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('parses frontmatter from a BOM-prefixed SKILL.md', () => {
+    const filePath = path.join(tempDir, 'bom-skill.md');
+    const body = `---
+id: bom-skill
+name: BOM Skill
+description: A skill saved by Windows Notepad with UTF-8 BOM
+category: encoding
+tags:
+  - regression
+  - windows
+---
+
+You are a skill defined in a BOM-prefixed file.
+`;
+    fs.writeFileSync(filePath, Buffer.concat([BOM_BYTES, Buffer.from(body, 'utf-8')]));
+
+    const skill = loadSkillFromFile(filePath);
+
+    expect(skill).not.toBeNull();
+    // Without the BOM strip these would fall back to filename/empty defaults.
+    expect(skill?.id).toBe('bom-skill');
+    expect(skill?.name).toBe('BOM Skill');
+    expect(skill?.description).toBe('A skill saved by Windows Notepad with UTF-8 BOM');
+    expect(skill?.category).toBe('encoding');
+    expect(skill?.tags).toEqual(['regression', 'windows']);
+    // Prompt content should be preserved verbatim (with the trailing newline
+    // trimmed by the loader).
+    expect(skill?.prompt).toBe('You are a skill defined in a BOM-prefixed file.');
+  });
+
+  it('loadSkillsFromDirectory picks up BOM-prefixed SKILL.md files', () => {
+    const filePath = path.join(tempDir, 'nested-bom.md');
+    const body = `---
+id: nested-bom-skill
+name: Nested BOM Skill
+description: Loaded through the directory loader
+---
+
+Body.
+`;
+    fs.writeFileSync(filePath, Buffer.concat([BOM_BYTES, Buffer.from(body, 'utf-8')]));
+
+    const skills = loadSkillsFromDirectory(tempDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].id).toBe('nested-bom-skill');
+    expect(skills[0].name).toBe('Nested BOM Skill');
+  });
+
+  it('non-BOM SKILL.md still loads (no regression)', () => {
+    const filePath = path.join(tempDir, 'plain.md');
+    const body = `---
+id: plain-skill
+name: Plain Skill
+description: No BOM
+---
+
+Body.
+`;
+    fs.writeFileSync(filePath, body, 'utf-8');
+
+    const skill = loadSkillFromFile(filePath);
+    expect(skill).not.toBeNull();
+    expect(skill?.id).toBe('plain-skill');
+    expect(skill?.name).toBe('Plain Skill');
+  });
+});

--- a/tests/utils/frontmatter.test.ts
+++ b/tests/utils/frontmatter.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import {
+  stripUtf8Bom,
+  readUtf8FileStripBom,
+  readUtf8FileSyncStripBom,
+} from '../../src/utils/frontmatter.js';
+
+const BOM = '\uFEFF';
+
+describe('stripUtf8Bom', () => {
+  it('removes a leading UTF-8 BOM', () => {
+    const input = `${BOM}hello`;
+    expect(stripUtf8Bom(input)).toBe('hello');
+  });
+
+  it('is a no-op when no BOM is present', () => {
+    expect(stripUtf8Bom('hello')).toBe('hello');
+  });
+
+  it('is a no-op on empty strings', () => {
+    expect(stripUtf8Bom('')).toBe('');
+  });
+
+  it('leaves BOM characters that appear mid-string alone', () => {
+    // A BOM in the middle of a file is genuine data, not an encoding marker.
+    const input = `hello${BOM}world`;
+    expect(stripUtf8Bom(input)).toBe(`hello${BOM}world`);
+  });
+
+  it('only strips a single leading BOM (not repeated BOMs)', () => {
+    const input = `${BOM}${BOM}hello`;
+    expect(stripUtf8Bom(input)).toBe(`${BOM}hello`);
+  });
+
+  it('preserves the content that follows the BOM verbatim', () => {
+    const body = '---\nname: test\n---\nBody line 1\nBody line 2\n';
+    expect(stripUtf8Bom(`${BOM}${body}`)).toBe(body);
+  });
+});
+
+describe('readUtf8FileStripBom / readUtf8FileSyncStripBom', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'alexi-bom-'));
+  });
+
+  afterEach(async () => {
+    await fsPromises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('async: reads a BOM-prefixed file and strips the BOM', async () => {
+    const filePath = path.join(tempDir, 'bom.md');
+    const body = '---\nname: test\n---\nbody\n';
+    // Write with the BOM as bytes (UTF-8: EF BB BF).
+    await fsPromises.writeFile(
+      filePath,
+      Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(body, 'utf-8')])
+    );
+
+    const content = await readUtf8FileStripBom(filePath);
+    expect(content).toBe(body);
+    expect(content.charCodeAt(0)).not.toBe(0xfeff);
+    expect(content.startsWith('---')).toBe(true);
+  });
+
+  it('async: reads a non-BOM file unchanged', async () => {
+    const filePath = path.join(tempDir, 'plain.md');
+    const body = '---\nname: test\n---\nbody\n';
+    await fsPromises.writeFile(filePath, body, 'utf-8');
+
+    const content = await readUtf8FileStripBom(filePath);
+    expect(content).toBe(body);
+  });
+
+  it('sync: reads a BOM-prefixed file and strips the BOM', () => {
+    const filePath = path.join(tempDir, 'bom-sync.md');
+    const body = '---\nname: test\n---\nbody\n';
+    fs.writeFileSync(
+      filePath,
+      Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(body, 'utf-8')])
+    );
+
+    const content = readUtf8FileSyncStripBom(filePath);
+    expect(content).toBe(body);
+    expect(content.charCodeAt(0)).not.toBe(0xfeff);
+  });
+
+  it('sync: reads a non-BOM file unchanged', () => {
+    const filePath = path.join(tempDir, 'plain-sync.md');
+    const body = 'hello world';
+    fs.writeFileSync(filePath, body, 'utf-8');
+
+    expect(readUtf8FileSyncStripBom(filePath)).toBe(body);
+  });
+});


### PR DESCRIPTION
Closes #1025

## Summary

Windows Notepad's default 'UTF-8 with BOM' encoding prepends a U+FEFF byte-order mark to text files. gray-matter and regex-style frontmatter parsers require the opening `---` at byte offset 0, so any SKILL.md / command / agent markdown saved by Notepad on Windows had its frontmatter silently ignored — no error, the loader just fell back to filename-derived defaults and the skill/command/agent effectively failed to configure.

## Changes

- **New helper**: `src/utils/frontmatter.ts` exports:
  - `stripUtf8Bom(content)` — drop a single leading U+FEFF if present.
  - `readUtf8FileStripBom(path)` — async read + strip.
  - `readUtf8FileSyncStripBom(path)` — sync read + strip (used by legacy call sites).
- **Wired up** on every existing gray-matter caller:
  - `src/skill/index.ts` — `loadSkillFromFile`.
  - `src/command/index.ts` — `loadCommandFromFile`.
  - `src/agent/customAgentLoader.ts` — `loadAgentFromFile`.
- **Wired up** on the AGENTS.md / ALEXI.md / `.alexi/rules/*.md` text loader (`src/agent/system.ts::loadTextFile`) so a BOM at the top of a rule file does not inject an invisible character into the assembled system prompt.
- **Tests**:
  - `tests/utils/frontmatter.test.ts` — helper behaviour (empty, no BOM, single BOM, mid-string BOM left alone, repeated BOM only strips first, async + sync file read variants).
  - `tests/skill/bom.test.ts` — regression: SKILL.md written with the raw UTF-8 BOM bytes (EF BB BF) is loaded with correct id/name/description/tags via both `loadSkillFromFile` and `loadSkillsFromDirectory`; non-BOM files remain unaffected.

## Verification

```
npm run lint         # 0 errors
npm run typecheck    # clean
npm run format:check # clean
npm test             # 2997 passed / 2 skipped (13 new tests)
npm run build        # ok
```

Reference: cline/cline#12277 (upstream fix that inspired this change).