### PR TITLE
feat(core): add stalled-stream watchdog to streamingOrchestrator

### DIFF
--- a/src/core/streamWatchdog.ts
+++ b/src/core/streamWatchdog.ts
@@ -1,0 +1,438 @@
+/**
+ * Stream watchdog for provider streaming.
+ *
+ * Wraps a provider `AsyncIterable<StreamChunk>` (e.g.
+ * `provider.streamComplete(...)`) in a hand-rolled `AsyncIterableIterator`
+ * with two properties that a native `async function*` generator cannot
+ * provide:
+ *
+ * 1. **Preemptive return().** Calling `return()` fires an internal
+ *    `AbortController` and *does not await* the outstanding pull on the
+ *    source. The source's `return()` is forwarded (best-effort, unawaited)
+ *    so its finally-block runs, but the wrapper resolves the caller
+ *    immediately. This fixes the Cline-#12249 preemption trap in which a
+ *    native `async function*` cannot preempt its in-flight `await` on the
+ *    source iterator when the consumer breaks the loop or calls `return()`.
+ *
+ * 2. **Idle-timeout watchdog.** If no chunk arrives within
+ *    `idleTimeoutMs` (default 30_000 ms), the wrapper aborts the source
+ *    and rejects the pending `next()` with a synthetic `AbortError` carrying
+ *    the reason `stream idle timeout`. Long-running tool calls (bash,
+ *    shell, background_process, agent_manager, ...) extend the idle
+ *    window to `toolExtensionMs` (default 10 minutes) while the model is
+ *    streaming their tool-call deltas.
+ *
+ * The wrapper is deliberately provider-agnostic: it consumes any
+ * `AsyncIterable<StreamChunk>` and forwards the caller's `AbortSignal` to
+ * the source (in addition to its own idle-timeout controller). Callers pass
+ * `sourceFactory(signal)` — a function that returns the source iterable
+ * given the effective abort signal — so the wrapper can splice in its own
+ * timeout controller upstream of the source.
+ */
+
+import type { StreamChunk } from '../providers/index.js';
+
+/**
+ * Names of tools whose in-flight tool-call chunks should extend the idle
+ * timeout window. These are tools that legitimately produce long silent
+ * periods (e.g. shell commands, background processes, sub-agents). The
+ * match is done on the `tool_calls[].function.name` field of streaming
+ * deltas.
+ *
+ * Keep this list in sync with the actual tool `name` values in
+ * `src/tool/tools/*.ts`.
+ */
+export const DEFAULT_LONG_RUNNING_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'bash',
+  'shell',
+  'background_process',
+  'agent_manager',
+]);
+
+/** Default idle-timeout window before a stalled stream is aborted. */
+export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 30_000;
+
+/** Default extended idle window when a long-running tool is in-flight. */
+export const DEFAULT_STREAM_TOOL_EXTENSION_MS = 10 * 60 * 1000;
+
+/**
+ * Options accepted by {@link createStreamWatchdog}.
+ */
+export interface StreamWatchdogOptions {
+  /**
+   * Idle timeout in milliseconds. If no chunk arrives within this window,
+   * the watchdog aborts the source stream. Default: 30_000 ms.
+   */
+  idleTimeoutMs?: number;
+  /**
+   * Extended idle window (ms) applied while a long-running tool-call chunk
+   * is being streamed. Default: 600_000 ms (10 minutes).
+   */
+  toolExtensionMs?: number;
+  /**
+   * Set of tool names whose tool-call deltas extend the idle window.
+   * Default: {@link DEFAULT_LONG_RUNNING_TOOL_NAMES}.
+   */
+  longRunningToolNames?: ReadonlySet<string>;
+  /**
+   * Parent abort signal from the caller (e.g. user-pressed Ctrl+C).
+   * The watchdog links its internal controller so aborting either
+   * parent or watchdog triggers the source's teardown.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Factory that produces the source stream, given the effective abort
+ * signal the caller must forward to the provider. This indirection lets
+ * the watchdog splice its own timeout controller into the signal chain
+ * without the caller having to know about it.
+ *
+ * The returned source may be either an `AsyncIterable<StreamChunk>` (the
+ * production case, where `provider.streamComplete` is an
+ * `async function*`) or an `Iterable<StreamChunk>` (test doubles that use
+ * a sync `function*`). The watchdog normalizes both shapes.
+ */
+export type StreamSourceFactory = (
+  signal: AbortSignal
+) => AsyncIterable<StreamChunk> | Iterable<StreamChunk>;
+
+/**
+ * The hand-rolled async-iterator shape the watchdog returns. Exposes the
+ * same surface as `AsyncGenerator<StreamChunk, void>` so callers can drop
+ * it into a `for await` loop OR drive it manually with `next()`/`return()`.
+ */
+export interface StreamWatchdogIterator extends AsyncIterableIterator<StreamChunk> {
+  /**
+   * Preemptively terminate the stream. Fires the internal abort controller
+   * (which cascades to the source) and forwards `return()` to the source
+   * without awaiting outstanding pulls. Resolves synchronously with
+   * `{ done: true, value: undefined }`.
+   */
+  return(value?: unknown): Promise<IteratorResult<StreamChunk, undefined>>;
+  /**
+   * Propagate an error into the wrapper. Behaves like `return()` for
+   * cleanup purposes and then rejects with the given error.
+   */
+  throw(err?: unknown): Promise<IteratorResult<StreamChunk, undefined>>;
+}
+
+/**
+ * Create a watchdog-wrapped async iterator over a provider stream.
+ *
+ * @param sourceFactory Callback that creates the source iterable given
+ *   the effective abort signal. The factory is called eagerly (before
+ *   the first `next()`) so any construction cost is paid up-front.
+ * @param options Optional watchdog configuration.
+ * @returns A hand-rolled AsyncIterableIterator whose `return()` preempts
+ *   the outstanding source pull.
+ */
+export function createStreamWatchdog(
+  sourceFactory: StreamSourceFactory,
+  options?: StreamWatchdogOptions
+): StreamWatchdogIterator {
+  const idleTimeoutMs = options?.idleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+  const toolExtensionMs = options?.toolExtensionMs ?? DEFAULT_STREAM_TOOL_EXTENSION_MS;
+  const longRunningToolNames = options?.longRunningToolNames ?? DEFAULT_LONG_RUNNING_TOOL_NAMES;
+
+  // Internal controller: aborted on idle timeout, on preemptive return(), or
+  // when the parent signal fires. Its signal is what we forward to the
+  // provider source, so any of the three paths cascades to a real HTTP
+  // teardown inside the provider.
+  const controller = new AbortController();
+
+  const parentSignal = options?.signal;
+  if (parentSignal) {
+    if (parentSignal.aborted) {
+      controller.abort(parentSignal.reason);
+    } else {
+      parentSignal.addEventListener(
+        'abort',
+        () => {
+          controller.abort(parentSignal.reason);
+        },
+        { once: true }
+      );
+    }
+  }
+
+  // Construct the source eagerly so we can grab its iterator up-front.
+  // Any exception here bubbles synchronously to the caller (parity with an
+  // async generator's first-`next()` throw).
+  const source = sourceFactory(controller.signal);
+  const sourceIter = toAsyncIterator(source);
+
+  // Track whether we have already torn down. Multiple return() calls are
+  // idempotent.
+  let finished = false;
+  // Track currently-active tool-call names so the idle window can be
+  // extended while any long-running tool is in flight.
+  const activeLongRunningTools = new Map<number, string>();
+
+  // Idle watchdog state: a single active timer, restarted on each chunk.
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  let currentWindowMs = idleTimeoutMs;
+
+  function clearIdleTimer(): void {
+    if (idleTimer !== null) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+  }
+
+  function armIdleTimer(): void {
+    clearIdleTimer();
+    if (currentWindowMs <= 0 || !Number.isFinite(currentWindowMs)) {
+      return;
+    }
+    idleTimer = setTimeout(() => {
+      idleTimer = null;
+      if (!finished && !controller.signal.aborted) {
+        controller.abort(
+          new DOMException(`stream idle timeout after ${currentWindowMs}ms`, 'AbortError')
+        );
+      }
+    }, currentWindowMs);
+    // Do not keep the Node event loop alive solely for a watchdog timer.
+    // If the user has explicitly abandoned the process, the timer should
+    // not delay exit.
+    if (typeof (idleTimer as { unref?: () => void }).unref === 'function') {
+      (idleTimer as { unref: () => void }).unref();
+    }
+  }
+
+  function recomputeWindow(): void {
+    // Extend to toolExtensionMs while any long-running tool is active,
+    // otherwise revert to the base idle timeout.
+    const nextWindow = activeLongRunningTools.size > 0 ? toolExtensionMs : idleTimeoutMs;
+    if (nextWindow !== currentWindowMs) {
+      currentWindowMs = nextWindow;
+    }
+  }
+
+  function trackToolCalls(chunk: StreamChunk): void {
+    const toolCalls = chunk.toolCalls;
+    if (!toolCalls || toolCalls.length === 0) {
+      return;
+    }
+    let changed = false;
+    for (const tc of toolCalls) {
+      const name = tc.function?.name;
+      if (!name) {
+        continue;
+      }
+      if (!longRunningToolNames.has(name)) {
+        continue;
+      }
+      // Streaming tool-call deltas repeat the same index for one tool call;
+      // record the first observed name at that index. New indices signal a
+      // new tool call.
+      if (!activeLongRunningTools.has(tc.index)) {
+        activeLongRunningTools.set(tc.index, name);
+        changed = true;
+      }
+    }
+    if (changed) {
+      recomputeWindow();
+    }
+  }
+
+  function releaseToolCallsOnFinish(chunk: StreamChunk): void {
+    // The provider emits a terminal chunk with `finishReason` set; at that
+    // point any in-flight tool call is considered "queued" for execution
+    // and no longer producing streamed silence. Reset the idle window so
+    // stale extensions do not linger for the caller's post-stream logic.
+    if (chunk.finishReason && activeLongRunningTools.size > 0) {
+      activeLongRunningTools.clear();
+      recomputeWindow();
+    }
+  }
+
+  // Hand-rolled next(): races the source's pull against our internal abort
+  // signal. If the source resolves first, we forward the chunk (and reset
+  // the idle timer). If the abort fires first (idle timeout OR parent OR
+  // preemptive return()), we reject with an AbortError immediately, without
+  // waiting for the source to unstick.
+  async function next(): Promise<IteratorResult<StreamChunk, undefined>> {
+    if (finished) {
+      return { value: undefined, done: true };
+    }
+    // If already aborted before we start pulling, short-circuit.
+    if (controller.signal.aborted) {
+      await cleanup();
+      throw abortError(controller.signal.reason);
+    }
+
+    armIdleTimer();
+
+    const abortPromise = new Promise<never>((_resolve, reject) => {
+      if (controller.signal.aborted) {
+        reject(abortError(controller.signal.reason));
+        return;
+      }
+      controller.signal.addEventListener(
+        'abort',
+        () => {
+          reject(abortError(controller.signal.reason));
+        },
+        { once: true }
+      );
+    });
+
+    try {
+      const result = await Promise.race([sourceIter.next(), abortPromise]);
+      // Any completion (value or done) counts as activity: clear the timer
+      // before we re-arm on the next pull.
+      clearIdleTimer();
+      if (result.done) {
+        finished = true;
+        return { value: undefined, done: true };
+      }
+      const chunk = result.value;
+      trackToolCalls(chunk);
+      releaseToolCallsOnFinish(chunk);
+      return { value: chunk, done: false };
+    } catch (err) {
+      // On any error (including our own abort), tear down the source.
+      // Cleanup is best-effort and intentionally unawaited to preserve the
+      // preemption guarantee from return().
+      finished = true;
+      clearIdleTimer();
+      // Fire-and-forget source.return() so its finally-block runs; do not
+      // await, because that is precisely the Cline #12249 trap.
+      void safeSourceReturn();
+      throw err;
+    }
+  }
+
+  async function cleanup(): Promise<void> {
+    finished = true;
+    clearIdleTimer();
+    void safeSourceReturn();
+  }
+
+  // Best-effort source teardown. Some sources implement `return()`, others
+  // do not. Anything thrown from the source's return is swallowed here to
+  // preserve the preemption guarantee.
+  async function safeSourceReturn(): Promise<void> {
+    try {
+      if (typeof sourceIter.return === 'function') {
+        await sourceIter.return();
+      }
+    } catch {
+      // Swallow — source cleanup errors should not surface to the caller
+      // that already asked to stop.
+    }
+  }
+
+  // Preemptive return(): fires the abort controller (waking any pending
+  // race in next()), marks finished, forwards return() to the source
+  // WITHOUT awaiting it, and resolves immediately.
+  async function returnFn(_value?: unknown): Promise<IteratorResult<StreamChunk, undefined>> {
+    if (finished) {
+      return { value: undefined, done: true };
+    }
+    finished = true;
+    clearIdleTimer();
+    if (!controller.signal.aborted) {
+      controller.abort(new DOMException('stream cancelled by consumer', 'AbortError'));
+    }
+    // Fire-and-forget: do NOT await. This is the whole point of the
+    // hand-rolled iterator vs. `async function*` — the outstanding
+    // source.next() must not delay teardown.
+    void safeSourceReturn();
+    return { value: undefined, done: true };
+  }
+
+  async function throwFn(err?: unknown): Promise<IteratorResult<StreamChunk, undefined>> {
+    if (finished) {
+      throw err;
+    }
+    finished = true;
+    clearIdleTimer();
+    if (!controller.signal.aborted) {
+      controller.abort(
+        err instanceof Error ? err : new DOMException(String(err ?? 'throw'), 'AbortError')
+      );
+    }
+    void safeSourceReturn();
+    throw err;
+  }
+
+  const iterator: StreamWatchdogIterator = {
+    next,
+    return: returnFn,
+    throw: throwFn,
+    [Symbol.asyncIterator](): StreamWatchdogIterator {
+      return iterator;
+    },
+  };
+  return iterator;
+}
+
+/**
+ * Normalize a source that may be either `AsyncIterable` or `Iterable`
+ * into an `AsyncIterator`. Sync iterables have their `next()`/`return()`
+ * results promise-wrapped so the watchdog can uniformly `await` them.
+ */
+function toAsyncIterator(
+  source: AsyncIterable<StreamChunk> | Iterable<StreamChunk>
+): AsyncIterator<StreamChunk> {
+  const asyncIt = (source as AsyncIterable<StreamChunk>)[Symbol.asyncIterator];
+  if (typeof asyncIt === 'function') {
+    return asyncIt.call(source);
+  }
+  const syncIt = (source as Iterable<StreamChunk>)[Symbol.iterator];
+  if (typeof syncIt === 'function') {
+    const it = syncIt.call(source);
+    return {
+      next(): Promise<IteratorResult<StreamChunk>> {
+        try {
+          const result = it.next();
+          return Promise.resolve(result);
+        } catch (err) {
+          return Promise.reject(err);
+        }
+      },
+      return(value?: StreamChunk): Promise<IteratorResult<StreamChunk>> {
+        try {
+          if (typeof it.return === 'function') {
+            const result = it.return(value);
+            return Promise.resolve(result);
+          }
+          return Promise.resolve({ value: undefined as unknown as StreamChunk, done: true });
+        } catch (err) {
+          return Promise.reject(err);
+        }
+      },
+      throw(err?: unknown): Promise<IteratorResult<StreamChunk>> {
+        try {
+          if (typeof it.throw === 'function') {
+            const result = it.throw(err);
+            return Promise.resolve(result);
+          }
+          return Promise.reject(err);
+        } catch (thrown) {
+          return Promise.reject(thrown);
+        }
+      },
+    };
+  }
+  throw new TypeError('stream watchdog source is neither AsyncIterable nor Iterable');
+}
+
+/**
+ * Coerce an unknown abort-reason into an `Error`. Node's `signal.reason`
+ * may be any value (including the DOMException we set), so we normalize
+ * to make `err instanceof Error` reliable for consumers.
+ */
+function abortError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
+  const err = new DOMException(
+    typeof reason === 'string' && reason.length > 0 ? reason : 'stream aborted',
+    'AbortError'
+  );
+  return err as unknown as Error;
+}

