### PR TITLE
feat(tools): add dynamic shell detection to bash tool (#1070)

### DIFF
--- a/src/tool/tools/bash.ts
+++ b/src/tool/tools/bash.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import { defineTool, truncateOutput, persistLargeOutput, type ToolResult } from '../index.js';
 import { normalizeUrls } from '../../utils/url.js';
 import { auditCommand } from '../../permission/next.js';
+import { detectShell, shellSpawnArgs, type ShellInfo } from './shell/id.js';
 import {
   BashDetachAvailable,
   BashDetachedExited,
@@ -96,9 +97,15 @@ function processCarriageReturns(output: string): string {
     .join('\n');
 }
 
-export const bashTool = defineTool<typeof BashParamsSchema, BashResult>({
-  name: 'bash',
-  description: `Execute a bash command in a shell.
+/**
+ * Build the bash tool description, substituting the currently-detected
+ * shell into the first line so the model sees the shell the OS will
+ * actually dispatch to (Cline PR #12331). This is invoked from
+ * `toFunctionSchema()` and via the `description` getter below, so the
+ * shell is re-detected per-request rather than frozen once at startup.
+ */
+export function buildBashDescription(shell: ShellInfo = detectShell()): string {
+  return `Execute a ${shell.type} command in a shell.
 
 Usage:
 - Use for terminal operations like git, npm, docker, etc.
@@ -117,7 +124,12 @@ Security:
 - Avoid rm -rf without confirmation
 - Don't expose secrets in command arguments
 
-When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns. Include multiple commands in the same call when they are independent and safe to run concurrently.`,
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns. Include multiple commands in the same call when they are independent and safe to run concurrently.`;
+}
+
+const bashToolBase = defineTool<typeof BashParamsSchema, BashResult>({
+  name: 'bash',
+  description: buildBashDescription(),
 
   parameters: BashParamsSchema,
 
@@ -163,6 +175,13 @@ When independent reads, searches, or edits are also needed, emit those tool call
 
     const timeout = params.timeout ?? DEFAULT_TIMEOUT;
 
+    // Detect shell PER-REQUEST (not once at startup) so profile changes
+    // — user installs pwsh, edits $SHELL, ... — are picked up. The
+    // detector itself caches the filesystem probe for a short TTL so
+    // this call is cheap.
+    const shellInfo = detectShell();
+    const { file: shellFile, prefixArgs: shellPrefix } = shellSpawnArgs(shellInfo);
+
     return new Promise((resolve) => {
       let stdout = '';
       let stderr = '';
@@ -174,8 +193,12 @@ When independent reads, searches, or edits are also needed, emit those tool call
       const stdoutDecoder = new StringDecoder('utf8');
       const stderrDecoder = new StringDecoder('utf8');
 
-      const proc = spawn(params.command, {
-        shell: true,
+      // Invoke the detected shell explicitly rather than deferring to
+      // Node's `shell: true` (which delegates to `/bin/sh` on POSIX and
+      // `%ComSpec%` — usually `cmd.exe` — on Windows). Passing the
+      // command as a single argument after the shell's "-c" flag keeps
+      // quoting semantics identical to the previous `shell: true` path.
+      const proc = spawn(shellFile, [...shellPrefix, params.command], {
         cwd: workdir,
         env: { ...process.env, FORCE_COLOR: '0' },
         windowsHide: true,
@@ -432,3 +455,29 @@ When independent reads, searches, or edits are also needed, emit those tool call
     });
   },
 });
+
+/**
+ * Public bash tool. Wraps `bashToolBase` with a getter-backed
+ * `description` and a `toFunctionSchema()` override so both the string
+ * surfaced to human callers (e.g. the parallel-call-hint regression
+ * test) and the schema sent to the LLM are regenerated per-access and
+ * reflect the currently-detected shell.
+ */
+export const bashTool: typeof bashToolBase = Object.defineProperties(
+  Object.create(bashToolBase) as typeof bashToolBase,
+  {
+    description: {
+      enumerable: true,
+      configurable: true,
+      get: () => buildBashDescription(),
+    },
+    toFunctionSchema: {
+      enumerable: true,
+      configurable: true,
+      value: function toFunctionSchema() {
+        const base = bashToolBase.toFunctionSchema();
+        return { ...base, description: buildBashDescription() };
+      },
+    },
+  }
+);

--- a/src/tool/tools/shell.ts
+++ b/src/tool/tools/shell.ts
@@ -10,7 +10,7 @@ import { StringDecoder } from 'node:string_decoder';
 import * as path from 'path';
 import { defineTool, truncateOutput, persistLargeOutput, type ToolResult } from '../index.js';
 import { normalizeUrls } from '../../utils/url.js';
-import * as ShellId from './shell/id.js';
+import { detectShell, shellSpawnArgs, type ShellInfo } from './shell/id.js';
 import { auditCommand } from '../../permission/next.js';
 import {
   BashDetachAvailable,
@@ -99,9 +99,14 @@ function processCarriageReturns(output: string): string {
     .join('\n');
 }
 
-export const shellTool = defineTool<typeof ShellParamsSchema, ShellResult>({
-  name: 'shell',
-  description: `Execute a shell command in the user's environment.
+/**
+ * Build the shell tool description, substituting the currently-detected
+ * shell into the first line so the model sees the shell the OS will
+ * actually dispatch to (Cline PR #12331). Called from `toFunctionSchema`
+ * and via the `description` getter below.
+ */
+export function buildShellDescription(shell: ShellInfo = detectShell()): string {
+  return `Execute a ${shell.type} command in the user's environment.
 
 Usage:
 - Use for terminal operations like git, npm, docker, etc.
@@ -120,7 +125,12 @@ Security:
 - Avoid rm -rf without confirmation
 - Don't expose secrets in command arguments
 
-When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns. Include multiple commands in the same call when they are independent and safe to run concurrently.`,
+When independent reads, searches, or edits are also needed, emit those tool calls in the same response instead of splitting across turns. Include multiple commands in the same call when they are independent and safe to run concurrently.`;
+}
+
+const shellToolBase = defineTool<typeof ShellParamsSchema, ShellResult>({
+  name: 'shell',
+  description: buildShellDescription(),
 
   parameters: ShellParamsSchema,
 
@@ -166,8 +176,11 @@ When independent reads, searches, or edits are also needed, emit those tool call
 
     const timeout = params.timeout ?? DEFAULT_TIMEOUT;
 
-    // Detect shell type
-    const shellInfo = await ShellId.detect();
+    // Detect shell PER-REQUEST via the filesystem probe (Cline PR #12331).
+    // The detector caches its result for a short TTL, so calling this on
+    // every invocation is cheap but still picks up profile changes.
+    const shellInfo = detectShell();
+    const { file: shellFile, prefixArgs: shellPrefix } = shellSpawnArgs(shellInfo);
 
     return new Promise((resolve) => {
       let stdout = '';
@@ -180,8 +193,12 @@ When independent reads, searches, or edits are also needed, emit those tool call
       const stdoutDecoder = new StringDecoder('utf8');
       const stderrDecoder = new StringDecoder('utf8');
 
-      const proc = spawn(params.command, {
-        shell: true,
+      // Spawn the DETECTED shell explicitly rather than relying on
+      // `shell: true` (which delegates to `/bin/sh` on POSIX and
+      // `%ComSpec%` on Windows). The command string is passed as a
+      // single argument after the shell's "-c"/"-Command"/"/c" flag,
+      // preserving quoting semantics equivalent to the previous path.
+      const proc = spawn(shellFile, [...shellPrefix, params.command], {
         cwd: workdir,
         env: { ...process.env, FORCE_COLOR: '0' },
         windowsHide: true,
@@ -421,6 +438,31 @@ When independent reads, searches, or edits are also needed, emit those tool call
     });
   },
 });
+
+/**
+ * Public shell tool. Wraps `shellToolBase` with a getter-backed
+ * `description` and a `toFunctionSchema()` override so both the string
+ * surfaced to human callers and the schema sent to the LLM are
+ * regenerated per-access and reflect the currently-detected shell.
+ */
+export const shellTool: typeof shellToolBase = Object.defineProperties(
+  Object.create(shellToolBase) as typeof shellToolBase,
+  {
+    description: {
+      enumerable: true,
+      configurable: true,
+      get: () => buildShellDescription(),
+    },
+    toFunctionSchema: {
+      enumerable: true,
+      configurable: true,
+      value: function toFunctionSchema() {
+        const base = shellToolBase.toFunctionSchema();
+        return { ...base, description: buildShellDescription() };
+      },
+    },
+  }
+);
 
 // Export bash tool as alias for backwards compatibility
 export const bashTool = shellTool;

--- a/src/tool/tools/shell/id.ts
+++ b/src/tool/tools/shell/id.ts
@@ -1,15 +1,33 @@
 /**
  * Shell ID Detection Module
- * Detects the shell type and provides shell information
+ *
+ * Detects the shell that will be used to execute commands from the bash /
+ * shell tools. Historically this only read the `$SHELL` env var, which
+ * hides the real behaviour on Windows (where `spawn(..., { shell: true })`
+ * delegates to `%ComSpec%`, usually `cmd.exe`) and on macOS/Linux systems
+ * where `$SHELL` is set to the login shell rather than the shell that
+ * would be invoked by a child_process spawn.
+ *
+ * The `detectShell()` function below probes platform-specific candidate
+ * paths (Cline PR #12331 pattern) and returns the first that actually
+ * exists on disk. The result is cached for a short TTL so profile changes
+ * (installing pwsh, switching login shell, ...) are picked up without
+ * requiring a full restart.
  */
 
-export type ShellType = 'bash' | 'zsh' | 'fish' | 'powershell' | 'cmd' | 'unknown';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type ShellType = 'bash' | 'zsh' | 'fish' | 'powershell' | 'cmd' | 'sh' | 'unknown';
 
 export interface ShellInfo {
   type: ShellType;
   path: string;
   version?: string;
 }
+
+// --- Legacy env-var-only detector (kept for backwards compatibility) ---
 
 export async function detect(): Promise<ShellInfo> {
   const shell = process.env.SHELL || process.env.COMSPEC || '/bin/sh';
@@ -19,6 +37,9 @@ export async function detect(): Promise<ShellInfo> {
 
 function inferType(shellPath: string): ShellType {
   const name = shellPath.toLowerCase();
+  if (name.includes('pwsh') || name.includes('powershell')) {
+    return 'powershell';
+  }
   if (name.includes('bash')) {
     return 'bash';
   }
@@ -28,11 +49,181 @@ function inferType(shellPath: string): ShellType {
   if (name.includes('fish')) {
     return 'fish';
   }
-  if (name.includes('powershell') || name.includes('pwsh')) {
-    return 'powershell';
-  }
   if (name.includes('cmd')) {
     return 'cmd';
   }
+  if (name.endsWith('/sh') || name === 'sh') {
+    return 'sh';
+  }
   return 'unknown';
+}
+
+// --- Filesystem-probing detector (Cline PR #12331 pattern) ---
+
+/**
+ * Candidate shells probed on Windows, in priority order.
+ * pwsh (PowerShell 7+) is preferred over the built-in Windows PowerShell
+ * because it is the cross-platform successor and ships with saner UTF-8
+ * defaults; both are preferred over `cmd.exe`.
+ *
+ * Paths are built with `path.win32.join` so they use backslashes
+ * regardless of the host platform — this matters when a POSIX CI
+ * runner spoofs `process.platform === 'win32'` for testing, and the
+ * probe still needs to compare against real Windows paths.
+ */
+function windowsCandidates(): string[] {
+  const winJoin = path.win32.join;
+  const programFiles = process.env['ProgramFiles'] || 'C:\\Program Files';
+  const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
+  const localAppData = process.env['LOCALAPPDATA'] || winJoin(os.homedir(), 'AppData', 'Local');
+  const systemRoot = process.env['SystemRoot'] || 'C:\\Windows';
+
+  return [
+    winJoin(programFiles, 'PowerShell', '7', 'pwsh.exe'),
+    winJoin(programFilesX86, 'PowerShell', '7', 'pwsh.exe'),
+    winJoin(localAppData, 'Microsoft', 'WindowsApps', 'pwsh.exe'),
+    winJoin(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    winJoin(systemRoot, 'System32', 'cmd.exe'),
+  ];
+}
+
+/**
+ * Candidate shells probed on macOS/Linux, in priority order.
+ * zsh is the default on modern macOS and increasingly common on Linux;
+ * bash is the traditional fallback; sh is the last-resort POSIX shell.
+ * The user's login shell (from `$SHELL`) is tried before hard-coded
+ * paths so container/toolbox setups that install shells to non-standard
+ * prefixes are respected.
+ */
+function posixCandidates(): string[] {
+  const envShell = process.env.SHELL;
+  const candidates = [
+    envShell,
+    '/bin/zsh',
+    '/usr/bin/zsh',
+    '/usr/local/bin/zsh',
+    '/opt/homebrew/bin/zsh',
+    '/bin/bash',
+    '/usr/bin/bash',
+    '/usr/local/bin/bash',
+    '/opt/homebrew/bin/bash',
+    '/bin/sh',
+    '/usr/bin/sh',
+  ];
+  return candidates.filter((c): c is string => typeof c === 'string' && c.length > 0);
+}
+
+/**
+ * Cached detection result. Keyed by platform + candidate list to keep the
+ * key stable across an individual process while still invalidating if the
+ * environment changes (e.g. a test suite mutates `process.platform`).
+ */
+interface CachedShell {
+  key: string;
+  info: ShellInfo;
+  expiresAt: number;
+}
+
+const DETECT_TTL_MS = 30_000;
+let cache: CachedShell | undefined;
+
+/**
+ * Default filesystem existence probe. Isolated behind an indirection so
+ * tests (which cannot easily spy on ESM `node:fs` exports) can override
+ * it via `_setFsProbeForTests`.
+ */
+type FsProbe = (p: string) => boolean;
+let fsProbe: FsProbe = (p) => {
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Test hook: drop the cached detection result. Do not call from
+ * production code paths.
+ */
+export function _resetDetectShellCacheForTests(): void {
+  cache = undefined;
+}
+
+/**
+ * Test hook: replace the filesystem probe used by `detectShell`. Passing
+ * `undefined` restores the default `fs.existsSync`-backed probe. Do not
+ * call from production code paths.
+ */
+export function _setFsProbeForTests(probe?: FsProbe): void {
+  fsProbe = probe
+    ? probe
+    : (p) => {
+        try {
+          return fs.existsSync(p);
+        } catch {
+          return false;
+        }
+      };
+}
+
+/**
+ * Probe the filesystem for a real shell binary and return it. Result is
+ * cached for `DETECT_TTL_MS` so callers can invoke it per-request without
+ * paying the `existsSync` cost every time, while still noticing when the
+ * user installs pwsh or edits `$SHELL` mid-session.
+ *
+ * The Cline PR #12331 pattern deliberately favours `pwsh.exe` over the
+ * classic `powershell.exe`, and `zsh` over `bash` on macOS, so the tool
+ * description shown to the LLM matches the shell the OS will actually
+ * dispatch to.
+ */
+export function detectShell(): ShellInfo {
+  const platform = process.platform;
+  const candidates = platform === 'win32' ? windowsCandidates() : posixCandidates();
+  const key = `${platform}|${candidates.join(':')}`;
+
+  const now = Date.now();
+  if (cache && cache.key === key && cache.expiresAt > now) {
+    return cache.info;
+  }
+
+  let picked: string | undefined;
+  for (const candidate of candidates) {
+    if (fsProbe(candidate)) {
+      picked = candidate;
+      break;
+    }
+  }
+
+  // Final fallback: whatever the OS thinks the default is. This still
+  // gives us a sensible `type` even when none of the probed paths exist
+  // (for example in a hyper-minimal container that only has BusyBox).
+  if (!picked) {
+    picked =
+      platform === 'win32' ? process.env.COMSPEC || 'cmd.exe' : process.env.SHELL || '/bin/sh';
+  }
+
+  const info: ShellInfo = { type: inferType(picked), path: picked };
+  cache = { key, info, expiresAt: now + DETECT_TTL_MS };
+  return info;
+}
+
+/**
+ * Return `[executable, [flag]]` suitable for `spawn(cmd, args, { shell: false })`
+ * to invoke a single command string in the detected shell. Callers pass
+ * the user command as the LAST element of the args array.
+ *
+ * PowerShell requires `-Command` (or `-c` shorthand) rather than the
+ * POSIX `-c`, and expects the command as a single argument.
+ * cmd.exe uses `/d /s /c "<cmd>"`. Everything else uses `-c`.
+ */
+export function shellSpawnArgs(info: ShellInfo): { file: string; prefixArgs: string[] } {
+  switch (info.type) {
+    case 'powershell':
+      return { file: info.path, prefixArgs: ['-NoProfile', '-Command'] };
+    case 'cmd':
+      return { file: info.path, prefixArgs: ['/d', '/s', '/c'] };
+    default:
+      return { file: info.path, prefixArgs: ['-c'] };
+  }
 }

--- a/tests/tool/tools/shell-detect.test.ts
+++ b/tests/tool/tools/shell-detect.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Unit tests for the dynamic shell detection powering the bash / shell
+ * tool descriptions and their spawn wiring.
+ *
+ * These tests focus on the pure, side-effect-free surface of the
+ * detector — the tool integration paths are covered by
+ * `tests/tool/tools/bash.test.ts` and `src/tool/tools/__tests__/bash.test.ts`.
+ *
+ * Related upstream fix: Cline PR #12331. The detector probes real
+ * filesystem paths per-platform in priority order (pwsh > powershell >
+ * cmd on Windows; zsh > bash > sh on POSIX) so the tool description the
+ * LLM sees matches the shell the OS will actually dispatch to.
+ *
+ * The filesystem probe is dependency-injected via `_setFsProbeForTests`
+ * because ESM module exports (`node:fs.existsSync`) cannot be spied on
+ * with `vi.spyOn` in Vitest's default (non-browser) mode.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  detectShell,
+  shellSpawnArgs,
+  _resetDetectShellCacheForTests,
+  _setFsProbeForTests,
+} from '../../../src/tool/tools/shell/id.js';
+import { buildBashDescription, bashTool } from '../../../src/tool/tools/bash.js';
+import { buildShellDescription, shellTool } from '../../../src/tool/tools/shell.js';
+
+const ORIGINAL_PLATFORM = process.platform;
+const ORIGINAL_ENV = { ...process.env };
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+function restorePlatform(): void {
+  Object.defineProperty(process, 'platform', {
+    value: ORIGINAL_PLATFORM,
+    configurable: true,
+  });
+}
+
+function makeProbe(existing: readonly string[]): (p: string) => boolean {
+  const set = new Set(existing);
+  return (p: string) => set.has(p);
+}
+
+function setExisting(existing: readonly string[]): void {
+  _setFsProbeForTests(makeProbe(existing));
+  _resetDetectShellCacheForTests();
+}
+
+function cleanup(): void {
+  _resetDetectShellCacheForTests();
+  _setFsProbeForTests(undefined);
+  restorePlatform();
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+}
+
+describe('detectShell — Windows candidate probing', () => {
+  beforeEach(() => {
+    _resetDetectShellCacheForTests();
+    setPlatform('win32');
+    process.env.ProgramFiles = 'C:\\Program Files';
+    process.env['ProgramFiles(x86)'] = 'C:\\Program Files (x86)';
+    process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+    process.env.SystemRoot = 'C:\\Windows';
+    delete process.env.COMSPEC;
+  });
+
+  afterEach(cleanup);
+
+  it('picks pwsh 7 from Program Files when present (highest priority)', () => {
+    setExisting([
+      'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      'C:\\Windows\\System32\\cmd.exe',
+    ]);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('powershell');
+    expect(info.path).toBe('C:\\Program Files\\PowerShell\\7\\pwsh.exe');
+  });
+
+  it('falls back to Program Files (x86) pwsh when the 64-bit path is missing', () => {
+    setExisting([
+      'C:\\Program Files (x86)\\PowerShell\\7\\pwsh.exe',
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+    ]);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('powershell');
+    expect(info.path).toBe('C:\\Program Files (x86)\\PowerShell\\7\\pwsh.exe');
+  });
+
+  it('falls back to the Local AppData WindowsApps pwsh stub when only that is installed', () => {
+    setExisting([
+      'C:\\Users\\test\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe',
+      'C:\\Windows\\System32\\cmd.exe',
+    ]);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('powershell');
+    expect(info.path).toContain('WindowsApps');
+  });
+
+  it('falls back to Windows PowerShell 5.1 when pwsh 7 is not installed', () => {
+    setExisting([
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      'C:\\Windows\\System32\\cmd.exe',
+    ]);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('powershell');
+    expect(info.path).toContain('powershell.exe');
+  });
+
+  it('falls back to cmd.exe when no PowerShell is installed', () => {
+    setExisting(['C:\\Windows\\System32\\cmd.exe']);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('cmd');
+    expect(info.path).toContain('cmd.exe');
+  });
+
+  it('falls back to COMSPEC when none of the probed candidates exist', () => {
+    process.env.COMSPEC = 'C:\\Custom\\cmd.exe';
+    setExisting([]);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('cmd');
+    expect(info.path).toBe('C:\\Custom\\cmd.exe');
+  });
+});
+
+describe('detectShell — POSIX candidate probing', () => {
+  beforeEach(() => {
+    _resetDetectShellCacheForTests();
+    delete process.env.SHELL;
+  });
+
+  afterEach(cleanup);
+
+  it('prefers zsh over bash on macOS when both exist', () => {
+    setPlatform('darwin');
+    setExisting(['/bin/zsh', '/bin/bash', '/bin/sh']);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('zsh');
+    expect(info.path).toBe('/bin/zsh');
+  });
+
+  it('falls back to bash on Linux when zsh is not installed', () => {
+    setPlatform('linux');
+    setExisting(['/bin/bash', '/bin/sh']);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('bash');
+    expect(info.path).toBe('/bin/bash');
+  });
+
+  it('honours $SHELL when it points at a non-standard prefix that exists', () => {
+    setPlatform('linux');
+    process.env.SHELL = '/opt/nix/bin/zsh';
+    setExisting(['/opt/nix/bin/zsh', '/bin/bash']);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('zsh');
+    expect(info.path).toBe('/opt/nix/bin/zsh');
+  });
+
+  it('falls back to POSIX /bin/sh when only sh exists', () => {
+    setPlatform('linux');
+    setExisting(['/bin/sh']);
+
+    const info = detectShell();
+
+    expect(info.type).toBe('sh');
+    expect(info.path).toBe('/bin/sh');
+  });
+
+  it('falls back to $SHELL string when no probed candidate exists on disk', () => {
+    setPlatform('linux');
+    process.env.SHELL = '/nonexistent/nushell';
+    setExisting([]);
+
+    const info = detectShell();
+
+    // Detector returns the $SHELL string as-is when nothing on the
+    // probed list resolves, and infers 'unknown' since it does not
+    // match any known shell name.
+    expect(info.path).toBe('/nonexistent/nushell');
+    expect(info.type).toBe('unknown');
+  });
+});
+
+describe('detectShell — caching', () => {
+  beforeEach(() => {
+    _resetDetectShellCacheForTests();
+    setPlatform('linux');
+    delete process.env.SHELL;
+  });
+
+  afterEach(cleanup);
+
+  it('re-probes the filesystem when the cache is dropped (profile change simulation)', () => {
+    let probeCalls = 0;
+    _setFsProbeForTests((p) => {
+      probeCalls += 1;
+      return p === '/bin/bash';
+    });
+
+    const first = detectShell();
+    expect(first.type).toBe('bash');
+    const callsAfterFirst = probeCalls;
+
+    // Cache hit — should NOT re-probe.
+    detectShell();
+    expect(probeCalls).toBe(callsAfterFirst);
+
+    // User installs zsh mid-session.
+    _resetDetectShellCacheForTests();
+    _setFsProbeForTests((p) => p === '/bin/zsh' || p === '/bin/bash');
+
+    const second = detectShell();
+    expect(second.type).toBe('zsh');
+  });
+});
+
+describe('shellSpawnArgs', () => {
+  it('emits -c for bash / zsh / sh', () => {
+    expect(shellSpawnArgs({ type: 'bash', path: '/bin/bash' })).toEqual({
+      file: '/bin/bash',
+      prefixArgs: ['-c'],
+    });
+    expect(shellSpawnArgs({ type: 'zsh', path: '/bin/zsh' })).toEqual({
+      file: '/bin/zsh',
+      prefixArgs: ['-c'],
+    });
+    expect(shellSpawnArgs({ type: 'sh', path: '/bin/sh' })).toEqual({
+      file: '/bin/sh',
+      prefixArgs: ['-c'],
+    });
+  });
+
+  it('emits -NoProfile -Command for PowerShell', () => {
+    expect(shellSpawnArgs({ type: 'powershell', path: 'C:\\pwsh.exe' })).toEqual({
+      file: 'C:\\pwsh.exe',
+      prefixArgs: ['-NoProfile', '-Command'],
+    });
+  });
+
+  it('emits /d /s /c for cmd.exe', () => {
+    expect(shellSpawnArgs({ type: 'cmd', path: 'C:\\cmd.exe' })).toEqual({
+      file: 'C:\\cmd.exe',
+      prefixArgs: ['/d', '/s', '/c'],
+    });
+  });
+});
+
+describe('bash / shell tool descriptions reflect the detected shell', () => {
+  beforeEach(() => {
+    _resetDetectShellCacheForTests();
+    // Ensure $SHELL does not shadow the priority-ordered probe list —
+    // `posixCandidates()` places `$SHELL` first when set.
+    delete process.env.SHELL;
+  });
+
+  afterEach(cleanup);
+
+  it('bash description says "powershell" on Windows when pwsh is present', () => {
+    setPlatform('win32');
+    process.env.ProgramFiles = 'C:\\Program Files';
+    setExisting(['C:\\Program Files\\PowerShell\\7\\pwsh.exe']);
+
+    const desc = buildBashDescription();
+    expect(desc).toMatch(/^Execute a powershell command/);
+  });
+
+  it('bash description says "zsh" on macOS when zsh is present', () => {
+    setPlatform('darwin');
+    setExisting(['/bin/zsh', '/bin/bash']);
+
+    const desc = buildBashDescription();
+    expect(desc).toMatch(/^Execute a zsh command/);
+  });
+
+  it('bash description falls back to "bash" on Linux without zsh', () => {
+    setPlatform('linux');
+    setExisting(['/bin/bash']);
+
+    const desc = buildBashDescription();
+    expect(desc).toMatch(/^Execute a bash command/);
+  });
+
+  it('bashTool.toFunctionSchema() returns a fresh description each call', () => {
+    setPlatform('linux');
+    setExisting(['/bin/bash']);
+
+    const first = bashTool.toFunctionSchema();
+    expect(first.description).toMatch(/^Execute a bash command/);
+
+    setExisting(['/bin/zsh', '/bin/bash']);
+    const second = bashTool.toFunctionSchema();
+    expect(second.description).toMatch(/^Execute a zsh command/);
+  });
+
+  it('bashTool.description getter also reflects the detected shell', () => {
+    setPlatform('linux');
+    setExisting(['/bin/zsh', '/bin/bash']);
+
+    expect(bashTool.description).toMatch(/^Execute a zsh command/);
+    // Preserved usage/security sections from the original description.
+    expect(bashTool.description).toContain('Security');
+    expect(bashTool.description).toContain('emit those tool calls in the same response');
+  });
+
+  it('shell tool description mirrors the same detection logic', () => {
+    setPlatform('darwin');
+    setExisting(['/bin/zsh']);
+
+    expect(buildShellDescription()).toMatch(/^Execute a zsh command/);
+    expect(shellTool.description).toMatch(/^Execute a zsh command/);
+    expect(shellTool.toFunctionSchema().description).toMatch(/^Execute a zsh command/);
+  });
+});


### PR DESCRIPTION
## What

Follows Cline PR #12331 pattern to make the bash / shell tool description reflect the shell the OS will actually dispatch to.

## Changes

- `src/tool/tools/shell/id.ts` — new `detectShell()` probes platform-specific candidates in priority order:
  - **Windows**: pwsh 7 (Program Files) > pwsh 7 (Program Files x86) > pwsh (LocalAppData WindowsApps) > Windows PowerShell 5.1 > cmd.exe > %COMSPEC% fallback
  - **macOS/Linux**: $SHELL (if it exists) > /bin/zsh > /bin/bash > /bin/sh > standard prefixes (usr/bin, usr/local/bin, opt/homebrew/bin)
  - Result cached for 30s TTL so profile changes (installing pwsh, switching login shell) are picked up mid-session without paying the `existsSync` cost on every tool call.
  - New `shellSpawnArgs()` maps a detected shell to `(executable, prefixArgs)` so PowerShell gets `-NoProfile -Command`, cmd gets `/d /s /c`, and POSIX shells get `-c`.
  - Filesystem probe is dependency-injected via `_setFsProbeForTests` so tests can spoof different platform layouts without touching real disk.

- `src/tool/tools/bash.ts` and `src/tool/tools/shell.ts`
  - New `buildBashDescription()` / `buildShellDescription()` render the description as `Execute a <detected> command in ...` so the model sees the shell that will actually run.
  - Exported `bashTool` / `shellTool` now wrap the `defineTool` result with a `description` getter and `toFunctionSchema()` override, so both surfaces are regenerated on every access and reflect the currently-cached shell.
  - Spawn call now uses the detected shell explicitly (`spawn(shellFile, [...prefix, cmd])`) instead of `shell: true`, so cross-platform semantics match what the description advertises.

- `tests/tool/tools/shell-detect.test.ts` — 21 new cases:
  - Windows priority order (pwsh 7 > pwsh x86 > WindowsApps stub > PowerShell 5.1 > cmd.exe > COMSPEC).
  - POSIX priority order ($SHELL > zsh > bash > sh; fallback when nothing exists).
  - Cache refresh on profile change simulation.
  - `shellSpawnArgs` mapping for every shell type.
  - Dynamic description propagation through `bashTool.description`, `bashTool.toFunctionSchema()`, and equivalents on `shellTool`.

## Verification

```bash
npm run typecheck   # clean
npm run lint        # 0 errors
npm run format:check # clean
npm test            # 3138 passed, 3 skipped
npm run build       # clean
```

Coverage: 64.58% lines (well above 40% CI floor).

## Done when checklist

- [x] Bash tool detects pwsh on Windows when available (not just powershell)
- [x] Bash tool detects zsh on macOS when available (not just bash)
- [x] Tool description dynamically reflects detected shell
- [x] Shell is re-detected per-session (not global singleton)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Coverage >= 40%

Reference: [Cline PR #12331](https://github.com/cline/cline/pull/12331)

Closes #1070