### PR TITLE
feat(server): UNIX socket server for remote slash commands (#1100)

### DIFF
--- a/.kilo/package-lock.json
+++ b/.kilo/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@kilocode/plugin": "7.4.15"
+        "@kilocode/plugin": "7.4.16"
       }
     },
     "node_modules/@kilocode/plugin": {
-      "version": "7.4.15",
-      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.4.15.tgz",
-      "integrity": "sha512-mefaR2muELcnzWya7QMspqlGav0tvA7BDGvrEIL3SEnJE9GGlPVxEYFcyHj0+/lzvB4j7qebW6eO3cLntYZtYA==",
+      "version": "7.4.16",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.4.16.tgz",
+      "integrity": "sha512-Rb/sEm1RV3d8DUFeH4PnjPMJDkmuUDdkG17bYQW3QONVRlO2xcoMZS8sl47qok5Hixovp6CX57rdGaP+FBDKLQ==",
       "license": "MIT",
       "dependencies": {
-        "@kilocode/sdk": "7.4.15",
+        "@kilocode/sdk": "7.4.16",
         "effect": "4.0.0-beta.74",
         "zod": "4.1.8"
       },
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@kilocode/sdk": {
-      "version": "7.4.15",
-      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.4.15.tgz",
-      "integrity": "sha512-lTotYGaQejpZrWV1KOvcShzeqyRyVkVNjd6ta1OB94RIy82yTIIamMfAgv5Y5n5OzCx8oz5jgkyoCtlw4lEUqw==",
+      "version": "7.4.16",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.4.16.tgz",
+      "integrity": "sha512-6ftpsR5sebWYd9XPESC9pMGOflTulfsBvoaO1v5cGj67cuE+K6OZnrr2id0jn/1Z5n76VDhf7z+fKwYD+OMk0A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.kilocode/package-lock.json
+++ b/.kilocode/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@kilocode/plugin": "7.4.15"
+        "@kilocode/plugin": "7.4.16"
       }
     },
     "node_modules/@kilocode/plugin": {
-      "version": "7.4.15",
-      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.4.15.tgz",
-      "integrity": "sha512-mefaR2muELcnzWya7QMspqlGav0tvA7BDGvrEIL3SEnJE9GGlPVxEYFcyHj0+/lzvB4j7qebW6eO3cLntYZtYA==",
+      "version": "7.4.16",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.4.16.tgz",
+      "integrity": "sha512-Rb/sEm1RV3d8DUFeH4PnjPMJDkmuUDdkG17bYQW3QONVRlO2xcoMZS8sl47qok5Hixovp6CX57rdGaP+FBDKLQ==",
       "license": "MIT",
       "dependencies": {
-        "@kilocode/sdk": "7.4.15",
+        "@kilocode/sdk": "7.4.16",
         "effect": "4.0.0-beta.74",
         "zod": "4.1.8"
       },
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@kilocode/sdk": {
-      "version": "7.4.15",
-      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.4.15.tgz",
-      "integrity": "sha512-lTotYGaQejpZrWV1KOvcShzeqyRyVkVNjd6ta1OB94RIy82yTIIamMfAgv5Y5n5OzCx8oz5jgkyoCtlw4lEUqw==",
+      "version": "7.4.16",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.4.16.tgz",
+      "integrity": "sha512-6ftpsR5sebWYd9XPESC9pMGOflTulfsBvoaO1v5cGj67cuE+K6OZnrr2id0jn/1Z5n76VDhf7z+fKwYD+OMk0A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -1,0 +1,206 @@
+# Alexi UNIX Socket Server
+
+The Alexi UNIX socket server is a long-running local daemon that exposes
+Alexi's slash-command surface over a UNIX domain socket. Remote clients
+(VS Code extension, JetBrains plugin, desktop app, test harnesses) can
+connect, authenticate, and dispatch slash commands without spawning a
+new `alexi` process per turn.
+
+The server is deliberately local-only: it never listens on TCP. Its
+sole transport is a UNIX domain socket bound under the user's home
+directory.
+
+## Quick start
+
+```bash
+# In terminal 1 - start the server
+alexi server start
+# -> Alexi server listening on /home/you/.alexi/server.sock
+# -> Auth token file: /home/you/.alexi/server-token
+
+# In terminal 2 - check status
+alexi server status
+# -> Server is running on /home/you/.alexi/server.sock
+
+# In terminal 3 - talk to it with plain netcat
+TOKEN=$(cat ~/.alexi/server-token)
+{
+  printf '{"id":"1","type":"auth","token":"%s"}\n' "$TOKEN"
+  printf '{"id":"2","type":"command","command":"/help"}\n'
+  printf '{"id":"3","type":"exit"}\n'
+} | nc -U ~/.alexi/server.sock
+
+# Later, shut the server down (SIGTERM the process from terminal 1)
+alexi server stop
+```
+
+## CLI subcommands
+
+| Command                | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| `alexi server start`   | Bind the socket, generate a token if needed, block until exit |
+| `alexi server stop`    | Send an exit frame; user must SIGTERM the daemon to fully stop|
+| `alexi server status`  | Report whether a running server is reachable on the socket    |
+
+All three accept `--socket <path>` for tests or non-default deployments.
+`alexi server status --json` emits machine-readable status for scripts.
+
+## Files
+
+| Path                          | Mode | Purpose                                       |
+| ----------------------------- | ---- | --------------------------------------------- |
+| `~/.alexi/server.sock`        | 0600 | UNIX domain socket the server binds to        |
+| `~/.alexi/server-token`       | 0600 | Shared token clients present in `auth` frames |
+
+The socket and token file are placed under `~/.alexi/` (mode 0700).
+Anyone with read access to the token file already has connect access to
+the socket, so the token is not a cryptographic bearer — it exists to
+prevent accidental cross-user connects on shared machines and to force
+clients to explicitly prove local filesystem access.
+
+## Wire protocol
+
+The wire format is **line-delimited JSON** (LDJSON): each frame is
+exactly one JSON object followed by a `\n` byte. The current protocol
+version reported in the `hello` banner is `1`.
+
+### Server -> client frames
+
+`hello` is sent unprompted immediately after a client connects:
+
+```json
+{"type":"hello","version":"1.18.9","protocol":1}
+```
+
+All request replies use one of two shapes:
+
+```json
+{"id":"<req-id>","type":"response","ok":true,"result":<any>}
+{"id":"<req-id>","type":"error","ok":false,"error":{"code":"<CODE>","message":"..."}}
+```
+
+The `id` in the reply matches the `id` in the request. The parser
+returns an error with `id: ""` for frames that cannot be parsed at all
+(invalid JSON, missing `id`).
+
+### Client -> server frames
+
+Every request carries an `id` (any non-empty string; clients typically
+use a UUID) and a `type` discriminator.
+
+| type              | Payload fields         | Auth required | Description                                          |
+| ----------------- | ---------------------- | ------------- | ---------------------------------------------------- |
+| `auth`            | `token`                | no            | Present the shared token                             |
+| `ping`            | -                      | no            | Health check; returns `{ pong: true, timestamp }`    |
+| `session.create`  | -                      | yes           | Allocate a new isolated session, returns `sessionId` |
+| `session.list`    | -                      | yes           | List all sessions this server has                    |
+| `command`         | `command`, `sessionId?`| yes           | Dispatch a slash command                             |
+| `exit`            | -                      | yes           | Close this client's connection (server keeps running)|
+
+### Authentication flow
+
+1. Client connects to the socket.
+2. Server sends the `hello` banner.
+3. Client sends `{ id, type: "auth", token }`.
+4. Server replies with `response` (`authenticated: true`) or `error`
+   (`INVALID_TOKEN`).
+5. Only after a successful `auth` may the client send `session.*` or
+   `command` frames. `ping` and `auth` are the only frames allowed
+   pre-authentication; other frames get `AUTH_REQUIRED`.
+
+### Dispatching a command
+
+Slash commands are dispatched through Alexi's shared command registry
+(the same one that powers the interactive REPL). A `command` frame
+carries the full slash line including the leading `/`:
+
+```json
+{"id":"c-1","type":"command","command":"/review src/foo.ts","sessionId":"abc"}
+```
+
+The server tokenises the line by whitespace and calls
+`getCommandRegistry().execute(name, args)`. Two built-ins are handled
+inline before hitting the registry:
+
+- `/help` returns `{ commands: [{ name, description }, ...] }` for
+  client-side rendering. No template is rendered.
+- `/exit` returns `{ closed: true }` and then closes only this client's
+  socket. It never terminates the daemon.
+
+### Session isolation
+
+Each remote client can create one or more sessions with
+`session.create`. Every session gets its own in-memory `SessionManager`
+instance, keyed by a nanoid. Sessions are visible to any authenticated
+client on the same server (there is no per-client scoping).
+
+If a `command` frame omits `sessionId`, the server creates a fresh
+session on the fly and returns its id in the response `sessionId`
+field. Passing a `sessionId` that does not exist returns an
+`SESSION_NOT_FOUND` error.
+
+Remote sessions are **separate** from the host CLI's own session store
+in `~/.alexi/sessions/` — remote sessions do not currently persist
+across server restarts. That is intentional for the initial cut and
+matches the "isolated" requirement in the design.
+
+### Error codes
+
+| Code                       | Meaning                                                        |
+| -------------------------- | -------------------------------------------------------------- |
+| `AUTH_REQUIRED`            | Request sent before authentication                             |
+| `INVALID_TOKEN`            | Token in `auth` frame did not match                            |
+| `INVALID_JSON`             | Frame body could not be JSON.parse'd                           |
+| `INVALID_REQUEST`          | JSON parsed but did not match the request schema               |
+| `INVALID_COMMAND`          | Command frame value did not start with `/`                     |
+| `EMPTY_FRAME`              | Empty line sent as a frame                                     |
+| `COMMAND_NOT_FOUND`        | Slash command name not registered                              |
+| `INVALID_ARGUMENTS`        | Command was found but arguments failed validation              |
+| `COMMAND_EXECUTION_FAILED` | Command template rendering threw an unexpected error           |
+| `SESSION_NOT_FOUND`        | `sessionId` in request does not match any live remote session  |
+| `INTERNAL_ERROR`           | Uncaught error inside the dispatcher; safe to retry            |
+
+## Reference client (Node.js)
+
+```ts
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const socketPath = path.join(os.homedir(), '.alexi', 'server.sock');
+const token = fs.readFileSync(path.join(os.homedir(), '.alexi', 'server-token'), 'utf-8').trim();
+
+const socket = net.createConnection(socketPath);
+socket.setEncoding('utf-8');
+
+let buffer = '';
+socket.on('data', (chunk: string) => {
+  buffer += chunk;
+  let idx = buffer.indexOf('\n');
+  while (idx !== -1) {
+    const line = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 1);
+    console.log('recv:', JSON.parse(line));
+    idx = buffer.indexOf('\n');
+  }
+});
+
+socket.on('connect', () => {
+  const send = (obj: unknown) => socket.write(JSON.stringify(obj) + '\n');
+  send({ id: '1', type: 'auth', token });
+  send({ id: '2', type: 'command', command: '/help' });
+  send({ id: '3', type: 'exit' });
+});
+```
+
+## Testing
+
+The server is exercised by three test files:
+
+- `tests/server/protocol.test.ts` — frame encoding, request parsing, slash-command tokenisation, and buffered LDJSON extraction.
+- `tests/server/auth.test.ts` — token generation, file mode, safe compare, and default path resolution.
+- `tests/server/socket.test.ts` — end-to-end lifecycle: connect, auth, dispatch, session isolation, and the `/exit` semantics.
+
+All three run under vitest (`node` environment, no real SAP credentials
+required — the server does not touch providers).

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -16,6 +16,7 @@ import { registerAgentCommand } from './agent.js';
 import { registerCodeReviewCommand } from './codeReview.js';
 import { registerPluginCommand } from './plugin.js';
 import { registerRevertCommand } from './revert.js';
+import { registerServerCommand } from './server.js';
 
 /**
  * Register all CLI commands on the program
@@ -35,6 +36,7 @@ export function registerAllCommands(program: Command): void {
   registerCodeReviewCommand(program);
   registerPluginCommand(program);
   registerRevertCommand(program);
+  registerServerCommand(program);
 }
 
 export {
@@ -51,4 +53,5 @@ export {
   registerCodeReviewCommand,
   registerPluginCommand,
   registerRevertCommand,
+  registerServerCommand,
 };

--- a/src/cli/commands/server.ts
+++ b/src/cli/commands/server.ts
@@ -1,0 +1,182 @@
+/**
+ * `alexi server` — manage the local UNIX socket server for remote
+ * slash commands. See `docs/SERVER.md` for the wire protocol.
+ *
+ *   alexi server start   Launch the socket server on ~/.alexi/server.sock
+ *   alexi server stop    Ask a running server to shut down cleanly
+ *   alexi server status  Report whether a server is currently listening
+ */
+
+import fs from 'node:fs';
+import net from 'node:net';
+import type { Command } from 'commander';
+import {
+  defaultSocketPath,
+  defaultTokenPath,
+  loadOrCreateToken,
+  readTokenIfExists,
+} from '../../server/auth.js';
+import { startSocketServer } from '../../server/socket.js';
+import { encodeFrame } from '../../server/protocol.js';
+import { registerBuiltInCommands } from '../../command/index.js';
+
+interface ServerStartOptions {
+  socket?: string;
+  detach?: boolean;
+}
+
+interface ServerStopOptions {
+  socket?: string;
+}
+
+interface ServerStatusOptions {
+  socket?: string;
+  json?: boolean;
+}
+
+/**
+ * Ask a running server on `socketPath` to stop. Since a client `exit`
+ * only closes its own connection, we implement `stop` by sending a
+ * special server-side control command: opening a connection and simply
+ * unlinking the socket file is racy, so we send `exit` then destroy the
+ * socket. The server on the other end is killed via SIGTERM by the
+ * caller (systemd / the shell); this helper is here to check liveness.
+ *
+ * Returns `true` if the server responded on the socket, `false` if the
+ * socket path does not exist or the connection was refused.
+ */
+export function pingSocket(socketPath: string, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (!fs.existsSync(socketPath)) {
+      resolve(false);
+      return;
+    }
+    const socket = net.createConnection(socketPath);
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+    socket.once('connect', () => {
+      clearTimeout(timer);
+      socket.end();
+      resolve(true);
+    });
+    socket.once('error', () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+export function registerServerCommand(program: Command): void {
+  const server = program.command('server').description('Manage the Alexi UNIX socket server');
+
+  server
+    .command('start')
+    .description('Start the UNIX socket server for remote slash commands')
+    .option('-s, --socket <path>', 'Socket path (default ~/.alexi/server.sock)')
+    .option(
+      '-d, --detach',
+      'Run the server in the current process and block until SIGINT/SIGTERM (default)'
+    )
+    .action(async (opts: ServerStartOptions) => {
+      try {
+        // Ensure built-in slash commands are loaded so remote clients
+        // can dispatch /review, /explain, /help, etc.
+        registerBuiltInCommands();
+
+        const socketPath = opts.socket ?? defaultSocketPath();
+        const tokenPath = defaultTokenPath();
+        const token = loadOrCreateToken(tokenPath);
+
+        const handle = await startSocketServer({ socketPath, token });
+        console.log(`Alexi server listening on ${handle.socketPath}`);
+        console.log(`Auth token file: ${tokenPath}`);
+
+        const shutdown = async (): Promise<void> => {
+          try {
+            await handle.stop();
+          } finally {
+            process.exit(0);
+          }
+        };
+        process.once('SIGINT', shutdown);
+        process.once('SIGTERM', shutdown);
+      } catch (e) {
+        console.error(`Failed to start server: ${e instanceof Error ? e.message : String(e)}`);
+        process.exit(1);
+      }
+    });
+
+  server
+    .command('stop')
+    .description('Stop a running Alexi socket server (removes the socket file)')
+    .option('-s, --socket <path>', 'Socket path (default ~/.alexi/server.sock)')
+    .action(async (opts: ServerStopOptions) => {
+      const socketPath = opts.socket ?? defaultSocketPath();
+      if (!fs.existsSync(socketPath)) {
+        console.log('No running server (socket file not found)');
+        return;
+      }
+      const alive = await pingSocket(socketPath);
+      if (!alive) {
+        // Stale socket file left behind by a previous crashed process.
+        try {
+          fs.unlinkSync(socketPath);
+          console.log(`Removed stale socket file at ${socketPath}`);
+        } catch (e) {
+          console.error(
+            `Failed to remove stale socket: ${e instanceof Error ? e.message : String(e)}`
+          );
+          process.exit(1);
+        }
+        return;
+      }
+      // Send an `exit` frame with a client id — the server will close
+      // only that client connection. To fully stop the daemon the user
+      // must signal the server process itself. We emit a hint.
+      try {
+        const socket = net.createConnection(socketPath);
+        socket.once('connect', () => {
+          const token = readTokenIfExists() ?? '';
+          socket.write(encodeFrame({ type: 'hello', version: '0', protocol: 1 }));
+          // Best-effort: auth then exit.
+          if (token) {
+            socket.write(JSON.stringify({ id: 'stop-1', type: 'auth', token }) + '\n');
+          }
+          socket.write(JSON.stringify({ id: 'stop-2', type: 'exit' }) + '\n');
+          socket.end();
+        });
+        socket.once('error', () => {
+          // Ignore
+        });
+      } catch {
+        // Ignore.
+      }
+      console.log('Sent exit signal. To fully stop the daemon, send SIGTERM to its PID.');
+    });
+
+  server
+    .command('status')
+    .description('Report whether an Alexi socket server is running')
+    .option('-s, --socket <path>', 'Socket path (default ~/.alexi/server.sock)')
+    .option('--json', 'Emit machine-readable JSON')
+    .action(async (opts: ServerStatusOptions) => {
+      const socketPath = opts.socket ?? defaultSocketPath();
+      const exists = fs.existsSync(socketPath);
+      const alive = exists ? await pingSocket(socketPath) : false;
+      if (opts.json) {
+        console.log(JSON.stringify({ socketPath, exists, alive }, null, 2));
+        return;
+      }
+      if (!exists) {
+        console.log(`No server: ${socketPath} does not exist`);
+        return;
+      }
+      if (alive) {
+        console.log(`Server is running on ${socketPath}`);
+      } else {
+        console.log(`Socket file exists at ${socketPath} but no server responded (stale)`);
+      }
+    });
+}

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,110 @@
+/**
+ * Token-based authentication for the UNIX socket server.
+ *
+ * A single shared token is generated on first server start and stored at
+ * `~/.alexi/server-token` with mode 0600 (owner read/write only). Remote
+ * clients read that file and echo the token in an `auth` frame to prove
+ * they have local filesystem access to the user's home directory.
+ *
+ * This is deliberately a low-ceremony scheme:
+ *   - The socket itself lives under `~/.alexi/` (mode 0700), so anyone
+ *     with connect access already has read access to the token file.
+ *   - The token protects against accidental cross-user connects on
+ *     shared machines and against non-privileged processes that ran
+ *     under a different UID.
+ *   - The token is NOT a cryptographic bearer for network use — the
+ *     socket never listens on TCP.
+ */
+
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Default location of the server token, resolved from `~/.alexi/`.
+ * Exposed as a getter so tests can override `HOME` at runtime.
+ */
+export function defaultTokenPath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.alexi', 'server-token');
+}
+
+/**
+ * Default location of the UNIX domain socket. Exposed for both the
+ * server (bind) and clients (connect).
+ */
+export function defaultSocketPath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.alexi', 'server.sock');
+}
+
+/**
+ * Generate a fresh 32-byte random token, hex-encoded (64 chars). Uses
+ * `crypto.randomBytes` — sufficient for a local file-backed shared
+ * secret.
+ */
+export function generateToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+/**
+ * Ensure a token file exists at `tokenPath`. If missing, generate a new
+ * token, write it with mode 0600, and return it. If present, read and
+ * return the existing token. The directory is created with mode 0700
+ * when it does not exist.
+ *
+ * On systems where `fs.chmodSync` is a no-op (Windows), the token is
+ * still written but the mode is best-effort.
+ */
+export function loadOrCreateToken(tokenPath: string = defaultTokenPath()): string {
+  const dir = path.dirname(tokenPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+
+  if (fs.existsSync(tokenPath)) {
+    const existing = fs.readFileSync(tokenPath, 'utf-8').trim();
+    if (existing.length > 0) {
+      return existing;
+    }
+  }
+
+  const token = generateToken();
+  fs.writeFileSync(tokenPath, token, { mode: 0o600 });
+  try {
+    // Some filesystems (mostly Windows) will silently ignore this.
+    fs.chmodSync(tokenPath, 0o600);
+  } catch {
+    // Best effort.
+  }
+  return token;
+}
+
+/**
+ * Constant-time compare two tokens. Returns `false` if lengths differ,
+ * without doing an early-exit character compare.
+ */
+export function safeCompareToken(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    return false;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+/**
+ * Read an existing token file. Returns `null` if the file does not
+ * exist or is empty. Does not create the file.
+ */
+export function readTokenIfExists(tokenPath: string = defaultTokenPath()): string | null {
+  if (!fs.existsSync(tokenPath)) {
+    return null;
+  }
+  const value = fs.readFileSync(tokenPath, 'utf-8').trim();
+  return value.length > 0 ? value : null;
+}

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1,0 +1,209 @@
+/**
+ * UNIX socket server protocol
+ *
+ * Line-delimited JSON (LDJSON): each frame is exactly one JSON object
+ * terminated by a `\n` byte. This keeps the wire format trivial for
+ * remote clients (`nc -U`, IDE plugins, test harnesses) while still
+ * being strongly typed on both ends.
+ *
+ * Message shapes:
+ *
+ *   Client -> Server (request):
+ *     { id, type: 'auth',           token }
+ *     { id, type: 'ping' }
+ *     { id, type: 'command',        command, sessionId? }   // "/help", "/foo a b"
+ *     { id, type: 'session.create' }
+ *     { id, type: 'session.list' }
+ *     { id, type: 'exit' }                                   // close this client
+ *
+ *   Server -> Client:
+ *     { type: 'hello',   version, protocol }                 // sent on connect
+ *     { id, type: 'response', ok: true,  result }
+ *     { id, type: 'error',    ok: false, error: { code, message } }
+ *
+ * Auth: the server sends `hello`, then rejects every non-`auth`/`ping`
+ * request with `AUTH_REQUIRED` until the client sends a valid `auth`
+ * frame. See {@link src/server/auth.ts} for token generation/storage.
+ */
+
+import { z } from 'zod';
+
+/** Wire-format protocol version. Bump when adding breaking changes. */
+export const PROTOCOL_VERSION = 1;
+
+// ============ Request Schemas ============
+
+const RequestBaseSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const AuthRequestSchema = RequestBaseSchema.extend({
+  type: z.literal('auth'),
+  token: z.string().min(1),
+});
+
+export const PingRequestSchema = RequestBaseSchema.extend({
+  type: z.literal('ping'),
+});
+
+export const CommandRequestSchema = RequestBaseSchema.extend({
+  type: z.literal('command'),
+  /**
+   * Full slash-command line including the leading `/`. E.g. `/help` or
+   * `/review src/foo.ts`. Whitespace-separated tokens after the command
+   * name are passed to the command's positional arguments.
+   */
+  command: z.string().min(1),
+  sessionId: z.string().optional(),
+});
+
+export const SessionCreateRequestSchema = RequestBaseSchema.extend({
+  type: z.literal('session.create'),
+});
+
+export const SessionListRequestSchema = RequestBaseSchema.extend({
+  type: z.literal('session.list'),
+});
+
+export const ExitRequestSchema = RequestBaseSchema.extend({
+  type: z.literal('exit'),
+});
+
+export const RequestSchema = z.discriminatedUnion('type', [
+  AuthRequestSchema,
+  PingRequestSchema,
+  CommandRequestSchema,
+  SessionCreateRequestSchema,
+  SessionListRequestSchema,
+  ExitRequestSchema,
+]);
+
+export type Request = z.infer<typeof RequestSchema>;
+export type AuthRequest = z.infer<typeof AuthRequestSchema>;
+export type CommandRequest = z.infer<typeof CommandRequestSchema>;
+
+// ============ Response Types ============
+
+export interface HelloMessage {
+  type: 'hello';
+  version: string;
+  protocol: number;
+}
+
+export interface SuccessResponse<T = unknown> {
+  id: string;
+  type: 'response';
+  ok: true;
+  result: T;
+}
+
+export interface ErrorResponse {
+  id: string;
+  type: 'error';
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+export type Response = SuccessResponse | ErrorResponse;
+export type ServerMessage = HelloMessage | Response;
+
+// ============ Parsing / Encoding ============
+
+/**
+ * Encode a server-to-client message as a single LDJSON frame terminated
+ * by `\n`. Never returns undefined; if `JSON.stringify` throws (e.g. a
+ * circular reference in `result`), it will propagate to the caller so
+ * the connection handler can convert it into an error frame.
+ */
+export function encodeFrame(message: ServerMessage): string {
+  return JSON.stringify(message) + '\n';
+}
+
+/**
+ * Parse and validate a single client request frame.
+ *
+ * Returns a typed {@link Request} on success, or a discriminated failure
+ * describing the problem. Callers should treat parse failures as
+ * protocol violations and reply with an `ErrorResponse`.
+ *
+ * Note: the incoming line must NOT include the trailing `\n` — the
+ * framing layer strips it before calling this function.
+ */
+export function parseRequest(
+  line: string
+): { ok: true; request: Request } | { ok: false; code: string; message: string } {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return { ok: false, code: 'EMPTY_FRAME', message: 'Empty frame' };
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(trimmed);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, code: 'INVALID_JSON', message: `Invalid JSON: ${detail}` };
+  }
+
+  const parsed = RequestSchema.safeParse(json);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const at = first?.path.length ? ` at ${first.path.join('.')}` : '';
+    const msg = first ? `${first.message}${at}` : 'Invalid request shape';
+    return { ok: false, code: 'INVALID_REQUEST', message: msg };
+  }
+  return { ok: true, request: parsed.data };
+}
+
+/**
+ * Build a success response frame for a given request id.
+ */
+export function success<T>(id: string, result: T): SuccessResponse<T> {
+  return { id, type: 'response', ok: true, result };
+}
+
+/**
+ * Build an error response frame for a given request id.
+ */
+export function failure(id: string, code: string, message: string): ErrorResponse {
+  return { id, type: 'error', ok: false, error: { code, message } };
+}
+
+/**
+ * Split a slash-command line like `/foo bar baz` into `{name, args}`.
+ * Returns `null` when the input does not start with `/` or contains no
+ * command name after the slash. Whitespace splitting is deliberately
+ * simple (no shell quoting) — this matches the interactive REPL and
+ * keeps the wire protocol trivial for IDE clients.
+ */
+export function parseSlashCommand(line: string): { name: string; args: string[] } | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('/')) {
+    return null;
+  }
+  const parts = trimmed.slice(1).split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    return null;
+  }
+  const [name, ...args] = parts;
+  return { name, args };
+}
+
+/**
+ * Feed raw bytes from a socket and yield complete LDJSON lines (without
+ * the trailing `\n`). Callers hand back the returned `buffer` on the
+ * next call to preserve partial frames.
+ *
+ * This helper is intentionally pure so it is easy to unit-test without
+ * spinning up a real socket.
+ */
+export function extractLines(buffer: string, chunk: string): { lines: string[]; buffer: string } {
+  const combined = buffer + chunk;
+  const parts = combined.split('\n');
+  // Last element is the (possibly empty) partial line still being received.
+  const remaining = parts.pop() ?? '';
+  return { lines: parts, buffer: remaining };
+}

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -1,0 +1,401 @@
+/**
+ * UNIX socket server for remote slash commands.
+ *
+ * Listens on `~/.alexi/server.sock` by default. Each connected client
+ * exchanges LDJSON frames (see {@link ./protocol.ts}) and, after a
+ * successful `auth`, can dispatch slash commands, create isolated
+ * sessions, and gracefully disconnect with `exit`.
+ *
+ * The server itself only terminates on {@link stopSocketServer}. A
+ * client's `exit` frame closes only that client's socket — it does
+ * NOT kill the daemon (per issue #1100 "remote exit bridge").
+ *
+ * Session isolation: every remote client gets its own {@link SessionManager}
+ * instance keyed by a nanoid returned from `session.create`. Sessions
+ * are stored in memory for the server's lifetime and are separate from
+ * the host CLI's own session state.
+ */
+
+import { createServer, type Server, type Socket } from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import { nanoid } from 'nanoid';
+import { SessionManager } from '../core/sessionManager.js';
+import { getCommandRegistry, CommandError } from '../command/index.js';
+import {
+  PROTOCOL_VERSION,
+  encodeFrame,
+  extractLines,
+  failure,
+  parseRequest,
+  parseSlashCommand,
+  success,
+  type Request,
+  type ServerMessage,
+} from './protocol.js';
+import { defaultSocketPath, safeCompareToken } from './auth.js';
+
+/**
+ * Version string reported in the `hello` banner. Kept in sync with the
+ * package.json version at runtime via a lazy `require`. Falls back to
+ * `0.0.0` when the package.json cannot be read (during tests, for
+ * example).
+ */
+function readServerVersion(): string {
+  try {
+    // Read the top-level package.json relative to the built module.
+    // In `dist/server/socket.js` the file is two levels up; in
+    // `src/server/socket.ts` it's the same. `process.cwd()` is not
+    // reliable, so we walk from `import.meta.url`.
+    const here = new URL(import.meta.url);
+    let dir = path.dirname(here.pathname);
+    for (let i = 0; i < 6; i++) {
+      const candidate = path.join(dir, 'package.json');
+      if (fs.existsSync(candidate)) {
+        const raw = JSON.parse(fs.readFileSync(candidate, 'utf-8')) as { version?: string };
+        return raw.version ?? '0.0.0';
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) {
+        break;
+      }
+      dir = parent;
+    }
+  } catch {
+    // Fall through.
+  }
+  return '0.0.0';
+}
+
+interface RemoteSession {
+  id: string;
+  manager: SessionManager;
+  createdAt: number;
+}
+
+interface ClientState {
+  socket: Socket;
+  authenticated: boolean;
+  buffer: string;
+  /** Sessions this specific client has created via `session.create`. */
+  ownedSessionIds: Set<string>;
+}
+
+export interface SocketServerOptions {
+  /** Absolute path to the socket file. Defaults to `~/.alexi/server.sock`. */
+  socketPath?: string;
+  /** Shared auth token. Any client presenting a mismatching token is rejected. */
+  token: string;
+  /**
+   * Optional injection point for tests: return a session manager instead
+   * of constructing one. Production callers should leave this undefined.
+   */
+  createSessionManager?: () => SessionManager;
+}
+
+export interface SocketServerHandle {
+  /** The underlying `net.Server`. Useful for tests. */
+  server: Server;
+  /** Resolved socket path (absolute). */
+  socketPath: string;
+  /** Number of live remote sessions. */
+  sessionCount(): number;
+  /** Number of currently connected clients. */
+  clientCount(): number;
+  /** Gracefully shut down the server and disconnect all clients. */
+  stop(): Promise<void>;
+}
+
+/**
+ * Start the UNIX socket server. Resolves once the listener is bound.
+ *
+ * A stale socket file left behind by a crashed previous instance is
+ * removed before binding (`fs.unlinkSync` on `EADDRINUSE`).
+ */
+export function startSocketServer(options: SocketServerOptions): Promise<SocketServerHandle> {
+  const socketPath = options.socketPath ?? defaultSocketPath();
+  const sessions = new Map<string, RemoteSession>();
+  const clients = new Set<ClientState>();
+  const serverVersion = readServerVersion();
+  const createManager =
+    options.createSessionManager ?? ((): SessionManager => new SessionManager());
+
+  const server = createServer((socket) => {
+    const state: ClientState = {
+      socket,
+      authenticated: false,
+      buffer: '',
+      ownedSessionIds: new Set(),
+    };
+    clients.add(state);
+
+    const send = (msg: ServerMessage): void => {
+      if (socket.destroyed) {
+        return;
+      }
+      try {
+        socket.write(encodeFrame(msg));
+      } catch {
+        // Client went away mid-write; the 'close' handler will clean up.
+      }
+    };
+
+    // Send hello banner immediately.
+    send({ type: 'hello', version: serverVersion, protocol: PROTOCOL_VERSION });
+
+    socket.setEncoding('utf-8');
+
+    socket.on('data', (chunk: string) => {
+      const { lines, buffer } = extractLines(state.buffer, chunk);
+      state.buffer = buffer;
+      for (const line of lines) {
+        handleLine(state, line, send, sessions, options.token, createManager);
+      }
+    });
+
+    socket.on('close', () => {
+      clients.delete(state);
+    });
+
+    socket.on('error', () => {
+      // Silently drop — the 'close' handler will remove the client.
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    const onError = (err: NodeJS.ErrnoException): void => {
+      if (err.code === 'EADDRINUSE') {
+        // Stale socket from a previous crash: try to remove and rebind.
+        try {
+          fs.unlinkSync(socketPath);
+          server.listen(socketPath);
+          return;
+        } catch (unlinkErr) {
+          reject(unlinkErr);
+          return;
+        }
+      }
+      reject(err);
+    };
+
+    server.once('error', onError);
+    server.once('listening', () => {
+      server.removeListener('error', onError);
+      // Restrict socket to owner. Best-effort — some filesystems ignore.
+      try {
+        fs.chmodSync(socketPath, 0o600);
+      } catch {
+        // Ignore.
+      }
+
+      const handle: SocketServerHandle = {
+        server,
+        socketPath,
+        sessionCount: () => sessions.size,
+        clientCount: () => clients.size,
+        stop: () =>
+          new Promise<void>((res) => {
+            for (const client of clients) {
+              try {
+                client.socket.destroy();
+              } catch {
+                // Ignore.
+              }
+            }
+            clients.clear();
+            sessions.clear();
+            server.close(() => {
+              // Best-effort cleanup of the socket file.
+              try {
+                if (fs.existsSync(socketPath)) {
+                  fs.unlinkSync(socketPath);
+                }
+              } catch {
+                // Ignore.
+              }
+              res();
+            });
+          }),
+      };
+      resolve(handle);
+    });
+
+    // Ensure parent directory exists before binding.
+    try {
+      const dir = path.dirname(socketPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+      }
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    server.listen(socketPath);
+  });
+}
+
+/**
+ * Handle a single decoded line from a client. Extracted so it can be
+ * unit-tested by driving requests through {@link parseRequest} without
+ * a real socket.
+ *
+ * @internal
+ */
+function handleLine(
+  state: ClientState,
+  line: string,
+  send: (msg: ServerMessage) => void,
+  sessions: Map<string, RemoteSession>,
+  token: string,
+  createManager: () => SessionManager
+): void {
+  const parsed = parseRequest(line);
+  if (!parsed.ok) {
+    send(failure('', parsed.code, parsed.message));
+    return;
+  }
+  const req = parsed.request;
+
+  // `auth` and `ping` are the only frames allowed pre-authentication.
+  if (!state.authenticated && req.type !== 'auth' && req.type !== 'ping') {
+    send(failure(req.id, 'AUTH_REQUIRED', 'Client must authenticate before issuing commands'));
+    return;
+  }
+
+  handleRequest(state, req, send, sessions, token, createManager).catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    send(failure(req.id, 'INTERNAL_ERROR', msg));
+  });
+}
+
+/**
+ * Dispatch a parsed request against the shared registry / session map.
+ *
+ * @internal
+ */
+async function handleRequest(
+  state: ClientState,
+  req: Request,
+  send: (msg: ServerMessage) => void,
+  sessions: Map<string, RemoteSession>,
+  token: string,
+  createManager: () => SessionManager
+): Promise<void> {
+  switch (req.type) {
+    case 'ping': {
+      send(success(req.id, { pong: true, timestamp: Date.now() }));
+      return;
+    }
+
+    case 'auth': {
+      if (safeCompareToken(req.token, token)) {
+        state.authenticated = true;
+        send(success(req.id, { authenticated: true }));
+      } else {
+        send(failure(req.id, 'INVALID_TOKEN', 'Authentication failed'));
+      }
+      return;
+    }
+
+    case 'session.create': {
+      const id = nanoid();
+      const manager = createManager();
+      manager.createSession('default');
+      sessions.set(id, { id, manager, createdAt: Date.now() });
+      state.ownedSessionIds.add(id);
+      send(success(req.id, { sessionId: id, createdAt: Date.now() }));
+      return;
+    }
+
+    case 'session.list': {
+      const list = Array.from(sessions.values()).map((s) => ({
+        id: s.id,
+        createdAt: s.createdAt,
+        messageCount: s.manager.getHistory().length,
+      }));
+      send(success(req.id, { sessions: list }));
+      return;
+    }
+
+    case 'command': {
+      // Resolve or fall back to a fresh session so `/help`-style read-only
+      // commands work without an explicit session.create round-trip.
+      let sessionId = req.sessionId;
+      if (sessionId && !sessions.has(sessionId)) {
+        send(failure(req.id, 'SESSION_NOT_FOUND', `Unknown sessionId: ${sessionId}`));
+        return;
+      }
+      if (!sessionId) {
+        sessionId = nanoid();
+        const manager = createManager();
+        manager.createSession('default');
+        sessions.set(sessionId, { id: sessionId, manager, createdAt: Date.now() });
+        state.ownedSessionIds.add(sessionId);
+      }
+
+      const parsed = parseSlashCommand(req.command);
+      if (!parsed) {
+        send(
+          failure(
+            req.id,
+            'INVALID_COMMAND',
+            'Command must be a slash-command line starting with "/"'
+          )
+        );
+        return;
+      }
+
+      // Built-in commands not registered in the CommandRegistry.
+      if (parsed.name === 'help') {
+        const registry = getCommandRegistry();
+        const commands = registry.list().map((c) => ({
+          name: c.name,
+          description: c.description,
+        }));
+        send(success(req.id, { sessionId, help: { commands } }));
+        return;
+      }
+      if (parsed.name === 'exit') {
+        // Remote /exit is a client-side disconnect signal, delivered as
+        // a normal response BEFORE the socket is closed so the client
+        // can observe it. It never terminates the daemon.
+        send(success(req.id, { sessionId, closed: true }));
+        try {
+          state.socket.end();
+        } catch {
+          // Ignore.
+        }
+        return;
+      }
+
+      try {
+        const registry = getCommandRegistry();
+        const rendered = await registry.execute(parsed.name, parsed.args);
+        send(success(req.id, { sessionId, rendered }));
+      } catch (err) {
+        if (err instanceof CommandError) {
+          send(failure(req.id, err.code, err.message));
+        } else {
+          const msg = err instanceof Error ? err.message : String(err);
+          send(failure(req.id, 'COMMAND_EXECUTION_FAILED', msg));
+        }
+      }
+      return;
+    }
+
+    case 'exit': {
+      // Explicit disconnect frame — respond, then close only this client.
+      send(success(req.id, { closed: true }));
+      try {
+        state.socket.end();
+      } catch {
+        // Ignore.
+      }
+      return;
+    }
+  }
+}
+
+// Re-export internal handler for testing without a real socket.
+export const _test = { handleLine, handleRequest };

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  defaultSocketPath,
+  defaultTokenPath,
+  generateToken,
+  loadOrCreateToken,
+  readTokenIfExists,
+  safeCompareToken,
+} from '../../src/server/auth.js';
+
+describe('server auth', () => {
+  let tmpdir: string;
+
+  beforeEach(() => {
+    tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-server-auth-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpdir, { recursive: true, force: true });
+  });
+
+  describe('generateToken', () => {
+    it('produces a hex string of 64 characters', () => {
+      const t = generateToken();
+      expect(t).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('is non-deterministic across calls', () => {
+      const a = generateToken();
+      const b = generateToken();
+      expect(a).not.toEqual(b);
+    });
+  });
+
+  describe('loadOrCreateToken', () => {
+    it('creates a new token file when missing and returns the same on next call', () => {
+      const p = path.join(tmpdir, 'nested', 'server-token');
+      const first = loadOrCreateToken(p);
+      expect(fs.existsSync(p)).toBe(true);
+
+      const second = loadOrCreateToken(p);
+      expect(second).toBe(first);
+    });
+
+    it('writes the token with mode 0600 on POSIX filesystems', () => {
+      if (process.platform === 'win32') {
+        return;
+      }
+      const p = path.join(tmpdir, 'server-token');
+      loadOrCreateToken(p);
+      const stat = fs.statSync(p);
+      const mode = stat.mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it('reuses an existing token verbatim', () => {
+      const p = path.join(tmpdir, 'server-token');
+      fs.writeFileSync(p, 'preseeded-token\n');
+      const loaded = loadOrCreateToken(p);
+      expect(loaded).toBe('preseeded-token');
+    });
+
+    it('regenerates when the existing file is empty', () => {
+      const p = path.join(tmpdir, 'server-token');
+      fs.writeFileSync(p, '   ');
+      const loaded = loadOrCreateToken(p);
+      expect(loaded.length).toBeGreaterThan(0);
+      expect(loaded).not.toBe('   ');
+    });
+  });
+
+  describe('readTokenIfExists', () => {
+    it('returns null when the file does not exist', () => {
+      expect(readTokenIfExists(path.join(tmpdir, 'missing'))).toBeNull();
+    });
+
+    it('returns the trimmed contents when the file exists', () => {
+      const p = path.join(tmpdir, 'server-token');
+      fs.writeFileSync(p, 'tok\n');
+      expect(readTokenIfExists(p)).toBe('tok');
+    });
+
+    it('returns null for whitespace-only files', () => {
+      const p = path.join(tmpdir, 'server-token');
+      fs.writeFileSync(p, '   \n');
+      expect(readTokenIfExists(p)).toBeNull();
+    });
+  });
+
+  describe('safeCompareToken', () => {
+    it('returns true for identical strings', () => {
+      expect(safeCompareToken('abc', 'abc')).toBe(true);
+    });
+
+    it('returns false for differing strings of equal length', () => {
+      expect(safeCompareToken('abc', 'abd')).toBe(false);
+    });
+
+    it('returns false when lengths differ', () => {
+      expect(safeCompareToken('abc', 'abcd')).toBe(false);
+    });
+
+    it('rejects non-strings without throwing', () => {
+      // @ts-expect-error deliberately invalid input for defence-in-depth
+      expect(safeCompareToken(null, 'abc')).toBe(false);
+    });
+  });
+
+  describe('default paths', () => {
+    it('places the token under the given home directory', () => {
+      const home = '/custom/home';
+      expect(defaultTokenPath(home)).toBe(path.join(home, '.alexi', 'server-token'));
+    });
+
+    it('places the socket under the given home directory', () => {
+      const home = '/custom/home';
+      expect(defaultSocketPath(home)).toBe(path.join(home, '.alexi', 'server.sock'));
+    });
+  });
+});

--- a/tests/server/protocol.test.ts
+++ b/tests/server/protocol.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PROTOCOL_VERSION,
+  encodeFrame,
+  extractLines,
+  failure,
+  parseRequest,
+  parseSlashCommand,
+  success,
+} from '../../src/server/protocol.js';
+
+describe('server protocol', () => {
+  describe('encodeFrame', () => {
+    it('encodes a hello message as a newline-terminated JSON line', () => {
+      const frame = encodeFrame({ type: 'hello', version: '1.0.0', protocol: PROTOCOL_VERSION });
+      expect(frame.endsWith('\n')).toBe(true);
+      const obj = JSON.parse(frame.trim());
+      expect(obj).toEqual({ type: 'hello', version: '1.0.0', protocol: PROTOCOL_VERSION });
+    });
+
+    it('encodes a success response', () => {
+      const frame = encodeFrame(success('req-1', { pong: true }));
+      const obj = JSON.parse(frame.trim());
+      expect(obj).toEqual({
+        id: 'req-1',
+        type: 'response',
+        ok: true,
+        result: { pong: true },
+      });
+    });
+
+    it('encodes an error response', () => {
+      const frame = encodeFrame(failure('req-2', 'INVALID', 'nope'));
+      const obj = JSON.parse(frame.trim());
+      expect(obj).toEqual({
+        id: 'req-2',
+        type: 'error',
+        ok: false,
+        error: { code: 'INVALID', message: 'nope' },
+      });
+    });
+  });
+
+  describe('parseRequest', () => {
+    it('parses a valid auth frame', () => {
+      const res = parseRequest(JSON.stringify({ id: '1', type: 'auth', token: 'abc' }));
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.request.type).toBe('auth');
+      }
+    });
+
+    it('parses a valid command frame with sessionId', () => {
+      const res = parseRequest(
+        JSON.stringify({ id: '2', type: 'command', command: '/help', sessionId: 's1' })
+      );
+      expect(res.ok).toBe(true);
+      if (res.ok && res.request.type === 'command') {
+        expect(res.request.command).toBe('/help');
+        expect(res.request.sessionId).toBe('s1');
+      }
+    });
+
+    it('rejects an empty frame', () => {
+      const res = parseRequest('   ');
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.code).toBe('EMPTY_FRAME');
+      }
+    });
+
+    it('rejects invalid JSON', () => {
+      const res = parseRequest('{not json');
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.code).toBe('INVALID_JSON');
+      }
+    });
+
+    it('rejects frames with unknown types', () => {
+      const res = parseRequest(JSON.stringify({ id: '1', type: 'nope' }));
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.code).toBe('INVALID_REQUEST');
+      }
+    });
+
+    it('rejects auth frames missing a token', () => {
+      const res = parseRequest(JSON.stringify({ id: '1', type: 'auth' }));
+      expect(res.ok).toBe(false);
+    });
+
+    it('rejects command frames with empty command', () => {
+      const res = parseRequest(JSON.stringify({ id: '1', type: 'command', command: '' }));
+      expect(res.ok).toBe(false);
+    });
+  });
+
+  describe('parseSlashCommand', () => {
+    it('parses /help with no args', () => {
+      expect(parseSlashCommand('/help')).toEqual({ name: 'help', args: [] });
+    });
+
+    it('parses /review with args', () => {
+      expect(parseSlashCommand('/review src/foo.ts')).toEqual({
+        name: 'review',
+        args: ['src/foo.ts'],
+      });
+    });
+
+    it('collapses multiple spaces between args', () => {
+      expect(parseSlashCommand('/refactor  a   b')).toEqual({
+        name: 'refactor',
+        args: ['a', 'b'],
+      });
+    });
+
+    it('returns null for non-slash input', () => {
+      expect(parseSlashCommand('help')).toBeNull();
+    });
+
+    it('returns null for a bare slash', () => {
+      expect(parseSlashCommand('/   ')).toBeNull();
+    });
+  });
+
+  describe('extractLines', () => {
+    it('yields complete lines and preserves partial trailing input', () => {
+      const first = extractLines('', '{"a":1}\n{"b":2}\n{"c":');
+      expect(first.lines).toEqual(['{"a":1}', '{"b":2}']);
+      expect(first.buffer).toBe('{"c":');
+
+      const second = extractLines(first.buffer, '3}\n');
+      expect(second.lines).toEqual(['{"c":3}']);
+      expect(second.buffer).toBe('');
+    });
+
+    it('yields nothing when the chunk has no newline', () => {
+      const res = extractLines('', 'partial');
+      expect(res.lines).toEqual([]);
+      expect(res.buffer).toBe('partial');
+    });
+
+    it('preserves order across successive chunks', () => {
+      let buffer = '';
+      const seen: string[] = [];
+      for (const chunk of ['{"i":1}\n{"i":', '2}\n{"i":3', '}\n']) {
+        const { lines, buffer: b } = extractLines(buffer, chunk);
+        seen.push(...lines);
+        buffer = b;
+      }
+      expect(seen).toEqual(['{"i":1}', '{"i":2}', '{"i":3}']);
+      expect(buffer).toBe('');
+    });
+  });
+});

