### PR TITLE
feat: [tool] Add bash tree-sitter support to repoMap (#1061)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alexi",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alexi",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^8.5.2",
@@ -35,6 +35,7 @@
         "terminal-image": "^5.0.1",
         "terminal-link": "^5.0.0",
         "tree-sitter": "^0.21.1",
+        "tree-sitter-bash": "^0.21.0",
         "tree-sitter-javascript": "^0.21.4",
         "tree-sitter-typescript": "^0.23.2",
         "xlsx": "^0.18.5",
@@ -9162,6 +9163,32 @@
         "node-gyp-build": "^4.8.0"
       }
     },
+    "node_modules/tree-sitter-bash": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.21.0.tgz",
+      "integrity": "sha512-UuXf+wliu1mmS/O2Iz7OQghExM4a+lk+GaVPndZVpAJnFuzanaN33UcHOsrmngHxaOXHz5JSZrwp6i2qM/PKag==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0",
+        "web-tree-sitter": "^0.21.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-bash/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/tree-sitter-javascript": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.21.4.tgz",
@@ -9631,6 +9658,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/voca/-/voca-1.4.1.tgz",
       "integrity": "sha512-NJC/BzESaHT1p4B5k4JykxedeltmNbau4cummStd4RjFojgq/kLew5TzYge9N2geeWyI2w8T30wUET5v+F7ZHA==",
+      "license": "MIT"
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.21.0.tgz",
+      "integrity": "sha512-iJ+QJ6ikN9D9cG7Kh6q3KtAstYFUQbYZ8OjuPEJYWfj2kLrmp5I3C2n6WjE1Y3jvj7nJbkcrJytJGWUEhCxn+g==",
       "license": "MIT"
     },
     "node_modules/webdriver-bidi-protocol": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "terminal-image": "^5.0.1",
     "terminal-link": "^5.0.0",
     "tree-sitter": "^0.21.1",
+    "tree-sitter-bash": "^0.21.0",
     "tree-sitter-javascript": "^0.21.4",
     "tree-sitter-typescript": "^0.23.2",
     "xlsx": "^0.18.5",

--- a/src/context/__tests__/repoMap.test.ts
+++ b/src/context/__tests__/repoMap.test.ts
@@ -104,6 +104,31 @@ describe('buildRepoMap', () => {
     const names = allSymbols.map((s) => s.name);
     expect(names).toContain('compute');
   });
+
+  it('discovers bash source files (.sh)', async () => {
+    writeFile(tmpDir, 'deploy.sh', 'deploy() { echo deploying; }\n');
+    const map = await buildRepoMap(tmpDir);
+    const keys = [...map.files.keys()];
+    expect(keys.some((k) => k.endsWith('deploy.sh'))).toBe(true);
+  });
+
+  it('extracts bash function symbols into the files map', async () => {
+    writeFile(
+      tmpDir,
+      'utils.sh',
+      [
+        'compile() { echo compile; }',
+        'function bundle { echo bundle; }',
+        'function ship() { echo ship; }',
+      ].join('\n')
+    );
+    const map = await buildRepoMap(tmpDir);
+    const allSymbols = [...map.files.values()].flat();
+    const names = allSymbols.map((s) => s.name);
+    expect(names).toContain('compile');
+    expect(names).toContain('bundle');
+    expect(names).toContain('ship');
+  });
 });
 
 // ─── generateRepoMap ──────────────────────────────────────────────────────────
@@ -173,6 +198,22 @@ describe('generateRepoMap', () => {
     writeFile(tmpDir, 'api.ts', 'export function doWork(input: string): boolean { return true; }');
     const result = await generateRepoMap(tmpDir);
     expect(result).toContain('doWork');
+  });
+
+  it('includes bash scripts with function signatures in the output', async () => {
+    writeFile(
+      tmpDir,
+      'scripts/release.sh',
+      [
+        '#!/usr/bin/env bash',
+        'tag_release() { git tag "v$1"; }',
+        'function push_tags { git push --tags; }',
+      ].join('\n')
+    );
+    const result = await generateRepoMap(tmpDir);
+    expect(result).toContain('scripts/release.sh');
+    expect(result).toContain('tag_release');
+    expect(result).toContain('push_tags');
   });
 });
 

--- a/src/context/__tests__/symbols.test.ts
+++ b/src/context/__tests__/symbols.test.ts
@@ -198,6 +198,65 @@ class Greeter {
     });
   });
 
