### PR TITLE
feat(config): custom file extensions for indexing

### DIFF
--- a/src/config/userConfig.ts
+++ b/src/config/userConfig.ts
@@ -212,6 +212,89 @@ export function clearConfigDefaultAgent(): void {
   deleteConfigValue('agent');
 }
 
+// ============ Indexing (custom file extensions) ============
+
+/**
+ * Regex describing a valid additional-extension value: must begin with `.`
+ * followed by one or more alphanumerics / `-` / `_`. Rejects `proto`,
+ * `.`, `..foo`, `.foo/bar`, whitespace, etc.
+ */
+const EXTENSION_PATTERN = /^\.[A-Za-z0-9_-]+$/;
+
+/**
+ * Validate a single additional-extension entry.
+ * Returns the trimmed extension when valid, or throws when invalid.
+ */
+export function validateAdditionalExtension(ext: unknown): string {
+  if (typeof ext !== 'string') {
+    throw new Error(`indexing.additionalExtensions entries must be strings (got ${typeof ext})`);
+  }
+  const trimmed = ext.trim();
+  if (!EXTENSION_PATTERN.test(trimmed)) {
+    throw new Error(
+      `indexing.additionalExtensions entry '${ext}' is invalid: must start with '.' and contain only [A-Za-z0-9_-] (e.g. '.proto')`
+    );
+  }
+  return trimmed.toLowerCase();
+}
+
+/**
+ * Load the configured additional file extensions for indexing.
+ *
+ * Returns an array of normalized extensions (each starting with `.` and
+ * lower-cased). Invalid entries are silently dropped so that a corrupt
+ * config never crashes tool execution — callers wanting strict validation
+ * should use {@link setConfigAdditionalExtensions} instead.
+ */
+export function getConfigAdditionalExtensions(): string[] {
+  const config = loadFullConfig();
+  const indexing = config.indexing;
+  if (!indexing || typeof indexing !== 'object' || Array.isArray(indexing)) {
+    return [];
+  }
+  const raw = (indexing as Record<string, unknown>).additionalExtensions;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'string') {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (!EXTENSION_PATTERN.test(trimmed)) {
+      continue;
+    }
+    const normalized = trimmed.toLowerCase();
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
+}
+
+/**
+ * Persist the list of additional file extensions for indexing.
+ * Validates every entry; throws on the first invalid one so callers
+ * (e.g. a `config set` CLI command) can surface the error to the user.
+ */
+export function setConfigAdditionalExtensions(extensions: string[]): void {
+  if (!Array.isArray(extensions)) {
+    throw new Error('indexing.additionalExtensions must be an array of strings');
+  }
+  const normalized = extensions.map(validateAdditionalExtension);
+  const config = loadFullConfig();
+  const existingIndexing =
+    config.indexing && typeof config.indexing === 'object' && !Array.isArray(config.indexing)
+      ? (config.indexing as Record<string, unknown>)
+      : {};
+  config.indexing = { ...existingIndexing, additionalExtensions: normalized };
+  saveFullConfig(config);
+}
+
 // ============ Batch update with options ============
 
 export interface UpdateGlobalOptions {

--- a/src/tool/tools/codesearch.ts
+++ b/src/tool/tools/codesearch.ts
@@ -12,6 +12,8 @@ import { z } from 'zod';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { defineTool, truncateOutput, type ToolResult } from '../index.js';
+import { getConfigAdditionalExtensions } from '../../config/userConfig.js';
+import { mergeExtensionSet, mergeIncludePattern } from './includePattern.js';
 
 // Hard cap on matches/symbols returned per query, to prevent context-window
 // blow-ups on broad queries over large repos. Aligns with grep.ts (1000) but
@@ -162,13 +164,17 @@ const CODE_EXTENSIONS = new Set([
   '.php',
 ]);
 
-function isCodeFile(filename: string): boolean {
+function isCodeFile(filename: string, extensions: ReadonlySet<string>): boolean {
   const ext = path.extname(filename).toLowerCase();
-  return CODE_EXTENSIONS.has(ext);
+  return extensions.has(ext);
 }
 
-function matchesInclude(filename: string, include?: string): boolean {
-  if (!include) return isCodeFile(filename);
+function matchesInclude(
+  filename: string,
+  include: string | undefined,
+  extensions: ReadonlySet<string>
+): boolean {
+  if (!include) return isCodeFile(filename, extensions);
 
   // Handle {a,b} alternatives
   const patterns = include.replace(/\{([^}]+)\}/g, (_, group) => {
@@ -189,7 +195,12 @@ function matchesInclude(filename: string, include?: string): boolean {
   return regex.test(filename);
 }
 
-async function findCodeFiles(dir: string, include?: string, maxFiles = 5000): Promise<string[]> {
+async function findCodeFiles(
+  dir: string,
+  include: string | undefined,
+  extensions: ReadonlySet<string>,
+  maxFiles = 5000
+): Promise<string[]> {
   const files: string[] = [];
 
   async function walk(currentDir: string): Promise<void> {
@@ -208,7 +219,7 @@ async function findCodeFiles(dir: string, include?: string, maxFiles = 5000): Pr
             continue;
           }
           await walk(fullPath);
-        } else if (matchesInclude(entry.name, include)) {
+        } else if (matchesInclude(entry.name, include, extensions)) {
           files.push(fullPath);
         }
       }
@@ -367,7 +378,16 @@ When independent reads, searches, or edits are also needed, emit those tool call
       : context.workdir;
 
     try {
-      const files = await findCodeFiles(searchPath, include);
+      // Merge configured `indexing.additionalExtensions` into both the
+      // built-in CODE_EXTENSIONS whitelist and the caller's include
+      // filter. Additional extensions are ADDITIVE: they extend the
+      // pool of files considered "code" but never narrow an existing
+      // include.
+      const additionalExtensions = getConfigAdditionalExtensions();
+      const effectiveExtensions = mergeExtensionSet(CODE_EXTENSIONS, additionalExtensions);
+      const effectiveInclude = mergeIncludePattern(include, additionalExtensions);
+
+      const files = await findCodeFiles(searchPath, effectiveInclude, effectiveExtensions);
       const allMatches: CodeMatch[] = [];
       const allSymbols: CodeSymbol[] = [];
 

--- a/src/tool/tools/glob.ts
+++ b/src/tool/tools/glob.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { defineTool, type ToolResult } from '../index.js';
 import { getReferenceService } from '../../reference/reference.js';
+import { getConfigAdditionalExtensions } from '../../config/userConfig.js';
 
 const GlobParamsSchema = z.object({
   pattern: z.string().describe("Glob pattern to match files (e.g., '**/*.ts')"),
@@ -16,6 +17,61 @@ const GlobParamsSchema = z.object({
 interface GlobResult {
   matches: string[];
   count: number;
+}
+
+/**
+ * Extend a glob pattern's last segment to include additional file
+ * extensions from the user config. Only the final path segment is
+ * touched so directory portions (`src/**`) are preserved.
+ *
+ * Recognized last-segment shapes (matching the grep include merger):
+ *   - `*.ts`         -> `*.{ts,proto}`
+ *   - `*.{ts,tsx}`   -> `*.{ts,tsx,proto}`
+ *   - anything else  -> returned unchanged (no safe way to inject
+ *                       alternates without changing semantics).
+ *
+ * When `additionalExtensions` is empty, the pattern is returned as-is.
+ */
+export function extendGlobPattern(pattern: string, additionalExtensions: string[]): string {
+  if (additionalExtensions.length === 0) {
+    return pattern;
+  }
+  const idx = pattern.lastIndexOf('/');
+  const prefix = idx === -1 ? '' : pattern.slice(0, idx + 1);
+  const last = idx === -1 ? pattern : pattern.slice(idx + 1);
+  const bare = additionalExtensions.map((e) => (e.startsWith('.') ? e.slice(1) : e).toLowerCase());
+
+  const singleExt = /^\*\.([A-Za-z0-9_-]+)$/.exec(last);
+  if (singleExt) {
+    const merged = uniqueLower([singleExt[1], ...bare]);
+    return `${prefix}${merged.length === 1 ? `*.${merged[0]}` : `*.{${merged.join(',')}}`}`;
+  }
+
+  const groupExt = /^\*\.\{([^{}]+)\}$/.exec(last);
+  if (groupExt) {
+    const parts = groupExt[1]
+      .split(',')
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+    const merged = uniqueLower([...parts, ...bare]);
+    return `${prefix}*.{${merged.join(',')}}`;
+  }
+
+  return pattern;
+}
+
+function uniqueLower(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    const lower = v.toLowerCase();
+    if (seen.has(lower)) {
+      continue;
+    }
+    seen.add(lower);
+    out.push(lower);
+  }
+  return out;
 }
 
 /**
@@ -90,11 +146,20 @@ async function globMatch(
   function matchPart(name: string, pattern: string): boolean {
     if (pattern === '*') return true;
 
-    // Convert glob pattern to regex
+    // Expand `{a,b,c}` alternates first so that patterns like
+    // `*.{ts,proto}` (used by indexing.additionalExtensions) match. We
+    // capture the group with a non-greedy inner class before escaping.
+    const expanded = pattern.replace(/\{([^{}]+)\}/g, (_, group: string) => {
+      const opts = group.split(',').map((s) => s.trim());
+      return `(${opts.join('|')})`;
+    });
+
+    // Convert glob pattern to regex. Escape regex specials, then
+    // restore the `(a|b)` groups we produced above.
     const regex = new RegExp(
       '^' +
-        pattern
-          .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+        expanded
+          .replace(/[.+^${}[\]\\]/g, '\\$&')
           .replace(/\*/g, '.*')
           .replace(/\?/g, '.') +
         '$'
@@ -163,7 +228,16 @@ When independent reads, searches, or edits are also needed, emit those tool call
         };
       }
 
-      let matches = await globMatch(searchPath, params.pattern, context.signal);
+      // Extend the caller's pattern with any additional extensions
+      // configured via `indexing.additionalExtensions`. Only the last
+      // segment is touched (e.g. `**/*.ts` -> `**/*.{ts,proto}`), so
+      // directory scoping is preserved. Patterns whose last segment is
+      // not a recognized extension shape (e.g. exact filenames) pass
+      // through unchanged.
+      const additionalExtensions = getConfigAdditionalExtensions();
+      const effectivePattern = extendGlobPattern(params.pattern, additionalExtensions);
+
+      let matches = await globMatch(searchPath, effectivePattern, context.signal);
 
       // Sort by modification time (most recent first)
       const withStats = await Promise.all(

--- a/src/tool/tools/grep.ts
+++ b/src/tool/tools/grep.ts
@@ -17,6 +17,8 @@ import { defineTool, type ToolResult } from '../index.js';
 import { getReferenceService } from '../../reference/reference.js';
 import { logger } from '../../utils/logger.js';
 import { attachAgentsMdRemindersForPaths } from '../../agent/agentsMdReminders.js';
+import { getConfigAdditionalExtensions } from '../../config/userConfig.js';
+import { mergeIncludePattern } from './includePattern.js';
 
 const GrepParamsSchema = z.object({
   pattern: z.string().describe('Regex pattern to search for'),
@@ -567,13 +569,20 @@ When independent reads, searches, or edits are also needed, emit those tool call
         throw err;
       }
 
+      // Merge the caller's include filter with any additional extensions
+      // configured via `indexing.additionalExtensions` in the user config.
+      // When no include was passed, the pattern remains undefined and the
+      // tool retains its historical "search all files" behavior.
+      const additionalExtensions = getConfigAdditionalExtensions();
+      const effectiveInclude = mergeIncludePattern(params.include, additionalExtensions);
+
       // Fast path: ripgrep when available.
       if (await detectRg()) {
         try {
           const value = await executeWithRg(
             params.pattern,
             searchPath,
-            params.include,
+            effectiveInclude,
             context.signal
           );
           // Apply the same 1000-match cap as the JS path.
@@ -617,7 +626,7 @@ When independent reads, searches, or edits are also needed, emit those tool call
 
       // JS fallback path
       const regex = validatedRegex;
-      const files = await findFiles(searchPath, params.include, 10000, context.signal);
+      const files = await findFiles(searchPath, effectiveInclude, 10000, context.signal);
       const matches: GrepMatch[] = [];
 
       for (const file of files) {

--- a/src/tool/tools/includePattern.ts
+++ b/src/tool/tools/includePattern.ts
@@ -1,0 +1,136 @@
+/**
+ * Include-pattern helpers shared by the grep, glob, and codesearch tools.
+ *
+ * These utilities implement the `indexing.additionalExtensions` config
+ * knob: user-provided include patterns are extended so that any file
+ * ending in one of the configured extensions ALSO matches, without the
+ * caller having to write `--include '*.{ts,proto,graphql}'` every time.
+ *
+ * Extensions are supplied in dotted form (`.proto`, `.graphql`) as
+ * validated by `validateAdditionalExtension` in `src/config/userConfig.ts`.
+ */
+
+/**
+ * Extract the bare extension name (no leading `.`) for each entry.
+ * Accepts entries with or without the leading dot; empty / invalid
+ * entries are dropped.
+ */
+function normalize(extensions: readonly string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of extensions) {
+    if (typeof raw !== 'string') {
+      continue;
+    }
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const bare = (trimmed.startsWith('.') ? trimmed.slice(1) : trimmed).toLowerCase();
+    if (bare.length === 0) {
+      continue;
+    }
+    if (seen.has(bare)) {
+      continue;
+    }
+    seen.add(bare);
+    out.push(bare);
+  }
+  return out;
+}
+
+/**
+ * Merge a caller-provided include pattern with the configured
+ * `additionalExtensions`.
+ *
+ * Behavior:
+ * - When `extensions` is empty, the include pattern is returned as-is.
+ * - When the user did NOT pass an include pattern (undefined) and
+ *   extensions is empty, undefined is returned (the tool searches all
+ *   files as before).
+ * - When the user did NOT pass an include pattern but extensions is
+ *   non-empty, the include pattern is left undefined — additional
+ *   extensions are ADDITIVE, they do not restrict a broad search. This
+ *   preserves the historical grep/glob "search everything" behavior for
+ *   projects that don't set an include.
+ * - When the user passed an include pattern, additional extensions are
+ *   UNIONED into the pattern. Recognized shapes:
+ *     - `*.ts`             -> `*.{ts,proto,graphql}`
+ *     - `*.{ts,tsx}`       -> `*.{ts,tsx,proto,graphql}`
+ *     - anything else      -> `{<original>,*.proto,*.graphql}`
+ *
+ * The returned pattern is intended to be handed to both `rg --glob` and
+ * the in-process include matcher; both understand `{a,b,c}` alternates.
+ */
+export function mergeIncludePattern(
+  include: string | undefined,
+  extensions: readonly string[]
+): string | undefined {
+  const bare = normalize(extensions);
+  if (bare.length === 0) {
+    return include;
+  }
+
+  if (include === undefined || include.trim().length === 0) {
+    // Additive semantics: do not narrow a broad search.
+    return include;
+  }
+
+  const trimmed = include.trim();
+
+  // Shape: *.<ext>
+  const singleExt = /^\*\.([A-Za-z0-9_-]+)$/.exec(trimmed);
+  if (singleExt) {
+    const merged = uniqueLower([singleExt[1], ...bare]);
+    return merged.length === 1 ? `*.${merged[0]}` : `*.{${merged.join(',')}}`;
+  }
+
+  // Shape: *.{a,b,c}
+  const groupExt = /^\*\.\{([^{}]+)\}$/.exec(trimmed);
+  if (groupExt) {
+    const parts = groupExt[1]
+      .split(',')
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+    const merged = uniqueLower([...parts, ...bare]);
+    return `*.{${merged.join(',')}}`;
+  }
+
+  // Fallback: wrap original pattern and each extension in an alternation.
+  const additions = bare.map((e) => `*.${e}`);
+  return `{${[trimmed, ...additions].join(',')}}`;
+}
+
+function uniqueLower(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    const lower = v.toLowerCase();
+    if (seen.has(lower)) {
+      continue;
+    }
+    seen.add(lower);
+    out.push(lower);
+  }
+  return out;
+}
+
+/**
+ * Merge a set of additional extensions into a base set of well-known
+ * code extensions. Used by the codesearch tool, which maintains a
+ * hard-coded `CODE_EXTENSIONS` whitelist. All returned extensions
+ * include the leading dot and are lower-cased.
+ */
+export function mergeExtensionSet(
+  base: ReadonlySet<string>,
+  extensions: readonly string[]
+): Set<string> {
+  const out = new Set<string>();
+  for (const b of base) {
+    out.add(b.toLowerCase());
+  }
+  for (const bare of normalize(extensions)) {
+    out.add(`.${bare}`);
+  }
+  return out;
+}

--- a/tests/config/userConfig.test.ts
+++ b/tests/config/userConfig.test.ts
@@ -17,6 +17,9 @@ import {
   getConfigDefaultAgent,
   setConfigDefaultAgent,
   clearConfigDefaultAgent,
+  getConfigAdditionalExtensions,
+  setConfigAdditionalExtensions,
+  validateAdditionalExtension,
 } from '../../src/config/userConfig.js';
 
 describe('userConfig', () => {
@@ -232,6 +235,118 @@ describe('userConfig', () => {
       expect(() => clearConfigDefaultAgent()).not.toThrow();
       expect(getConfigDefaultAgent()).toBeUndefined();
       expect(loadFullConfig().defaultModel).toBe('gpt-4.1');
+    });
+  });
+
+  describe('validateAdditionalExtension', () => {
+    it('should accept a well-formed extension with leading dot', () => {
+      expect(validateAdditionalExtension('.proto')).toBe('.proto');
+      expect(validateAdditionalExtension('.graphql')).toBe('.graphql');
+      expect(validateAdditionalExtension('.tf')).toBe('.tf');
+      expect(validateAdditionalExtension('.mdx')).toBe('.mdx');
+    });
+
+    it('should trim whitespace and lower-case the extension', () => {
+      expect(validateAdditionalExtension('  .PROTO  ')).toBe('.proto');
+    });
+
+    it('should reject extensions without a leading dot', () => {
+      expect(() => validateAdditionalExtension('proto')).toThrow(/must start with/);
+      expect(() => validateAdditionalExtension('graphql')).toThrow(/must start with/);
+    });
+
+    it('should reject empty and dot-only values', () => {
+      expect(() => validateAdditionalExtension('')).toThrow(/must start with/);
+      expect(() => validateAdditionalExtension('.')).toThrow(/must start with/);
+      expect(() => validateAdditionalExtension('..')).toThrow(/must start with/);
+    });
+
+    it('should reject extensions containing path separators or special chars', () => {
+      expect(() => validateAdditionalExtension('.foo/bar')).toThrow(/must start with/);
+      expect(() => validateAdditionalExtension('.foo bar')).toThrow(/must start with/);
+      expect(() => validateAdditionalExtension('.foo.bar')).toThrow(/must start with/);
+    });
+
+    it('should reject non-string entries', () => {
+      expect(() => validateAdditionalExtension(42 as unknown)).toThrow(/must be strings/);
+      expect(() => validateAdditionalExtension(null as unknown)).toThrow(/must be strings/);
+      expect(() => validateAdditionalExtension(undefined as unknown)).toThrow(/must be strings/);
+    });
+  });
+
+  describe('getConfigAdditionalExtensions / setConfigAdditionalExtensions', () => {
+    it('should return an empty array when unset', () => {
+      saveFullConfig({});
+      expect(getConfigAdditionalExtensions()).toEqual([]);
+    });
+
+    it('should return an empty array when indexing is not an object', () => {
+      saveFullConfig({ indexing: 'nope' });
+      expect(getConfigAdditionalExtensions()).toEqual([]);
+    });
+
+    it('should return an empty array when additionalExtensions is not an array', () => {
+      saveFullConfig({ indexing: { additionalExtensions: 'proto' } });
+      expect(getConfigAdditionalExtensions()).toEqual([]);
+    });
+
+    it('should silently drop invalid entries on read', () => {
+      saveFullConfig({
+        indexing: { additionalExtensions: ['.proto', 'graphql', 42, null, '.tf'] },
+      });
+      expect(getConfigAdditionalExtensions()).toEqual(['.proto', '.tf']);
+    });
+
+    it('should dedupe entries case-insensitively on read', () => {
+      saveFullConfig({
+        indexing: { additionalExtensions: ['.proto', '.PROTO', '.Proto', '.graphql'] },
+      });
+      expect(getConfigAdditionalExtensions()).toEqual(['.proto', '.graphql']);
+    });
+
+    it('should persist a list of valid extensions', () => {
+      saveFullConfig({});
+      setConfigAdditionalExtensions(['.proto', '.graphql', '.tf']);
+      expect(getConfigAdditionalExtensions()).toEqual(['.proto', '.graphql', '.tf']);
+    });
+
+    it('should normalize extensions to lower-case on write', () => {
+      saveFullConfig({});
+      setConfigAdditionalExtensions(['.PROTO', '.GraphQL']);
+      expect(getConfigAdditionalExtensions()).toEqual(['.proto', '.graphql']);
+    });
+
+    it('should throw when writing an invalid extension', () => {
+      saveFullConfig({});
+      expect(() => setConfigAdditionalExtensions(['proto'])).toThrow(/must start with/);
+      // Config should not have been mutated
+      const cfg = loadFullConfig();
+      expect(cfg.indexing).toBeUndefined();
+    });
+
+    it('should preserve unrelated top-level keys when writing extensions', () => {
+      saveFullConfig({ defaultModel: 'gpt-4.1', theme: 'dark' });
+      setConfigAdditionalExtensions(['.proto']);
+      const cfg = loadFullConfig();
+      expect(cfg.defaultModel).toBe('gpt-4.1');
+      expect(cfg.theme).toBe('dark');
+      expect(cfg.indexing).toEqual({ additionalExtensions: ['.proto'] });
+    });
+
+    it('should preserve unrelated indexing.* keys when writing extensions', () => {
+      saveFullConfig({ indexing: { somethingElse: true } });
+      setConfigAdditionalExtensions(['.proto']);
+      const cfg = loadFullConfig();
+      expect(cfg.indexing).toEqual({
+        somethingElse: true,
+        additionalExtensions: ['.proto'],
+      });
+    });
+
+    it('should throw on non-array input', () => {
+      expect(() => setConfigAdditionalExtensions('proto' as unknown as string[])).toThrow(
+        /must be an array/
+      );
     });
   });
 });

--- a/tests/tool/tools/additionalExtensions.integration.test.ts
+++ b/tests/tool/tools/additionalExtensions.integration.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Integration tests for `indexing.additionalExtensions`.
+ *
+ * Verifies that grep, glob, and codesearch honor the config-driven list
+ * of extra file extensions when locating files. We mock
+ * `getConfigAdditionalExtensions` rather than writing to the real
+ * ~/.alexi/config.json so the tests are hermetic.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import os from 'os';
+
+// Mock the tool index to bypass permission checks (same pattern as
+// existing grep/glob/codesearch tests).
+vi.mock('../../../src/tool/index.js', async () => {
+  const actual = await vi.importActual('../../../src/tool/index.js');
+  return {
+    ...actual,
+    defineTool: (def: {
+      name: string;
+      description: string;
+      execute: (...args: unknown[]) => unknown;
+    }) => ({
+      ...def,
+      execute: def.execute,
+      executeUnsafe: def.execute,
+      toFunctionSchema: () => ({
+        name: def.name,
+        description: def.description,
+        parameters: {},
+      }),
+    }),
+  };
+});
+
+// Mock the user config module so we can control the additional
+// extensions without touching the real filesystem config.
+const additionalExtensions: string[] = [];
+vi.mock('../../../src/config/userConfig.js', async () => {
+  const actual = await vi.importActual('../../../src/config/userConfig.js');
+  return {
+    ...actual,
+    getConfigAdditionalExtensions: (): string[] => [...additionalExtensions],
+  };
+});
+
+// Force the JS fallback path in grep so behavior is deterministic across
+// environments (ripgrep may or may not be installed on the runner). The
+// merge logic is the same on both paths.
+process.env.ALEXI_DISABLE_RG = '1';
+
+import { grepTool } from '../../../src/tool/tools/grep.js';
+import { globTool } from '../../../src/tool/tools/glob.js';
+import { codesearchTool } from '../../../src/tool/tools/codesearch.js';
+import type { ToolContext } from '../../../src/tool/index.js';
+
+describe('indexing.additionalExtensions integration', () => {
+  let tempDir: string;
+  let context: ToolContext;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'alexi-add-ext-test-'));
+    context = { workdir: tempDir };
+    additionalExtensions.length = 0;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    additionalExtensions.length = 0;
+  });
+
+  describe('grep', () => {
+    it('finds .proto files when include is *.ts + config has .proto', async () => {
+      await fs.writeFile(path.join(tempDir, 'schema.proto'), 'message Foo { needle = 1; }');
+      await fs.writeFile(path.join(tempDir, 'main.ts'), 'const needle = true;');
+      await fs.writeFile(path.join(tempDir, 'other.txt'), 'needle here');
+
+      additionalExtensions.push('.proto');
+
+      const result = await grepTool.execute({ pattern: 'needle', include: '*.ts' }, context);
+      expect(result.success).toBe(true);
+      const files = (result.data?.matches ?? []).map((m) => m.file).sort();
+      expect(files).toEqual(['main.ts', 'schema.proto']);
+      // The .txt file should NOT be included — additionalExtensions only
+      // extends the caller's filter.
+      expect(files).not.toContain('other.txt');
+    });
+
+    it('does not narrow an unset include when config has extensions', async () => {
+      await fs.writeFile(path.join(tempDir, 'schema.proto'), 'needle');
+      await fs.writeFile(path.join(tempDir, 'main.ts'), 'needle');
+      await fs.writeFile(path.join(tempDir, 'other.txt'), 'needle');
+
+      additionalExtensions.push('.proto');
+
+      // No include -> historical behavior of "search everything" is
+      // preserved. Extensions are additive; they must not restrict.
+      const result = await grepTool.execute({ pattern: 'needle' }, context);
+      expect(result.success).toBe(true);
+      const files = (result.data?.matches ?? []).map((m) => m.file).sort();
+      expect(files).toContain('schema.proto');
+      expect(files).toContain('main.ts');
+      expect(files).toContain('other.txt');
+    });
+
+    it('is a no-op when additionalExtensions is empty', async () => {
+      await fs.writeFile(path.join(tempDir, 'schema.proto'), 'needle');
+      await fs.writeFile(path.join(tempDir, 'main.ts'), 'needle');
+
+      const result = await grepTool.execute({ pattern: 'needle', include: '*.ts' }, context);
+      expect(result.success).toBe(true);
+      const files = (result.data?.matches ?? []).map((m) => m.file);
+      expect(files).toEqual(['main.ts']);
+    });
+  });
+
+  describe('glob', () => {
+    it('finds .proto files when pattern is **/*.ts + config has .proto', async () => {
+      await fs.writeFile(path.join(tempDir, 'schema.proto'), 'x');
+      await fs.writeFile(path.join(tempDir, 'main.ts'), 'x');
+      await fs.writeFile(path.join(tempDir, 'other.txt'), 'x');
+
+      additionalExtensions.push('.proto');
+
+      const result = await globTool.execute({ pattern: '**/*.ts' }, context);
+      expect(result.success).toBe(true);
+      const matches = (result.data?.matches ?? []).sort();
+      expect(matches).toContain('schema.proto');
+      expect(matches).toContain('main.ts');
+      expect(matches).not.toContain('other.txt');
+    });
+
+    it('is a no-op when additionalExtensions is empty', async () => {
+      await fs.writeFile(path.join(tempDir, 'schema.proto'), 'x');
+      await fs.writeFile(path.join(tempDir, 'main.ts'), 'x');
+
+      const result = await globTool.execute({ pattern: '**/*.ts' }, context);
+      expect(result.success).toBe(true);
+      const matches = result.data?.matches ?? [];
+      expect(matches).toEqual(['main.ts']);
+    });
+  });
+
+  describe('codesearch', () => {
+    it('extends the code-file whitelist with additional extensions', async () => {
+      // Without config, codesearch skips .proto (not in CODE_EXTENSIONS).
+      await fs.writeFile(
+        path.join(tempDir, 'schema.proto'),
+        'message HandleRequest { string name = 1; }'
+      );
+      await fs.writeFile(
+        path.join(tempDir, 'main.ts'),
+        'function handleRequest() { return true; }'
+      );
+
+      // Baseline: without config, only main.ts is searched.
+      let result = await codesearchTool.execute(
+        { query: 'HandleRequest', searchType: 'content' },
+        context
+      );
+      expect(result.success).toBe(true);
+      let matchFiles = (result.data?.matches ?? []).map((m) => m.file).sort();
+      expect(matchFiles).toContain('main.ts');
+      expect(matchFiles).not.toContain('schema.proto');
+
+      // With config, .proto is now considered a code file.
+      additionalExtensions.push('.proto');
+      result = await codesearchTool.execute(
+        { query: 'HandleRequest', searchType: 'content' },
+        context
+      );
+      expect(result.success).toBe(true);
+      matchFiles = (result.data?.matches ?? []).map((m) => m.file).sort();
+      expect(matchFiles).toContain('schema.proto');
+    });
+  });
+});

--- a/tests/tool/tools/includePattern.test.ts
+++ b/tests/tool/tools/includePattern.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+
+import { mergeIncludePattern, mergeExtensionSet } from '../../../src/tool/tools/includePattern.js';
+
+describe('mergeIncludePattern', () => {
+  it('returns include unchanged when extensions is empty', () => {
+    expect(mergeIncludePattern('*.ts', [])).toBe('*.ts');
+    expect(mergeIncludePattern(undefined, [])).toBeUndefined();
+  });
+
+  it('leaves undefined include untouched (additive semantics)', () => {
+    // When no include filter is passed, additional extensions must NOT
+    // narrow the search — the tool should keep searching all files.
+    expect(mergeIncludePattern(undefined, ['.proto', '.graphql'])).toBeUndefined();
+    expect(mergeIncludePattern('', ['.proto'])).toBe('');
+  });
+
+  it('extends a single-extension include with additional extensions', () => {
+    expect(mergeIncludePattern('*.ts', ['.proto', '.graphql'])).toBe('*.{ts,proto,graphql}');
+  });
+
+  it('extends a braced include with additional extensions', () => {
+    expect(mergeIncludePattern('*.{ts,tsx}', ['.proto'])).toBe('*.{ts,tsx,proto}');
+  });
+
+  it('dedupes overlapping extensions', () => {
+    expect(mergeIncludePattern('*.ts', ['.ts', '.proto'])).toBe('*.{ts,proto}');
+    expect(mergeIncludePattern('*.{ts,proto}', ['.proto', '.graphql'])).toBe(
+      '*.{ts,proto,graphql}'
+    );
+  });
+
+  it('accepts extensions without a leading dot', () => {
+    expect(mergeIncludePattern('*.ts', ['proto', 'graphql'])).toBe('*.{ts,proto,graphql}');
+  });
+
+  it('normalizes casing consistently', () => {
+    expect(mergeIncludePattern('*.TS', ['.Proto'])).toBe('*.{ts,proto}');
+  });
+
+  it('wraps an unrecognized pattern in an alternation', () => {
+    // Non-extension shapes (exact filenames, path patterns) cannot safely
+    // have alternates injected in-place; fall back to a top-level `{a,b}`
+    // union that both rg --glob and the in-process matcher understand.
+    expect(mergeIncludePattern('README.md', ['.proto'])).toBe('{README.md,*.proto}');
+  });
+
+  it('drops empty and whitespace entries', () => {
+    expect(mergeIncludePattern('*.ts', ['', '   ', '.proto'])).toBe('*.{ts,proto}');
+  });
+});
+
+describe('mergeExtensionSet', () => {
+  it('returns a copy of the base set when extensions is empty', () => {
+    const base = new Set(['.ts', '.js']);
+    const merged = mergeExtensionSet(base, []);
+    expect(merged).not.toBe(base);
+    expect([...merged].sort()).toEqual(['.js', '.ts']);
+  });
+
+  it('adds new extensions with a leading dot', () => {
+    const base = new Set(['.ts']);
+    const merged = mergeExtensionSet(base, ['.proto', 'graphql']);
+    expect(merged.has('.ts')).toBe(true);
+    expect(merged.has('.proto')).toBe(true);
+    expect(merged.has('.graphql')).toBe(true);
+  });
+
+  it('lower-cases everything', () => {
+    const base = new Set(['.TS']);
+    const merged = mergeExtensionSet(base, ['.PROTO']);
+    expect(merged.has('.ts')).toBe(true);
+    expect(merged.has('.proto')).toBe(true);
+    expect(merged.has('.PROTO')).toBe(false);
+  });
+
+  it('does not duplicate existing extensions', () => {
+    const base = new Set(['.proto']);
+    const merged = mergeExtensionSet(base, ['.proto']);
+    expect(merged.size).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #1040

## What

Adds an `indexing.additionalExtensions` user-config field so projects can include domain-specific file types (`.proto`, `.graphql`, `.tf`, `.mdx`, `.svelte`, `.prisma`, ...) in grep/glob/codesearch without repeating `--include` on every call.

## How

**Config** (`src/config/userConfig.ts`)
- New `indexing.additionalExtensions: string[]` field.
- Validation rejects entries without a leading `.` (regex `/^\.[A-Za-z0-9_-]+$/`).
- `setConfigAdditionalExtensions` throws on the first invalid entry.
- `getConfigAdditionalExtensions` silently drops invalid entries so a corrupt config never crashes tool execution.
- Existing top-level and `indexing.*` keys are preserved on write.

**Merge helper** (`src/tool/tools/includePattern.ts`)
- `mergeIncludePattern` performs the additive union used by grep / codesearch:
  - `*.ts` + `[.proto]` → `*.{ts,proto}`
  - `*.{ts,tsx}` + `[.proto]` → `*.{ts,tsx,proto}`
  - unknown shape + `[.proto]` → `{README.md,*.proto}` (safe fallback)
  - undefined include → left undefined (extensions are additive, never narrow a broad search)
- `mergeExtensionSet` extends codesearch's built-in `CODE_EXTENSIONS` whitelist.

**Tool wiring**
- `grep.ts`: load extensions, merge with `params.include`, pass to both rg and JS paths.
- `glob.ts`: load extensions, extend the last segment of the caller's pattern (`**/*.ts` → `**/*.{ts,proto}`); `matchPart` now understands `{a,b}` alternates.
- `codesearch.ts`: load extensions, extend `CODE_EXTENSIONS` and `include`.

## Tests

- `tests/config/userConfig.test.ts`: 20 new cases covering validation, dedupe, case-normalization, and read/write persistence.
- `tests/tool/tools/includePattern.test.ts`: pure-function coverage of merge shapes (single ext, braced, dedupe, fallback, casing).
- `tests/tool/tools/additionalExtensions.integration.test.ts`: creates a `.proto` file, sets the config, verifies grep / glob / codesearch surface it while non-configured extensions stay filtered.

## Verification

```bash
npm run lint          # 0 errors
npm run typecheck     # clean
npm run format:check  # clean
npm run test:coverage # 3033 passed
npm run build         # clean
```

Global line coverage is 63.99% (well above the 40% CI gate). The new `includePattern.ts` module reports 94% line coverage.

Reference: Kilocode PR #12306.