--- a/tests/server/socket.test.ts
+++ b/tests/server/socket.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { startSocketServer, type SocketServerHandle } from '../../src/server/socket.js';
+import { registerBuiltInCommands } from '../../src/command/index.js';
+
+/**
+ * Minimal LDJSON client for driving the server in tests. Buffers
+ * incoming data and yields decoded JSON frames via {@link readFrame}.
+ */
+class TestClient {
+  private socket: net.Socket;
+  private buffer = '';
+  private pending: string[] = [];
+  private waiters: Array<(line: string) => void> = [];
+
+  constructor(socketPath: string) {
+    this.socket = net.createConnection(socketPath);
+    this.socket.setEncoding('utf-8');
+    this.socket.on('data', (chunk: string) => {
+      this.buffer += chunk;
+      let idx = this.buffer.indexOf('\n');
+      while (idx !== -1) {
+        const line = this.buffer.slice(0, idx);
+        this.buffer = this.buffer.slice(idx + 1);
+        const waiter = this.waiters.shift();
+        if (waiter) {
+          waiter(line);
+        } else {
+          this.pending.push(line);
+        }
+        idx = this.buffer.indexOf('\n');
+      }
+    });
+  }
+
+  send(obj: unknown): void {
+    this.socket.write(JSON.stringify(obj) + '\n');
+  }
+
+  async ready(): Promise<void> {
+    if (this.socket.connecting) {
+      await new Promise<void>((resolve, reject) => {
+        this.socket.once('connect', resolve);
+        this.socket.once('error', reject);
+      });
+    }
+  }
+
+  async readFrame(): Promise<Record<string, unknown>> {
+    let line: string;
+    if (this.pending.length > 0) {
+      line = this.pending.shift()!;
+    } else {
+      line = await new Promise<string>((resolve) => this.waiters.push(resolve));
+    }
+    return JSON.parse(line) as Record<string, unknown>;
+  }
+
+  end(): void {
+    this.socket.end();
+  }
+
+  destroy(): void {
+    this.socket.destroy();
+  }
+
+  get isClosed(): boolean {
+    return this.socket.destroyed || this.socket.readyState === 'closed';
+  }
+}
+
+describe('UNIX socket server lifecycle', () => {
+  let tmpdir: string;
+  let socketPath: string;
+  let handle: SocketServerHandle;
+  const token = 'test-token-abc123';
+
+  beforeEach(async () => {
+    tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-socket-'));
+    socketPath = path.join(tmpdir, 'server.sock');
+    // Ensure at least one command is registered so /help lists something.
+    registerBuiltInCommands();
+    handle = await startSocketServer({ socketPath, token });
+  });
+
+  afterEach(async () => {
+    await handle.stop();
+    fs.rmSync(tmpdir, { recursive: true, force: true });
+  });
+
+  it('binds to the requested socket path and cleans up on stop', async () => {
+    expect(fs.existsSync(socketPath)).toBe(true);
+    await handle.stop();
+    expect(fs.existsSync(socketPath)).toBe(false);
+    // Restart for afterEach.
+    handle = await startSocketServer({ socketPath, token });
+  });
+
+  it('sends a hello banner on connect', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    const hello = await client.readFrame();
+    expect(hello.type).toBe('hello');
+    expect(hello.protocol).toBe(1);
+    client.end();
+  });
+
+  it('rejects unauthenticated non-auth requests with AUTH_REQUIRED', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    await client.readFrame(); // hello
+    client.send({ id: '1', type: 'session.create' });
+    const resp = await client.readFrame();
+    expect(resp.type).toBe('error');
+    expect(resp.ok).toBe(false);
+    const err = resp.error as { code: string };
+    expect(err.code).toBe('AUTH_REQUIRED');
+    client.end();
+  });
+
+  it('accepts a valid auth token', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    await client.readFrame(); // hello
+    client.send({ id: '1', type: 'auth', token });
+    const resp = await client.readFrame();
+    expect(resp.type).toBe('response');
+    expect(resp.ok).toBe(true);
+    const result = resp.result as { authenticated: boolean };
+    expect(result.authenticated).toBe(true);
+    client.end();
+  });
+
+  it('rejects a bad auth token', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    await client.readFrame(); // hello
+    client.send({ id: '1', type: 'auth', token: 'wrong-token' });
+    const resp = await client.readFrame();
+    expect(resp.type).toBe('error');
+    const err = resp.error as { code: string };
+    expect(err.code).toBe('INVALID_TOKEN');
+    client.end();
+  });
+
+  it('permits ping without authentication', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    await client.readFrame(); // hello
+    client.send({ id: '1', type: 'ping' });
+    const resp = await client.readFrame();
+    expect(resp.type).toBe('response');
+    const result = resp.result as { pong: boolean };
+    expect(result.pong).toBe(true);
+    client.end();
+  });
+
+  it('creates isolated sessions per session.create request', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    await client.readFrame(); // hello
+    client.send({ id: '1', type: 'auth', token });
+    await client.readFrame(); // auth ok
+
+    client.send({ id: '2', type: 'session.create' });
+    const s1 = (await client.readFrame()).result as { sessionId: string };
+    client.send({ id: '3', type: 'session.create' });
+    const s2 = (await client.readFrame()).result as { sessionId: string };
+
+    expect(s1.sessionId).toBeTruthy();
+    expect(s2.sessionId).toBeTruthy();
+    expect(s1.sessionId).not.toBe(s2.sessionId);
+    expect(handle.sessionCount()).toBe(2);
+    client.end();
+  });
+
+  it('dispatches /help through the command registry', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    await client.readFrame(); // hello
+    client.send({ id: '1', type: 'auth', token });
+    await client.readFrame();
+
+    client.send({ id: '2', type: 'command', command: '/help' });
+    const resp = await client.readFrame();
+    expect(resp.type).toBe('response');
+    const result = resp.result as {
+      sessionId: string;
+      help: { commands: Array<{ name: string }> };
+    };
+    expect(result.sessionId).toBeTruthy();
+    expect(Array.isArray(result.help.commands)).toBe(true);
+    expect(result.help.commands.length).toBeGreaterThan(0);
+    client.end();
+  });
+
+  it('reports COMMAND_NOT_FOUND for unknown slash commands', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    await client.readFrame();
+    client.send({ id: '1', type: 'auth', token });
+    await client.readFrame();
+
+    client.send({ id: '2', type: 'command', command: '/does-not-exist' });
+    const resp = await client.readFrame();
+    expect(resp.type).toBe('error');
+    const err = resp.error as { code: string };
+    expect(err.code).toBe('COMMAND_NOT_FOUND');
+    client.end();
+  });
+
+  it('remote /exit closes only that client, not the server', async () => {
+    const c1 = new TestClient(socketPath);
+    const c2 = new TestClient(socketPath);
+    await c1.ready();
+    await c2.ready();
+    await c1.readFrame();
+    await c2.readFrame();
+
+    c1.send({ id: '1', type: 'auth', token });
+    c2.send({ id: '1', type: 'auth', token });
+    await c1.readFrame();
+    await c2.readFrame();
+
+    c1.send({ id: '2', type: 'command', command: '/exit' });
+    const closed = await c1.readFrame();
+    expect(closed.type).toBe('response');
+    const result = closed.result as { closed: boolean };
+    expect(result.closed).toBe(true);
+
+    // Give c1 a moment to close, then confirm c2 still works.
+    await new Promise((r) => setTimeout(r, 30));
+
+    c2.send({ id: '2', type: 'ping' });
+    const pong = await c2.readFrame();
+    expect(pong.type).toBe('response');
+    c2.end();
+  });
+
+  it('an explicit exit frame closes only the sending client', async () => {
+    const c1 = new TestClient(socketPath);
+    const c2 = new TestClient(socketPath);
+    await c1.ready();
+    await c2.ready();
+    await c1.readFrame();
+    await c2.readFrame();
+    c1.send({ id: '1', type: 'auth', token });
+    c2.send({ id: '1', type: 'auth', token });
+    await c1.readFrame();
+    await c2.readFrame();
+
+    c1.send({ id: '2', type: 'exit' });
+    const bye = await c1.readFrame();
+    expect(bye.type).toBe('response');
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    c2.send({ id: '2', type: 'ping' });
+    const pong = await c2.readFrame();
+    expect(pong.type).toBe('response');
+    c2.end();
+  });
+
+  it('rejects a command referencing an unknown sessionId', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    await client.readFrame();
+    client.send({ id: '1', type: 'auth', token });
+    await client.readFrame();
+
+    client.send({
+      id: '2',
+      type: 'command',
+      command: '/help',
+      sessionId: 'nonexistent-session',
+    });
+    const resp = await client.readFrame();
+    expect(resp.type).toBe('error');
+    const err = resp.error as { code: string };
+    expect(err.code).toBe('SESSION_NOT_FOUND');
+    client.end();
+  });
+
+  it('returns an error for invalid JSON frames', async () => {
+    const client = new TestClient(socketPath);
+    await client.ready();
+    await client.readFrame(); // hello
+    // Bypass send() to write malformed input directly. The test client
+    // exposes its underlying socket via a typed cast; using unknown as
+    // an intermediate keeps the cast eslint-clean.
+    const rawSocket = (client as unknown as { socket: net.Socket }).socket;
+    rawSocket.write('{not json}\n');
+    const resp = await client.readFrame();
+    expect(resp.type).toBe('error');
+    const err = resp.error as { code: string };
+    expect(err.code).toBe('INVALID_JSON');
+    client.end();
+  });
+});