--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -17,6 +17,11 @@ import { buildAssembledSystemPromptAsync } from '../agent/system.js';
 import { stripInternalOptions } from '../agent/index.js';
 import { buildSessionHeaders } from '../providers/sessionHeaders.js';
 import type { CompletionOptions } from '../providers/sapOrchestration.js';
+import {
+  createStreamWatchdog,
+  DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+  DEFAULT_STREAM_TOOL_EXTENSION_MS,
+} from './streamWatchdog.js';
 
 export interface StreamingOptions {
   modelOverride?: string;
@@ -33,6 +38,18 @@ export interface StreamingOptions {
   agentId?: string;
   /** Working directory for env info and AGENTS.md loading */
   workdir?: string;
+  /**
+   * Idle timeout in ms for the streaming watchdog. If no chunk arrives
+   * within this window, the stream is aborted with an AbortError.
+   * Default: 30_000 ms. Set to `Infinity` or `0` to disable.
+   */
+  streamIdleTimeoutMs?: number;
+  /**
+   * Extended idle window (ms) applied while a long-running tool call
+   * (bash, shell, background_process, agent_manager) is being streamed.
+   * Default: 600_000 ms (10 minutes).
+   */
+  streamToolExtensionMs?: number;
 }
 
 export interface StreamingResult {
@@ -52,184 +69,285 @@ export interface StreamingResult {
 export type { StreamChunk };
 
 /**
- * Stream chat completion, yielding text chunks as they arrive
- * Collects and returns full response after streaming completes
+ * The hand-rolled iterator returned by {@link streamChat}. Mirrors the
+ * `AsyncGenerator<StreamChunk, StreamingResult>` shape so existing callers
+ * that either `for await` or manually drive `next()` / inspect the final
+ * `{ done: true, value }` continue to work unchanged.
+ *
+ * The critical difference from a native `async function*` is that
+ * `return()` runs immediately — it fires the internal abort controller,
+ * schedules a fire-and-forget teardown of the underlying provider stream,
+ * and resolves synchronously without awaiting any outstanding pull. This
+ * fixes the Cline-#12249 preemption trap where a stalled provider stream
+ * (server responded 200 but has gone silent) hangs the caller on
+ * teardown.
  */
-export async function* streamChat(
+export interface StreamChatIterator extends AsyncIterableIterator<StreamChunk> {
+  next(): Promise<IteratorResult<StreamChunk, StreamingResult>>;
+  return(value?: unknown): Promise<IteratorResult<StreamChunk, StreamingResult>>;
+  throw(err?: unknown): Promise<IteratorResult<StreamChunk, StreamingResult>>;
+}
+
+/**
+ * Stream chat completion, yielding text chunks as they arrive.
+ *
+ * Collects and returns the full response as the terminal value of the
+ * iterator (accessible via the `value` field when `done === true`). The
+ * iterator is hand-rolled (not a native `async function*`) so that
+ * `return()` can preempt outstanding provider pulls — see
+ * {@link StreamChatIterator} for the rationale.
+ */
+export function streamChat(
   message: string | unknown[],
   options?: StreamingOptions
-): AsyncGenerator<StreamChunk, StreamingResult> {
+): StreamChatIterator {
   const effortConfig = getEffortConfig(options?.effort ?? DEFAULT_EFFORT);
   const preferCheap = options?.preferCheap ?? effortConfig.preferCheap;
 
-  // Extract text for routing and session history (multimodal messages have array content)
+  // Extract text for routing and session history (multimodal messages have
+  // array content).
   const isMultimodal = Array.isArray(message);
   const messageText = isMultimodal ? '[multimodal message]' : message;
 
+  // Mutable state shared across the setup phase and the streaming phase.
+  // `modelId` may be reassigned by the fallback resolver or the router.
   let modelId: string;
   let routingReason: string | undefined;
 
-  // Auto-routing enabled?
   if (options?.autoRoute && !options?.modelOverride) {
     const decision = routePrompt(messageText, { preferCheap });
     modelId = decision.modelId;
     routingReason = decision.reason;
   } else {
-    // Use specified or default model
     modelId = (options?.modelOverride ?? getDefaultModel()).trim();
   }
 
-  // Assemble the effective system prompt using the pipeline.
-  // buildAssembledSystemPrompt handles soul → model → env → agent → AGENTS.md layers.
-  // A manual systemPrompt (e.g. from /system command) is appended as custom rules.
-  const assembledPrompt = await buildAssembledSystemPromptAsync({
-    modelId,
-    agentId: options?.agentId,
-    workdir: options?.workdir,
-    customRules: options?.systemPrompt,
-    sessionId: options?.sessionManager?.getCurrentSession()?.metadata.id,
-  });
-
-  // Build messages array with history if session manager provided
-  // Content can be string (text) or unknown[] (multimodal content items)
-  const messages: Array<{ role: string; content: string | unknown[] }> = [];
-
-  if (options?.sessionManager) {
-    const session = options.sessionManager.getCurrentSession();
-
-    // Initialize session if needed
-    if (!session) {
-      options.sessionManager.createSession(modelId);
-    }
-
-    // Get conversation history
-    const history = options.sessionManager.getHistory(20); // Last 20 messages
-
-    // Add assembled system prompt if not already in history
-    if (assembledPrompt && !history.some((m) => m.role === 'system')) {
-      messages.push({ role: 'system', content: assembledPrompt });
-    }
-
-    // Add conversation history
-    messages.push(...history.map((m) => ({ role: m.role, content: m.content })));
-  } else {
-    // Single message without history
-    if (assembledPrompt) {
-      messages.push({ role: 'system', content: assembledPrompt });
-    }
-  }
-
-  // If a `switchTo(...)` happened since the last outbound user turn, stamp
-  // an `<agent_switch from="X" to="Y"/>` marker on this user message so the
-  // destination agent's model can see the handover. Only text messages get
-  // the prefix; multimodal content arrays are passed through unchanged
-  // because prepending to an array item is ambiguous.
-  let outboundContent: string | unknown[] = message;
-  let outboundTextForSession = messageText;
-  try {
-    const { getAgentRegistry } = await import('../agent/index.js');
-    const marker = getAgentRegistry().consumePendingSwitchMarker();
-    if (marker && !isMultimodal && typeof message === 'string') {
-      const prefixed = `<agent_switch from="${marker.from}" to="${marker.to}"/>\n\n${message}`;
-      outboundContent = prefixed;
-      outboundTextForSession = prefixed;
-    }
-  } catch {
-    // Agent registry not available in this environment — no-op.
-  }
-
-  // Add current user message
-  messages.push({ role: 'user', content: outboundContent });
-
-  // Get SAP Orchestration provider for this model, falling back to
-  // routingConfig.preferences.fallbackModel if the primary id is not recognized.
-  const resolution = getProviderForModelWithFallback(modelId);
-  const provider = resolution.provider;
-  if (resolution.usedFallback) {
-    modelId = resolution.effectiveModelId;
-  }
-
-  // Build agent observability headers
-  const sessionId = options?.sessionManager?.getCurrentSession()?.metadata.id;
-  const extraHeaders = buildSessionHeaders(
-    sessionId ?? 'anonymous',
-    undefined,
-    options?.agentId,
-    undefined // parentAgentId - future enhancement
-  );
-
   let fullText = '';
   let finalUsage: StreamingResult['usage'];
+  // The watchdog-wrapped source iterator, created lazily on first next().
+  let watchdog: ReturnType<typeof createStreamWatchdog> | null = null;
+  let setupDone = false;
+  let finished = false;
+  // Naturally-completed vs. aborted/failed. We only tick route success on
+  // a clean end-of-stream, not on preemptive return() or provider error.
+  let completedCleanly = false;
+  // Cache the terminal result so repeat `next()` calls after `done: true`
+  // return the same value without re-persisting the session/cost record.
+  let cachedResult: StreamingResult | null = null;
+  let outboundTextForSession = messageText;
 
-  // Stream using SAP Orchestration provider. Wrap so permanent failures
-  // (401/403/404, model_not_found, deployment_not_found) tick the route's
-  // auto-disable counter; success resets it. Transient errors are left to
-  // ErrorBackoff.
-  try {
+  async function setup(): Promise<void> {
+    if (setupDone) {
+      return;
+    }
+    setupDone = true;
+
+    // Assemble the effective system prompt using the pipeline.
+    // buildAssembledSystemPrompt handles soul -> model -> env -> agent ->
+    // AGENTS.md layers. A manual systemPrompt (e.g. from /system command)
+    // is appended as custom rules.
+    const assembledPrompt = await buildAssembledSystemPromptAsync({
+      modelId,
+      agentId: options?.agentId,
+      workdir: options?.workdir,
+      customRules: options?.systemPrompt,
+      sessionId: options?.sessionManager?.getCurrentSession()?.metadata.id,
+    });
+
+    // Build messages array with history if session manager provided.
+    // Content can be string (text) or unknown[] (multimodal content items).
+    const messages: Array<{ role: string; content: string | unknown[] }> = [];
+
+    if (options?.sessionManager) {
+      const session = options.sessionManager.getCurrentSession();
+      if (!session) {
+        options.sessionManager.createSession(modelId);
+      }
+      const history = options.sessionManager.getHistory(20);
+      if (assembledPrompt && !history.some((m) => m.role === 'system')) {
+        messages.push({ role: 'system', content: assembledPrompt });
+      }
+      messages.push(...history.map((m) => ({ role: m.role, content: m.content })));
+    } else {
+      if (assembledPrompt) {
+        messages.push({ role: 'system', content: assembledPrompt });
+      }
+    }
+
+    // If a `switchTo(...)` happened since the last outbound user turn,
+    // stamp an `<agent_switch from="X" to="Y"/>` marker on this user
+    // message so the destination agent's model can see the handover.
+    let outboundContent: string | unknown[] = message;
+    try {
+      const { getAgentRegistry } = await import('../agent/index.js');
+      const marker = getAgentRegistry().consumePendingSwitchMarker();
+      if (marker && !isMultimodal && typeof message === 'string') {
+        const prefixed = `<agent_switch from="${marker.from}" to="${marker.to}"/>\n\n${message}`;
+        outboundContent = prefixed;
+        outboundTextForSession = prefixed;
+      }
+    } catch {
+      // Agent registry not available in this environment - no-op.
+    }
+
+    messages.push({ role: 'user', content: outboundContent });
+
+    // Get SAP Orchestration provider for this model, falling back to
+    // routingConfig.preferences.fallbackModel if the primary id is not
+    // recognized.
+    const resolution = getProviderForModelWithFallback(modelId);
+    const provider = resolution.provider;
+    if (resolution.usedFallback) {
+      modelId = resolution.effectiveModelId;
+    }
+
+    // Build agent observability headers.
+    const sessionId = options?.sessionManager?.getCurrentSession()?.metadata.id;
+    const extraHeaders = buildSessionHeaders(
+      sessionId ?? 'anonymous',
+      undefined,
+      options?.agentId,
+      undefined // parentAgentId - future enhancement
+    );
+
     // Build the completion-options bag and strip any agent-metadata keys
-    // before dispatch. Keys defined in `INTERNAL_OPTION_KEYS` (agent id,
-    // displayName, source, reference, resolved, mode, aliases, ...) must
-    // never reach SAP AI Core / SAP Orchestration; see
-    // `stripInternalOptions` in `src/agent/index.ts`.
+    // before dispatch. Keys defined in `INTERNAL_OPTION_KEYS` must never
+    // reach SAP AI Core / SAP Orchestration; see `stripInternalOptions`.
     const merged: CompletionOptions = {
       maxTokens: options?.maxTokens ?? effortConfig.maxTokens,
       temperature: options?.temperature,
-      signal: options?.signal,
+      // Note: the watchdog splices its own signal in via sourceFactory,
+      // combining the caller signal with an idle-timeout controller. Do
+      // not forward options.signal here — the watchdog forwards it.
       headers: extraHeaders as Record<string, string>,
     };
     const providerOpts = stripInternalOptions(merged) as CompletionOptions;
-    for await (const chunk of provider.streamComplete(messages, providerOpts)) {
-      fullText += chunk.text;
-      if (chunk.usage) finalUsage = chunk.usage;
-      yield chunk;
-    }
-  } catch (err) {
-    const classified = classifyRouteError(err);
-    if (classified.kind === 'permanent') {
-      recordRouteOutcome(modelId, classified);
-    }
-    const formatted = formatProviderError(err);
-    if (err instanceof Error && formatted !== err.message) {
-      err.message = formatted;
-    }
-    throw err;
-  }
-  recordRouteOutcome(modelId, { kind: 'success' });
 
-  // Save messages to session AFTER streaming completes (not per-chunk).
-  // Persist the raw outbound content (including any `<agent_switch/>`
-  // marker) so session replay preserves the handover context. TUI display
-  // and `sessions export` strip the wrappers.
-  if (options?.sessionManager) {
-    options.sessionManager.addMessage('user', outboundTextForSession, {
-      input: finalUsage?.prompt_tokens,
-    });
-    options.sessionManager.addMessage('assistant', fullText, {
-      output: finalUsage?.completion_tokens,
-    });
-  }
-
-  // Record cost for this API call
-  if (finalUsage?.prompt_tokens || finalUsage?.completion_tokens) {
-    const sessionId = options?.sessionManager?.getCurrentSession()?.metadata.id;
-    getCostTracker().recordUsage(
-      modelId,
-      finalUsage.prompt_tokens ?? 0,
-      finalUsage.completion_tokens ?? 0,
-      sessionId,
+    watchdog = createStreamWatchdog(
+      (effectiveSignal) =>
+        provider.streamComplete(messages, { ...providerOpts, signal: effectiveSignal }),
       {
-        read: finalUsage.cache_read_input_tokens,
-        write: finalUsage.cache_creation_input_tokens,
+        signal: options?.signal,
+        idleTimeoutMs: options?.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+        toolExtensionMs: options?.streamToolExtensionMs ?? DEFAULT_STREAM_TOOL_EXTENSION_MS,
       }
     );
   }
 
-  return {
-    text: fullText,
-    usage: finalUsage,
-    modelUsed: modelId,
-    routingReason,
+  function persistAndRecord(): StreamingResult {
+    if (cachedResult) {
+      return cachedResult;
+    }
+    if (completedCleanly) {
+      recordRouteOutcome(modelId, { kind: 'success' });
+    }
+    // Save messages to session AFTER streaming completes (not per-chunk).
+    // Persist the raw outbound content (including any `<agent_switch/>`
+    // marker) so session replay preserves the handover context. TUI
+    // display and `sessions export` strip the wrappers.
+    if (options?.sessionManager) {
+      options.sessionManager.addMessage('user', outboundTextForSession, {
+        input: finalUsage?.prompt_tokens,
+      });
+      options.sessionManager.addMessage('assistant', fullText, {
+        output: finalUsage?.completion_tokens,
+      });
+    }
+
+    if (finalUsage?.prompt_tokens || finalUsage?.completion_tokens) {
+      const sessionId = options?.sessionManager?.getCurrentSession()?.metadata.id;
+      getCostTracker().recordUsage(
+        modelId,
+        finalUsage.prompt_tokens ?? 0,
+        finalUsage.completion_tokens ?? 0,
+        sessionId,
+        {
+          read: finalUsage.cache_read_input_tokens,
+          write: finalUsage.cache_creation_input_tokens,
+        }
+      );
+    }
+
+    cachedResult = {
+      text: fullText,
+      usage: finalUsage,
+      modelUsed: modelId,
+      routingReason,
+    };
+    return cachedResult;
+  }
+
+  const iterator: StreamChatIterator = {
+    async next(): Promise<IteratorResult<StreamChunk, StreamingResult>> {
+      if (finished) {
+        return { value: persistAndRecord(), done: true };
+      }
+      try {
+        if (!setupDone) {
+          await setup();
+        }
+        // watchdog is guaranteed non-null after setup().
+        const step = await watchdog!.next();
+        if (step.done) {
+          finished = true;
+          completedCleanly = true;
+          return { value: persistAndRecord(), done: true };
+        }
+        const chunk = step.value;
+        fullText += chunk.text;
+        if (chunk.usage) {
+          finalUsage = chunk.usage;
+        }
+        return { value: chunk, done: false };
+      } catch (err) {
+        finished = true;
+        // Best-effort tear down the source without awaiting.
+        if (watchdog) {
+          void watchdog.return();
+        }
+        const classified = classifyRouteError(err);
+        if (classified.kind === 'permanent') {
+          recordRouteOutcome(modelId, classified);
+        }
+        const formatted = formatProviderError(err);
+        if (err instanceof Error && formatted !== err.message) {
+          err.message = formatted;
+        }
+        throw err;
+      }
+    },
+
+    async return(_value?: unknown): Promise<IteratorResult<StreamChunk, StreamingResult>> {
+      if (finished) {
+        return { value: persistAndRecord(), done: true };
+      }
+      finished = true;
+      // Preemptive teardown: signal the watchdog to fire its abort and
+      // schedule a fire-and-forget provider.return(). Critically we do
+      // NOT await the watchdog's own outstanding pull chain here — the
+      // watchdog's return() is designed to resolve immediately.
+      if (watchdog) {
+        void watchdog.return();
+      }
+      return { value: persistAndRecord(), done: true };
+    },
+
+    async throw(err?: unknown): Promise<IteratorResult<StreamChunk, StreamingResult>> {
+      if (!finished) {
+        finished = true;
+        if (watchdog) {
+          void watchdog.return();
+        }
+      }
+      throw err;
+    },
+
+    [Symbol.asyncIterator](): StreamChatIterator {
+      return iterator;
+    },
   };
+
+  return iterator;
 }
 
 /**

--- a/tests/core/streamingOrchestrator.test.ts
+++ b/tests/core/streamingOrchestrator.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for the streaming orchestrator watchdog and hand-rolled iterator
+ * (issue #1115). Verifies that:
+ *
+ *  1. `streamChat` returns a hand-rolled iterator whose `return()` runs
+ *     immediately and does NOT await an outstanding provider pull.
+ *  2. A stalled provider stream is aborted by the idle-timeout watchdog
+ *     within the configured window.
+ *  3. Streamed tool-call deltas for long-running tools (bash, shell,
+ *     background_process, agent_manager) extend the idle window so the
+ *     model can wait for legitimate tool execution without being killed.
+ *  4. External caller-provided AbortSignal is still honoured (cascades
+ *     to the watchdog's controller).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../src/providers/index.js', () => ({
+  getProviderForModelWithFallback: vi.fn(),
+  getDefaultModel: vi.fn(() => 'gpt-4o'),
+}));
+
+vi.mock('../../src/core/router.js', () => ({
+  routePrompt: vi.fn(),
+  recordRouteOutcome: vi.fn(),
+  classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
+}));
+
+import { streamChat } from '../../src/core/streamingOrchestrator.js';
+import { getProviderForModelWithFallback, getDefaultModel } from '../../src/providers/index.js';
+import type { StreamChunk } from '../../src/providers/index.js';
+
+interface StreamCall {
+  signal?: AbortSignal;
+  aborted: boolean;
+  returnCalled: boolean;
+}
+
+/**
+ * Build a provider whose stream:
+ *  - yields one initial chunk (so tests can distinguish "first chunk"
+ *    from "waiting for next"), then
+ *  - parks on a promise that only settles when the effective abort
+ *    signal fires (mirroring a stalled SAP AI Core SSE stream).
+ * Records teardown so tests can assert `return()` reached the source.
+ */
+function makeStalledProvider(): {
+  provider: { streamComplete: ReturnType<typeof vi.fn> };
+  latest(): StreamCall;
+} {
+  const calls: StreamCall[] = [];
+
+  function streamComplete(_messages: unknown, opts?: { signal?: AbortSignal }) {
+    const call: StreamCall = { signal: opts?.signal, aborted: false, returnCalled: false };
+    calls.push(call);
+
+    async function* gen(): AsyncGenerator<StreamChunk> {
+      try {
+        yield { text: 'hello' };
+        await new Promise<void>((_resolve, reject) => {
+          const sig = opts?.signal;
+          if (sig?.aborted) {
+            call.aborted = true;
+            reject(new DOMException('Aborted', 'AbortError'));
+            return;
+          }
+          sig?.addEventListener(
+            'abort',
+            () => {
+              call.aborted = true;
+              reject(new DOMException('Aborted', 'AbortError'));
+            },
+            { once: true }
+          );
+        });
+        // Unreachable, but keeps the generator valid.
+        yield { text: 'never' };
+      } finally {
+        call.returnCalled = true;
+      }
+    }
+
+    return gen();
+  }
+
+  return {
+    provider: { streamComplete: vi.fn(streamComplete) },
+    latest: () => calls[calls.length - 1]!,
+  };
+}
+
+/**
+ * Build a provider that yields a fixed list of chunks (no stalling).
+ */
+function makeFiniteProvider(chunks: StreamChunk[]): {
+  provider: { streamComplete: ReturnType<typeof vi.fn> };
+} {
+  function streamComplete(_messages: unknown, _opts?: unknown) {
+    async function* gen(): AsyncGenerator<StreamChunk> {
+      for (const c of chunks) {
+        yield c;
+      }
+    }
+    return gen();
+  }
+  return { provider: { streamComplete: vi.fn(streamComplete) } };
+}
+
+describe('streamChat hand-rolled iterator preemption (issue #1115)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDefaultModel).mockReturnValue('gpt-4o');
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('return() on a stalled stream resolves immediately without awaiting the outstanding pull', async () => {
+    const { provider, latest } = makeStalledProvider();
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: provider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: false,
+    });
+
+    const iter = streamChat('hi', {
+      modelOverride: 'gpt-4o',
+      // Disable idle timeout for this test — we want return() itself to
+      // preempt, not the watchdog.
+      streamIdleTimeoutMs: 0,
+    });
+
+    // Pull the first chunk; the provider generator will be suspended at
+    // its post-yield state.
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    expect((first.value as StreamChunk).text).toBe('hello');
+    expect(latest().returnCalled).toBe(false);
+
+    // Fire the second pull. The provider generator resumes and parks on
+    // its stalled `await` — this is the Cline #12249 hot spot. The
+    // outstanding `iter.next()` promise is now pending indefinitely.
+    const outstanding = iter.next();
+
+    // Preemptively return. This must resolve quickly even though the
+    // provider is blocked on the stalled await. The Cline #12249
+    // preemption trap for async-generator return() would have hung this
+    // call because the source's return() has to unwind through the
+    // pending await.
+    const start = Date.now();
+    const closed = await iter.return();
+    const elapsed = Date.now() - start;
+
+    expect(closed.done).toBe(true);
+    expect(elapsed).toBeLessThan(200);
+
+    // The outstanding pull rejects with an AbortError once the watchdog
+    // fires its internal controller. This is deterministic and does not
+    // require any wall-clock wait.
+    await expect(outstanding).rejects.toBeInstanceOf(Error);
+
+    // Give the event loop a few ticks so the fire-and-forget teardown
+    // on the source generator's finally-block lands.
+    for (let i = 0; i < 5; i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    expect(latest().aborted).toBe(true);
+    expect(latest().returnCalled).toBe(true);
+  });
+
+  it('aborts a stalled stream via idle-timeout watchdog within the configured window', async () => {
+    const { provider, latest } = makeStalledProvider();
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: provider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: false,
+    });
+
+    const iter = streamChat('hi', {
+      modelOverride: 'gpt-4o',
+      streamIdleTimeoutMs: 100, // tiny window for a fast test
+    });
+
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    expect((first.value as StreamChunk).text).toBe('hello');
+
+    const start = Date.now();
+    await expect(iter.next()).rejects.toBeInstanceOf(Error);
+    const elapsed = Date.now() - start;
+
+    // The idle timer should fire around 100ms. Allow a wide upper bound
+    // for slow CI machines.
+    expect(elapsed).toBeGreaterThanOrEqual(80);
+    expect(elapsed).toBeLessThan(1500);
+    expect(latest().aborted).toBe(true);
+    expect(latest().returnCalled).toBe(true);
+  });
+
+  it('extends the idle window while a long-running tool call is being streamed', async () => {
+    // Provider: emit a bash tool-call delta, then stall. With the default
+    // idle window (very small in this test) the stream would be killed
+    // fast — but the long-running-tool extension should keep it alive.
+    const streamCalls: StreamCall[] = [];
+    const provider = {
+      streamComplete: vi.fn(function streamComplete(
+        _messages: unknown,
+        opts?: { signal?: AbortSignal }
+      ) {
+        const call: StreamCall = {
+          signal: opts?.signal,
+          aborted: false,
+          returnCalled: false,
+        };
+        streamCalls.push(call);
+        async function* gen(): AsyncGenerator<StreamChunk> {
+          try {
+            yield {
+              text: '',
+              toolCalls: [
+                {
+                  index: 0,
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'bash', arguments: '{"cmd":"sleep 5"}' },
+                },
+              ],
+            };
+            await new Promise<void>((_resolve, reject) => {
+              const sig = opts?.signal;
+              if (sig?.aborted) {
+                call.aborted = true;
+                reject(new DOMException('Aborted', 'AbortError'));
+                return;
+              }
+              sig?.addEventListener(
+                'abort',
+                () => {
+                  call.aborted = true;
+                  reject(new DOMException('Aborted', 'AbortError'));
+                },
+                { once: true }
+              );
+            });
+            yield { text: 'never' };
+          } finally {
+            call.returnCalled = true;
+          }
+        }
+        return gen();
+      }),
+    };
+
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: provider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: false,
+    });
+
+    const iter = streamChat('run a bash command', {
+      modelOverride: 'gpt-4o',
+      streamIdleTimeoutMs: 100, // would fire in 100ms without extension
+      streamToolExtensionMs: 5_000, // extended window
+    });
+
+    // First chunk carries the bash tool call.
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    expect((first.value as StreamChunk).toolCalls?.[0]?.function?.name).toBe('bash');
+
+    // Race a 400ms deadline against the second pull. Because bash is in
+    // the long-running set, the idle window is now 5s and the second
+    // pull should still be pending after 400ms (i.e. NOT aborted).
+    const pull = iter.next();
+    const raceResult = await Promise.race([
+      pull.then(() => 'settled' as const).catch(() => 'settled'),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 400)),
+    ]);
+    expect(raceResult).toBe('pending');
+
+    // Tear down cleanly so vitest does not report leaked timers.
+    await iter.return();
+    await new Promise((r) => setImmediate(r));
+    await expect(pull).rejects.toBeInstanceOf(Error);
+    expect(streamCalls[streamCalls.length - 1]?.aborted).toBe(true);
+  });
+
+  it('forwards caller AbortSignal to the provider stream', async () => {
+    const { provider, latest } = makeStalledProvider();
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: provider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: false,
+    });
+
+    const ac = new AbortController();
+    const iter = streamChat('hi', {
+      modelOverride: 'gpt-4o',
+      signal: ac.signal,
+      streamIdleTimeoutMs: 0,
+    });
+
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+
+    const pull = iter.next();
+    ac.abort();
+    await expect(pull).rejects.toBeInstanceOf(Error);
+    expect(latest().aborted).toBe(true);
+  });
+
+  it('completes naturally and returns a StreamingResult when the source ends', async () => {
+    const { provider } = makeFiniteProvider([
+      { text: 'a' },
+      { text: 'b' },
+      { text: '', usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 } },
+    ]);
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: provider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: false,
+    });
+
+    const iter = streamChat('hi', { modelOverride: 'gpt-4o' });
+    const chunks: string[] = [];
+
+    async function drain(): Promise<{ modelUsed: string; usage?: { total_tokens?: number } }> {
+      for (;;) {
+        const step = await iter.next();
+        if (step.done) {
+          return step.value as { modelUsed: string; usage?: { total_tokens?: number } };
+        }
+        chunks.push(step.value.text);
+      }
+    }
+
+    const finalResult = await drain();
+    expect(chunks.join('')).toBe('ab');
+    expect(finalResult.modelUsed).toBe('gpt-4o');
+    expect(finalResult.usage?.total_tokens).toBe(5);
+  });
+
+  it('is drivable via `for await` (Symbol.asyncIterator)', async () => {
+    const { provider } = makeFiniteProvider([{ text: 'x' }, { text: 'y' }]);
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: provider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: false,
+    });
+
+    const iter = streamChat('hi', { modelOverride: 'gpt-4o' });
+    const chunks: string[] = [];
+    for await (const c of iter) {
+      chunks.push(c.text);
+    }
+    expect(chunks).toEqual(['x', 'y']);
+  });
+});