+  describe('bash support', () => {
+    it('extracts a POSIX-style function from a .sh file', () => {
+      const src = 'greet() {\n  echo "hi $1"\n}';
+      const symbols = extractSymbols(src, 'script.sh');
+      expect(symbolNames(symbols)).toContain('greet');
+      const sym = symbols.find((s) => s.name === 'greet')!;
+      expect(sym.kind).toBe('function');
+      expect(sym.line).toBe(1);
+      expect(sym.signature).toBe('greet()');
+    });
+
+    it('extracts a Bash keyword-style function without parens', () => {
+      const src = 'function farewell {\n  echo bye\n}';
+      const symbols = extractSymbols(src, 'script.sh');
+      expect(symbolNames(symbols)).toContain('farewell');
+      const sym = symbols.find((s) => s.name === 'farewell')!;
+      expect(sym.kind).toBe('function');
+      expect(sym.signature).toBe('function farewell');
+    });
+
+    it('extracts a Bash keyword-style function with parens', () => {
+      const src = 'function ping() {\n  echo pong\n}';
+      const symbols = extractSymbols(src, 'script.bash');
+      expect(symbolNames(symbols)).toContain('ping');
+      const sym = symbols.find((s) => s.name === 'ping')!;
+      expect(sym.signature).toBe('function ping()');
+    });
+
+    it('extracts multiple bash functions in order', () => {
+      const src = [
+        'alpha() { echo a; }',
+        'function beta { echo b; }',
+        'function gamma() { echo g; }',
+      ].join('\n');
+      const symbols = extractSymbols(src, 'utils.sh');
+      expect(symbolNames(symbols)).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('ignores nested helper functions defined inside another function', () => {
+      const src = ['outer() {', '  inner() { echo nested; }', '  inner', '}'].join('\n');
+      const symbols = extractSymbols(src, 'script.sh');
+      expect(symbolNames(symbols)).toEqual(['outer']);
+    });
+
+    it('returns empty array for a bash file with no functions', () => {
+      const src = 'echo hello\nls -la\n';
+      const symbols = extractSymbols(src, 'script.sh');
+      expect(symbols).toEqual([]);
+    });
+
+    it('sets filePath and references correctly on bash symbols', () => {
+      const src = 'foo() { echo hi; }';
+      const symbols = extractSymbols(src, 'scripts/deploy.sh');
+      const sym = symbols[0];
+      expect(sym.filePath).toBe('scripts/deploy.sh');
+      expect(sym.references).toBe(0);
+    });
+  });
+
   describe('multiple symbols', () => {
     it('extracts multiple top-level symbols in order', () => {
       const src = `

--- a/src/context/__tests__/treeSitter.test.ts
+++ b/src/context/__tests__/treeSitter.test.ts
@@ -36,6 +36,14 @@ describe('isSupportedFile', () => {
     expect(isSupportedFile('component.jsx')).toBe(true);
   });
 
+  it('returns true for .sh files', () => {
+    expect(isSupportedFile('deploy.sh')).toBe(true);
+  });
+
+  it('returns true for .bash files', () => {
+    expect(isSupportedFile('helpers.bash')).toBe(true);
+  });
+
   it('returns false for .py files', () => {
     expect(isSupportedFile('script.py')).toBe(false);
   });
@@ -100,6 +108,20 @@ describe('parseSource', () => {
     const source = 'const el = <span>Hello</span>;';
     const root = parseSource(source, 'component.jsx');
     expect(root).not.toBeNull();
+  });
+
+  it('parses .sh files as bash', () => {
+    const source = 'foo() { echo hi; }';
+    const root = parseSource(source, 'script.sh');
+    expect(root).not.toBeNull();
+    expect(root?.type).toBe('program');
+  });
+
+  it('parses .bash files as bash', () => {
+    const source = 'function bar() { echo hi; }';
+    const root = parseSource(source, 'helpers.bash');
+    expect(root).not.toBeNull();
+    expect(root?.type).toBe('program');
   });
 
   it('returns null for unsupported file extensions', () => {

--- a/src/context/symbols.ts
+++ b/src/context/symbols.ts
@@ -6,7 +6,7 @@
  * the tree-sitter AST produced by treeSitter.ts.
  */
 
-import { parseSource, walkNode, getNameNode } from './treeSitter.js';
+import { parseSource, walkNode, getNameNode, findChildOfType } from './treeSitter.js';
 
 // ─── Public interfaces ────────────────────────────────────────────────────────
 
@@ -109,6 +109,75 @@ function extractDeclaration(
   };
 }
 
+// ─── Bash symbol extraction ───────────────────────────────────────────────────
+
+/**
+ * Returns true if the file path points to a bash script.
+ */
+function isBashFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return ext === 'sh' || ext === 'bash';
+}
+
+/**
+ * Build a compact single-line signature for a bash function declaration.
+ * Produces either `name()` or `function name` / `function name()` to match
+ * the two supported syntaxes.
+ */
+function extractBashSignature(node: import('tree-sitter').SyntaxNode, name: string): string {
+  const raw = node.text ?? '';
+  const firstLine = raw.split('\n')[0].trim();
+  // Detect Bash-style `function name [()] { ... }`
+  const startsWithFunction = /^function\b/.test(firstLine);
+  // Detect POSIX `name() { ... }` style — parens present in the head
+  const headBeforeBody = firstLine.replace(/\{.*$/, '').trim();
+  const hasParens = /\(\s*\)/.test(headBeforeBody);
+  if (startsWithFunction) {
+    return hasParens ? `function ${name}()` : `function ${name}`;
+  }
+  return `${name}()`;
+}
+
+/**
+ * Extract top-level function definitions from a bash source file.
+ *
+ * Handles both POSIX-style `name() { ... }` and Bash keyword-style
+ * `function name [()] { ... }`. Only direct children of the program root
+ * are considered so that helpers defined inside other functions do not
+ * leak into the top-level symbol list.
+ */
+function extractBashSymbols(
+  root: import('tree-sitter').SyntaxNode,
+  filePath: string
+): CodeSymbol[] {
+  const symbols: CodeSymbol[] = [];
+
+  for (let i = 0; i < root.childCount; i++) {
+    const child = root.child(i);
+    if (!child || child.type !== 'function_definition') continue;
+
+    // tree-sitter-bash exposes the function name as the `name` field.
+    // Fall back to the first `word` child if the field lookup returns null
+    // (older grammar versions and defensive coding for future churn).
+    const nameNode = child.childForFieldName?.('name') ?? findChildOfType(child, 'word');
+    if (!nameNode) continue;
+
+    const name = nameNode.text;
+    if (!name) continue;
+
+    symbols.push({
+      name,
+      kind: 'function',
+      filePath,
+      line: child.startPosition.row + 1,
+      signature: extractBashSignature(child, name),
+      references: 0,
+    });
+  }
+
+  return symbols;
+}
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
@@ -120,6 +189,11 @@ function extractDeclaration(
 export function extractSymbols(source: string, filePath: string): CodeSymbol[] {
   const root = parseSource(source, filePath);
   if (!root) return [];
+
+  // Bash uses a different AST shape (no classes / interfaces / etc.)
+  if (isBashFile(filePath)) {
+    return extractBashSymbols(root, filePath);
+  }
 
   const symbols: CodeSymbol[] = [];
 

--- a/src/context/treeSitter.ts
+++ b/src/context/treeSitter.ts
@@ -1,18 +1,20 @@
 /**
  * Tree-sitter AST parsing helpers
  *
- * Provides lazy-initialised parsers for TypeScript and JavaScript.
+ * Provides lazy-initialised parsers for TypeScript, JavaScript, and Bash.
  * The parsers are created on first use to avoid startup overhead.
  */
 
 import Parser from 'tree-sitter';
 import TypeScript from 'tree-sitter-typescript';
 import JavaScript from 'tree-sitter-javascript';
+import Bash from 'tree-sitter-bash';
 
 // Lazily initialised parsers (one per language to avoid setLanguage races)
 let tsParser: Parser | null = null;
 let jsParser: Parser | null = null;
 let tsxParser: Parser | null = null;
+let bashParser: Parser | null = null;
 
 /**
  * Get (or lazily create) the TypeScript parser
@@ -56,7 +58,21 @@ function getJsParser(): Parser | null {
   return jsParser;
 }
 
-export type SupportedExtension = 'ts' | 'tsx' | 'js' | 'mjs' | 'cjs' | 'jsx';
+/**
+ * Get (or lazily create) the Bash parser
+ */
+function getBashParser(): Parser | null {
+  if (!Parser) {
+    return null;
+  }
+  if (!bashParser) {
+    bashParser = new Parser();
+    bashParser.setLanguage(Bash);
+  }
+  return bashParser;
+}
+
+export type SupportedExtension = 'ts' | 'tsx' | 'js' | 'mjs' | 'cjs' | 'jsx' | 'sh' | 'bash';
 
 /**
  * Returns true if the file extension is supported by tree-sitter parsers
@@ -64,7 +80,14 @@ export type SupportedExtension = 'ts' | 'tsx' | 'js' | 'mjs' | 'cjs' | 'jsx';
 export function isSupportedFile(filePath: string): boolean {
   const ext = filePath.split('.').pop()?.toLowerCase();
   return (
-    ext === 'ts' || ext === 'tsx' || ext === 'js' || ext === 'mjs' || ext === 'cjs' || ext === 'jsx'
+    ext === 'ts' ||
+    ext === 'tsx' ||
+    ext === 'js' ||
+    ext === 'mjs' ||
+    ext === 'cjs' ||
+    ext === 'jsx' ||
+    ext === 'sh' ||
+    ext === 'bash'
   );
 }
 
@@ -88,6 +111,10 @@ export function parseSource(source: string, filePath: string): Parser.SyntaxNode
     case 'mjs':
     case 'cjs':
       parser = getJsParser();
+      break;
+    case 'sh':
+    case 'bash':
+      parser = getBashParser();
       break;
     default:
       return null;


### PR DESCRIPTION
## Summary

Automated implementation of #1061 by **Kilo CLI** via the agent factory (role=engineering).

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 7
- **Branch**: `auto/1061-tool-add-bash-tree-sitter-support-to-repomap`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #1061
