### PR TITLE
docs(tools): document optional tree-sitter grammar dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,58 @@ npm install
 npm run build
 ```
 
+## Optional Dependencies
+
+Alexi ships with a small set of native tree-sitter grammars that power **AST-based
+symbol extraction** for the code-context and definitions tooling:
+
+- `tree-sitter`
+- `tree-sitter-typescript`
+- `tree-sitter-javascript`
+- `tree-sitter-bash`
+
+These grammars are **optional**. The `definitions` tool ships with a built-in
+regex-based extractor for TypeScript, JavaScript, Python, and Bash and will
+continue to work when the grammars are not installed. AST-based extraction is
+strictly an upgrade path (see [`docs/TOOLS.md`](docs/TOOLS.md#definitions-tool)
+for the comparison).
+
+### When to install the grammars
+
+Install the grammar packages if any of the following applies:
+
+- You want the most accurate symbol extraction for large TypeScript/JavaScript
+  codebases (nested classes, complex generics, computed method names).
+- You use the repo-map / context features under `src/context/` (these depend on
+  the AST parsers today).
+- You are contributing to Alexi and need the full test suite (the tree-sitter
+  tests are skipped when the grammars are missing).
+
+### When you can skip them
+
+Skip the grammars if you only need:
+
+- Chat, routing, and session management.
+- The `definitions` tool's regex-based extraction (works out of the box).
+- A slimmer install. The four native packages add roughly **~67 MB** to
+  `node_modules` and require a C++ toolchain on non-prebuilt platforms.
+
+### Installation
+
+```bash
+# Install grammars alongside Alexi
+npm install tree-sitter tree-sitter-typescript tree-sitter-javascript tree-sitter-bash
+```
+
+When the grammars are absent, tree-sitter-backed features fall back to the
+regex path automatically — no configuration required.
+
+> **Note:** In the current release these packages are still declared as
+> `dependencies` in `package.json` and are therefore installed by default.
+> The move to `optionalDependencies` / `peerDependencies` is tracked in a
+> follow-up issue; the fallback path described above is already implemented
+> in the `definitions` tool and safe to rely on going forward.
+
 ## Quick Start
 
 ### 1. Install Dependencies

--- a/contributing.md
+++ b/contributing.md
@@ -49,6 +49,33 @@ Please be respectful and professional in all interactions. We welcome contributi
    npm test
    ```
 