### PR DESCRIPTION
Closes #1100

## Summary

Adds a long-running local daemon that binds a UNIX domain socket at `~/.alexi/server.sock` and exposes Alexi's slash-command surface to remote clients (VS Code / JetBrains plugins, test harnesses, IDE integrations) without spawning a new `alexi` Node process per turn.

## Files

- `src/server/protocol.ts` — LDJSON wire protocol with zod-validated request schema (`auth`, `ping`, `command`, `session.create`, `session.list`, `exit`) plus a pure line-extraction helper.
- `src/server/auth.ts` — token generation and file storage at `~/.alexi/server-token` (mode 0600) with a constant-time compare.
- `src/server/socket.ts` — `net.createServer` harness, per-client authentication gate, session isolation via separate `SessionManager` instances, and the remote-`/exit`-closes-client-only semantic from the design.
- `src/cli/commands/server.ts` — `alexi server start | stop | status` subcommands, registered on the main CLI program.
- `docs/SERVER.md` — protocol reference and a Node.js reference client.
- `tests/server/` — 46 new tests covering protocol parsing, auth token lifecycle, and end-to-end socket dispatch with a real `net.createConnection` client.

## Design highlights

- **Transport**: line-delimited JSON over a UNIX domain socket. Never listens on TCP.
- **Auth**: shared token stored at `~/.alexi/server-token` (mode 0600). Clients present the token in an `auth` frame; all non-`auth`/`ping` frames pre-auth receive `AUTH_REQUIRED`.
- **Command dispatch**: bridges through the existing `getCommandRegistry()` in `src/command/index.ts` so `/help`, `/review`, `/explain`, etc. behave identically to the interactive REPL. `/help` and `/exit` are built-in server-side.
- **Session isolation**: each remote session gets its own `SessionManager`, keyed by nanoid. Commands may reference an existing session via `sessionId` or the server creates one on the fly.
- **Remote exit bridge**: a client `/exit` (or explicit `exit` frame) closes only that client's socket. The daemon keeps running.
- **Existing HTTP server** at `src/server/index.ts` is left untouched — the two servers are complementary transports.

## Verification

```
npm run lint          # 0 errors (warnings pre-existing)
npm run typecheck     # ok
npm run format:check  # ok
npm run test:coverage # 3237 tests pass, lines coverage 64.99% (>= 40% CI floor)
npm run build         # ok
```

Coverage of new files: `protocol.ts` 100%, `auth.ts` 100%, `socket.ts` 81%.

[alexi-bot]