### PR DESCRIPTION
Closes #1115.

## Summary

Fixes hung sessions when SAP AI Core streams stall mid-turn.

## Root cause

A native \`async function*\` generator's \`return()\` cannot preempt an in-flight \`await\` inside the generator body. When the provider stream stalls (SAP AI Core returned 200 OK then went silent) and the consumer aborts, the outer generator's teardown waits until the pending source \`await\` settles — which never happens. Documented in tests/providers/sapOrchestration-streamAbort.test.ts and Cline PR #12249.

## What changed

- New \`src/core/streamWatchdog.ts\` — a provider-agnostic hand-rolled \`AsyncIterableIterator\` wrapper with:
  - **Preemptive \`return()\`**: fires an internal AbortController and calls \`source.return()\` fire-and-forget. Resolves immediately without awaiting outstanding pulls.
  - **Idle-timeout watchdog**: aborts the stream when no chunk arrives within \`idleTimeoutMs\` (default 30_000 ms).
  - **Tool-aware extension**: long-running tools (\`bash\`, \`shell\`, \`background_process\`, \`agent_manager\`) extend the idle window to \`toolExtensionMs\` (default 10 min) while their tool-call deltas are being streamed.
  - Accepts either \`AsyncIterable\` (production) or \`Iterable\` (test doubles) sources.

- \`src/core/streamingOrchestrator.ts\` — \`streamChat\` refactored from \`async function*\` to a hand-rolled \`StreamChatIterator\` that composes the watchdog. Public shape (\`AsyncIterableIterator<StreamChunk>\` with terminal \`StreamingResult\` value) is preserved so existing consumers in \`server/\`, \`cli/interactive.ts\`, and \`cli/tui/hooks/useStreamChat.ts\` continue to work.

- \`src/providers/sapOrchestration.ts\` — no changes required. The SAP SDK already accepts \`options.signal\` and wires it to its internal abort controller; the watchdog splices its controller into the signal chain via a \`sourceFactory\` indirection.

- \`tests/core/streamingOrchestrator.test.ts\` — six tests covering: preemptive return on a stalled stream, idle-timeout abort, tool-aware idle extension for a bash tool call, caller AbortSignal propagation, natural completion producing a StreamingResult, and drivability via \`for await\`.

## Public API

New optional \`StreamingOptions\` fields:

- \`streamIdleTimeoutMs?: number\` — default 30_000, \`0\` or \`Infinity\` disables.
- \`streamToolExtensionMs?: number\` — default 600_000.

Existing callers do not need to change.

## Verification

All gates green locally:
- \`npm run lint\` — 0 errors (warnings unchanged from baseline)
- \`npm run typecheck\` — 0 errors
- \`npm run format:check\` — clean
- \`npm run test:coverage\` — 3254 pass, 3 skipped, 0 fail. Line coverage 65.41% (>= 40% CI gate). New files sit at 71.75% / 79.04%.
- \`npm run build\` — clean.

[alexi-bot]