+### Optional: tree-sitter grammars
+
+Alexi's AST-based symbol extraction (used by the repo-map / context features
+and the AST path of the `definitions` tool) relies on native tree-sitter
+grammars. These are **optional** — the tool falls back to regex-based
+extraction when they are missing — but contributors are encouraged to install
+them locally so the full test suite runs:
+
+```bash
+npm install tree-sitter tree-sitter-typescript tree-sitter-javascript tree-sitter-bash
+```
+
+Notes for contributors:
+
+- CI always has the grammars installed — they are currently declared as
+  regular `dependencies` in `package.json` (with a planned migration to
+  optional dependencies tracked in a separate issue), so
+  `npm run test:coverage` runs the full matrix on every PR. Skipping them
+  locally is fine for docs-only or non-context changes, but any PR touching
+  `src/context/**`, `src/tool/tools/definitions.ts`, or their tests should
+  be validated against a local install.
+- The grammars require a C++ toolchain on platforms that don't ship prebuilt
+  binaries. If `npm install` fails on your machine, either install a
+  toolchain or omit the grammars locally and rely on CI.
+- See [`docs/TOOLS.md`](docs/TOOLS.md#definitions-tool) for the difference
+  between AST-based and regex-based extraction.
+
 ## Development Workflow
 
 ### Running in Development Mode

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -48,6 +48,26 @@ This document provides guidelines and instructions for contributing to the proje
    node dist/cli/program.js --help
    ```
 
+### Optional: tree-sitter grammars
+
+The AST-based symbol extraction path used by `src/context/**` and the AST
+mode of the `definitions` tool relies on native tree-sitter grammars. These
+grammars are optional; the `definitions` tool falls back to a built-in
+regex-based extractor when they are missing. Contributors are encouraged to
+install them so the tree-sitter test files run locally:
+
+```bash
+npm install tree-sitter tree-sitter-typescript tree-sitter-javascript tree-sitter-bash
+```
+
+CI always has the grammars installed (they are currently declared as regular
+`dependencies` in `package.json`, with a planned migration to optional
+dependencies tracked in a follow-up issue), so `npm run test:coverage`
+exercises both paths on every PR. See
+[`docs/TOOLS.md`](TOOLS.md#definitions-tool) for the AST-vs-regex comparison
+and the [Optional Dependencies](../README.md#optional-dependencies) section
+of the README for install size and platform caveats.
+
 ### Environment Configuration
 
 Create a `.env` file (never commit this file) with:

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -6,6 +6,92 @@ For the full catalogue of tools and their parameters see
 [`src/tool/tools/definitions.ts`](../src/tool/tools/definitions.ts) and the
 individual implementations under `src/tool/tools/`.
 
+## Definitions Tool
+
+The `definitions` tool extracts code definitions (classes, functions,
+interfaces, types, constants, enums, methods) from a single source file. It
+supports TypeScript, JavaScript, Python, and Bash out of the box and is
+implemented in
+[`src/tool/tools/definitions.ts`](../src/tool/tools/definitions.ts).
+
+### Two extraction modes
+
+Alexi supports two symbol extraction strategies. Which one runs depends on
+whether the optional tree-sitter grammars (`tree-sitter`,
+`tree-sitter-typescript`, `tree-sitter-javascript`, `tree-sitter-bash`) are
+installed in the current `node_modules`.
+
+- **Regex-based extraction (always available).** The default path. A curated
+  set of regular expressions matches top-level and class-scoped declarations
+  in the source text. Zero native dependencies, zero build toolchain, works
+  on every platform. Implemented directly inside
+  [`src/tool/tools/definitions.ts`](../src/tool/tools/definitions.ts).
+- **AST-based extraction (requires tree-sitter grammars).** The upgraded
+  path used by the repo-map and code-context features under
+  [`src/context/`](../src/context/). Each source file is parsed into a real
+  syntax tree via `tree-sitter` and the corresponding grammar package, then
+  symbols are walked with proper scoping rules. Implemented in
+  [`src/context/treeSitter.ts`](../src/context/treeSitter.ts) and
+  [`src/context/symbols.ts`](../src/context/symbols.ts).
+
+When the tree-sitter grammars are missing, the tool automatically falls back
+to the regex path — there is no configuration flag, no error message to the
+user, and no need to gate calls in a client.
+
+### Side-by-side comparison
+
+| Aspect                       | Regex-based (default)                    | AST-based (tree-sitter)                        |
+| ---------------------------- | ---------------------------------------- | ---------------------------------------------- |
+| Requires native deps         | No                                       | Yes (`tree-sitter*` packages, ~67 MB)          |
+| Requires C++ toolchain       | No                                       | Yes on platforms without prebuilt binaries     |
+| Startup cost                 | Negligible                               | Small (lazy per-language parser initialisation) |
+| Handles nested classes       | Partial (class bodies scanned linearly)  | Full (real scope tree)                         |
+| Handles complex generics     | Best-effort                              | Accurate                                       |
+| Handles computed names       | No                                       | Yes                                            |
+| Handles TSX/JSX              | Yes (regex covers `.tsx`/`.jsx`)         | Yes (dedicated TSX parser)                     |
+| Bash function extraction     | POSIX + `function` keyword               | AST-driven, matches Aider's tag query          |
+| Python support               | Yes (class/def)                          | Not currently wired                            |
+| Failure mode when unsupported| Returns `Unsupported file type` error    | Falls back to regex path                       |
+
+For most day-to-day usage the regex path is sufficient and its output is
+identical to the AST path on well-formatted, idiomatic source files. Prefer
+AST-based extraction when working with large or unusually structured
+codebases where symbol names must be resolved exactly (for example, repo-map
+generation for a monorepo with heavy use of decorators, mixins, or
+metaprogramming).
+
+### Installing the grammars
+
+To enable AST-based extraction, install the optional grammar packages:
+
+```bash
+npm install tree-sitter tree-sitter-typescript tree-sitter-javascript tree-sitter-bash
+```
+
+See the [Optional Dependencies](../README.md#optional-dependencies) section of
+the README for the rationale, install size (~67 MB), and platform caveats.
+
+### Parameters
+
+```ts
+{
+  filePath: string;                // absolute path or path relative to workdir
+  types?: Array<
+    | 'class'
+    | 'function'
+    | 'interface'
+    | 'type'
+    | 'const'
+    | 'enum'
+    | 'method'
+  >;                               // optional filter; defaults to all
+}
+```
+
+The tool returns `{ filePath, definitions, language }` where each definition
+carries `name`, `type`, `line`, `signature`, and `exported`. Results are
+sorted by line number.
+
 ## Subagent Nesting Depth
 
 Alexi's `task` tool spawns a subagent to handle a self-contained piece of


### PR DESCRIPTION
## What

Adds documentation for the optional tree-sitter grammar dependencies and clarifies how the `definitions` tool behaves with and without the grammars installed.

## Changes

- **README.md** — new "Optional Dependencies" section (after "Installation") covering:
  - When to install the grammars (large codebases, repo-map / context features, full contributor test suite)
  - When to skip them (chat/routing/session use only, slimmer install ~67 MB, no C++ toolchain needed)
  - The install command: `npm install tree-sitter tree-sitter-typescript tree-sitter-javascript tree-sitter-bash`
  - A note that the packages are currently declared as `dependencies` and the migration to optional deps is tracked in a follow-up issue
- **docs/TOOLS.md** — new "Definitions Tool" section with:
  - Description of the two extraction modes (regex-based, AST-based)
  - Side-by-side comparison table (native deps, toolchain, generics, computed names, TSX/JSX, Bash, Python, failure mode)
  - Links to `src/tool/tools/definitions.ts` (regex path) and `src/context/treeSitter.ts` + `src/context/symbols.ts` (AST path)
  - Parameter reference
- **contributing.md** and **docs/CONTRIBUTING.md** — mirrored contributor note explaining when to install the grammars locally and confirming CI always runs with them installed.

## Verification

- `npm run lint`: 0 errors (warnings unchanged)
- `npm run typecheck`: clean
- `npm run format:check`: clean (markdown is prettier-ignored per `.prettierignore`; no formatting drift in `src/` or `tests/`)
- `npm run build`: clean

No source code was modified — the regex-based fallback path already exists in `src/tool/tools/definitions.ts`.

## References

- Research: `.github/research/2026-07-22-research.md` item #2

Closes #1090