### PR TITLE
feat(tools): add bash support to definitions tool

### DIFF
--- a/src/tool/tools/__tests__/definitions.test.ts
+++ b/src/tool/tools/__tests__/definitions.test.ts
@@ -365,6 +365,142 @@ async def fetch_data(url: str) -> dict:
     });
   });
 
+  describe('Bash definitions', () => {
+    it('should extract POSIX function syntax', async () => {
+      const filePath = path.join(tempDir, 'deploy.sh');
+      fs.writeFileSync(
+        filePath,
+        `#!/bin/bash
+deploy_app() {
+  echo "Deploying..."
+}
+
+cleanup() {
+  rm -rf tmp
+}`
+      );
+
+      const result = await definitionsTool.executeUnsafe({ filePath }, context);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.language).toBe('bash');
+      expect(result.data?.definitions).toHaveLength(2);
+
+      const deploy = result.data?.definitions.find((d) => d.name === 'deploy_app');
+      expect(deploy).toMatchObject({
+        name: 'deploy_app',
+        type: 'function',
+        line: 2,
+        signature: 'deploy_app()',
+        exported: true,
+      });
+
+      const cleanup = result.data?.definitions.find((d) => d.name === 'cleanup');
+      expect(cleanup).toMatchObject({
+        name: 'cleanup',
+        type: 'function',
+        line: 6,
+        signature: 'cleanup()',
+      });
+    });
+
+    it('should extract Bash keyword function syntax', async () => {
+      const filePath = path.join(tempDir, 'utils.bash');
+      fs.writeFileSync(
+        filePath,
+        `#!/bin/bash
+function build_project {
+  npm run build
+}
+
+function run_tests {
+  npm test
+}`
+      );
+
+      const result = await definitionsTool.executeUnsafe({ filePath }, context);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.language).toBe('bash');
+      expect(result.data?.definitions).toHaveLength(2);
+
+      const build = result.data?.definitions.find((d) => d.name === 'build_project');
+      expect(build).toMatchObject({
+        name: 'build_project',
+        type: 'function',
+        line: 2,
+        signature: 'function build_project',
+        exported: true,
+      });
+
+      const tests = result.data?.definitions.find((d) => d.name === 'run_tests');
+      expect(tests).toMatchObject({
+        name: 'run_tests',
+        type: 'function',
+        line: 6,
+      });
+    });
+
+    it('should deduplicate functions with both syntaxes', async () => {
+      const filePath = path.join(tempDir, 'mixed.sh');
+      fs.writeFileSync(
+        filePath,
+        `#!/bin/bash
+function my_func() {
+  echo "hi"
+}`
+      );
+
+      const result = await definitionsTool.executeUnsafe({ filePath }, context);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.definitions).toHaveLength(1);
+      expect(result.data?.definitions[0]).toMatchObject({
+        name: 'my_func',
+        type: 'function',
+      });
+    });
+
+    it('should extract mixed POSIX and Bash keyword functions', async () => {
+      const filePath = path.join(tempDir, 'mixed2.sh');
+      fs.writeFileSync(
+        filePath,
+        `#!/bin/bash
+posix_fn() {
+  echo "posix"
+}
+
+function keyword_fn {
+  echo "keyword"
+}`
+      );
+
+      const result = await definitionsTool.executeUnsafe({ filePath }, context);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.definitions).toHaveLength(2);
+      const names = result.data?.definitions.map((d) => d.name);
+      expect(names).toContain('posix_fn');
+      expect(names).toContain('keyword_fn');
+    });
+
+    it('should respect type filter for bash', async () => {
+      const filePath = path.join(tempDir, 'filter.sh');
+      fs.writeFileSync(
+        filePath,
+        `#!/bin/bash
+my_fn() {
+  echo "hi"
+}`
+      );
+
+      const result = await definitionsTool.executeUnsafe({ filePath, types: ['class'] }, context);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.definitions).toHaveLength(0);
+    });
+  });
+
   describe('Export detection', () => {
     it('should correctly identify exported vs non-exported definitions', async () => {
       const filePath = path.join(tempDir, 'test.ts');

--- a/src/tool/tools/definitions.ts
+++ b/src/tool/tools/definitions.ts
@@ -1,6 +1,6 @@
 /**
  * Definitions Tool - Extract code definitions from source files
- * Supports TypeScript, JavaScript, and Python
+ * Supports TypeScript, JavaScript, Python, and Bash
  */
 
 import { z } from 'zod';
@@ -41,7 +41,7 @@ interface DefinitionsResult {
   language: string;
 }
 
-type SupportedLanguage = 'typescript' | 'javascript' | 'python' | 'unknown';
+type SupportedLanguage = 'typescript' | 'javascript' | 'python' | 'bash' | 'unknown';
 
 // TypeScript/JavaScript regex patterns
 // Note: Use [ \t]* instead of \s* for indentation to avoid matching newlines
@@ -66,6 +66,14 @@ const pythonPatterns = {
   function: /^(async\s+)?def\s+(\w+)\s*(\([^)]*\))(\s*->\s*[^:]+)?:/gm,
 };
 
+// Bash regex patterns
+const bashPatterns = {
+  // POSIX function: name() { ... }
+  posixFunction: /^([ \t]*)([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\s*\)\s*\{/gm,
+  // Bash keyword: function name { ... } or function name() { ... }
+  bashFunction: /^([ \t]*)function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:\(\s*\))?\s*\{/gm,
+};
+
 /**
  * Detect language from file extension
  */
@@ -82,6 +90,9 @@ function detectLanguage(filePath: string): SupportedLanguage {
       return 'javascript';
     case '.py':
       return 'python';
+    case '.sh':
+    case '.bash':
+      return 'bash';
     default:
       return 'unknown';
   }
@@ -404,6 +415,62 @@ function extractPythonDefinitions(
   return definitions;
 }
 
+/**
+ * Extract Bash definitions
+ */
+function extractBashDefinitions(
+  content: string,
+  types: DefinitionType[] | undefined
+): Definition[] {
+  const definitions: Definition[] = [];
+  const shouldExtract = (type: DefinitionType) => !types || types.includes(type);
+
+  // Bash has no classes/interfaces/types — only functions
+  if (!shouldExtract('function')) {
+    return definitions;
+  }
+
+  // POSIX syntax: name() { ... }
+  const posixRegex = new RegExp(bashPatterns.posixFunction.source, 'gm');
+  let match;
+  while ((match = posixRegex.exec(content)) !== null) {
+    const line = getLineNumber(content, match.index);
+    const name = match[2];
+    const signature = `${name}()`;
+
+    definitions.push({
+      name,
+      type: 'function',
+      line,
+      signature,
+      exported: true, // Bash functions are globally scoped when sourced
+    });
+  }
+
+  // Bash keyword syntax: function name { ... } or function name() { ... }
+  const bashRegex = new RegExp(bashPatterns.bashFunction.source, 'gm');
+  while ((match = bashRegex.exec(content)) !== null) {
+    const line = getLineNumber(content, match.index);
+    const name = match[2];
+    const signature = `function ${name}`;
+
+    // Skip if already captured by POSIX pattern (dedup name() { ... } style)
+    if (definitions.some((d) => d.name === name)) {
+      continue;
+    }
+
+    definitions.push({
+      name,
+      type: 'function',
+      line,
+      signature,
+      exported: true,
+    });
+  }
+
+  return definitions;
+}
+
 export const definitionsTool = defineTool<typeof DefinitionsParamsSchema, DefinitionsResult>({
   name: 'definitions',
   description: `Extract code definitions (classes, functions, interfaces, etc.) from source files.
@@ -412,6 +479,7 @@ Supports:
 - TypeScript (.ts, .tsx): class, function, interface, type, const, enum, method
 - JavaScript (.js, .jsx): class, function, const, method
 - Python (.py): class, function/def
+- Bash (.sh, .bash): function
 
 Returns definition name, type, line number, signature, and export status.`,
 
@@ -445,7 +513,7 @@ Returns definition name, type, line number, signature, and export status.`,
       if (language === 'unknown') {
         return {
           success: false,
-          error: `Unsupported file type: ${path.extname(filePath)}. Supported: .ts, .tsx, .js, .jsx, .mjs, .cjs, .py`,
+          error: `Unsupported file type: ${path.extname(filePath)}. Supported: .ts, .tsx, .js, .jsx, .mjs, .cjs, .py, .sh, .bash`,
         };
       }
 
@@ -453,6 +521,8 @@ Returns definition name, type, line number, signature, and export status.`,
       let definitions: Definition[];
       if (language === 'python') {
         definitions = extractPythonDefinitions(content, params.types);
+      } else if (language === 'bash') {
+        definitions = extractBashDefinitions(content, params.types);
       } else {
         const isTypeScript = language === 'typescript';
         definitions = extractTsDefinitions(content, params.types, isTypeScript);


### PR DESCRIPTION
## Summary

Adds bash script support to the `definitions` tool. The tool now recognizes `.sh` and `.bash` extensions and extracts function definitions using two patterns:

- **POSIX syntax**: `name() { ... }` -> signature `name()`
- **Bash keyword syntax**: `function name { ... }` (with optional parens) -> signature `function name`

Combined `function name() { ... }` form is captured once via the POSIX pattern; the keyword pass skips duplicates by name.

## Changes

- `src/tool/tools/definitions.ts`: added `bash` to `SupportedLanguage`, extended `detectLanguage` for `.sh`/`.bash`, added `bashPatterns` regex + `extractBashDefinitions`, wired into `execute`, updated tool description and unsupported-file error message.
- `src/tool/tools/__tests__/definitions.test.ts`: 5 new test cases (POSIX, keyword, dedup, mixed, type filter).

## Verification

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm test` — 3103 passed, 3 skipped (228 files)
- `npm run build` — clean

Closes #1052