### PR TITLE
feat(tools): add shell environment info to bash tool description

### DIFF
--- a/src/tool/tools/bash.ts
+++ b/src/tool/tools/bash.ts
@@ -11,6 +11,7 @@ import { defineTool, truncateOutput, persistLargeOutput, type ToolResult } from 
 import { normalizeUrls } from '../../utils/url.js';
 import { auditCommand } from '../../permission/next.js';
 import { detectShell, shellSpawnArgs, type ShellInfo } from './shell/id.js';
+import { detectShellEnv, formatShellEnvSummary } from './shell/env.js';
 import {
   BashDetachAvailable,
   BashDetachedExited,
@@ -112,7 +113,15 @@ function processCarriageReturns(output: string): string {
  * shell is re-detected per-request rather than frozen once at startup.
  */
 export function buildBashDescription(shell: ShellInfo = detectShell()): string {
+  // Probe version + PATH + available tools per description build so a
+  // fresh install of `gh` or `docker` mid-session shows up on the next
+  // tool-schema flush (Cline PR #12331; issue #1123). The probe caches
+  // internally for a short TTL, so calling this on every description
+  // render is still cheap.
+  const envSummary = formatShellEnvSummary(detectShellEnv(shell));
   return `Execute a ${shell.type} command in a shell.
+
+${envSummary}
 
 Usage:
 - Use for terminal operations like git, npm, docker, etc.

--- a/src/tool/tools/shell.ts
+++ b/src/tool/tools/shell.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { defineTool, truncateOutput, persistLargeOutput, type ToolResult } from '../index.js';
 import { normalizeUrls } from '../../utils/url.js';
 import { detectShell, shellSpawnArgs, type ShellInfo } from './shell/id.js';
+import { detectShellEnv, formatShellEnvSummary } from './shell/env.js';
 import { auditCommand } from '../../permission/next.js';
 import {
   BashDetachAvailable,
@@ -106,7 +107,15 @@ function processCarriageReturns(output: string): string {
  * and via the `description` getter below.
  */
 export function buildShellDescription(shell: ShellInfo = detectShell()): string {
+  // Probe version + PATH + available tools per description build so a
+  // fresh install of `gh` or `docker` mid-session shows up on the next
+  // tool-schema flush (Cline PR #12331; issue #1123). The probe caches
+  // internally for a short TTL, so calling this on every description
+  // render is still cheap.
+  const envSummary = formatShellEnvSummary(detectShellEnv(shell));
   return `Execute a ${shell.type} command in the user's environment.
+
+${envSummary}
 
 Usage:
 - Use for terminal operations like git, npm, docker, etc.

--- a/src/tool/tools/shell/env.ts
+++ b/src/tool/tools/shell/env.ts
@@ -1,0 +1,287 @@
+/**
+ * Shell Environment Probe
+ *
+ * Complements `./id.ts` (which resolves *which* shell will be used) by
+ * capturing runtime environment information about that shell that is
+ * useful for the LLM when generating commands: the shell version, a
+ * short summary of `$PATH`, and which of a small set of common tools
+ * (`git`, `gh`, `npm`, `node`, `docker`, `kubectl`) are actually
+ * installed on the runner.
+ *
+ * Motivated by issue #1123 / Cline PR #12331: when a shell command
+ * fails because a tool is missing or a shell built-in doesn't behave
+ * the way the model expected, giving the model an accurate snapshot of
+ * the environment lets it fix the command in the next turn instead of
+ * repeatedly failing.
+ *
+ * Design notes:
+ * - Version detection uses `spawnSync` with a short timeout so a broken
+ *   shell binary cannot hang description-building indefinitely. The
+ *   first line of stdout is captured verbatim (bash prints
+ *   `GNU bash, version 5.1.16(1)-release ...`, zsh prints `zsh 5.9 ...`,
+ *   pwsh prints `PowerShell 7.4.0`). If the probe fails we return
+ *   `undefined` rather than throwing — description-building must never
+ *   crash because a probe returned a non-zero exit code.
+ * - Tool detection walks `process.env.PATH` entries and checks each
+ *   candidate name against `fs.existsSync(join(dir, name[+ext]))`. No
+ *   subprocess is spawned per tool; this keeps the probe cheap enough
+ *   to run per-tool-description without blocking the event loop.
+ * - Results are cached for `PROBE_TTL_MS` so a busy session doesn't
+ *   re-shell-out repeatedly. The cache is keyed by the shell path and
+ *   the current `PATH` so profile changes are picked up. Test hooks
+ *   allow the cache and both probes to be overridden.
+ */
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { detectShell, type ShellInfo, type ShellType } from './id.js';
+
+/**
+ * Runtime snapshot of the shell environment. All fields are optional
+ * except `shell` and `availableTools` (which may be empty). Callers
+ * that render descriptions should tolerate missing fields gracefully.
+ */
+export interface ShellEnv {
+  /** The detected shell (identity + path). */
+  shell: ShellInfo;
+  /**
+   * First line of the shell's `--version` (or equivalent) output, if
+   * the probe succeeded. Trimmed and never contains newlines.
+   */
+  version?: string;
+  /**
+   * The first `PATH_SUMMARY_ENTRIES` entries of `process.env.PATH`,
+   * split on the platform separator. Rendered into the description so
+   * the model can reason about where commands will resolve from
+   * (e.g. `/opt/homebrew/bin` present -> Homebrew tools available).
+   */
+  pathSummary: string[];
+  /**
+   * Which of `COMMON_TOOLS` are present on `PATH`. Order matches
+   * `COMMON_TOOLS` for stable output. May be empty on minimal images.
+   */
+  availableTools: string[];
+}
+
+/**
+ * The set of common developer tools we probe for. Chosen to match the
+ * issue #1123 acceptance criteria and to cover the majority of shell
+ * commands agents actually generate. Kept short deliberately — every
+ * additional name costs a filesystem existence check per PATH entry.
+ */
+export const COMMON_TOOLS: readonly string[] = ['git', 'gh', 'npm', 'node', 'docker', 'kubectl'];
+
+/**
+ * Number of `PATH` entries surfaced in the description. Anything beyond
+ * this is elided with a `(+N more)` suffix so the description stays
+ * readable and cache-friendly.
+ */
+export const PATH_SUMMARY_ENTRIES = 5;
+
+/** Cache TTL. Matches the shell-id detector so both caches age in step. */
+const PROBE_TTL_MS = 30_000;
+
+/**
+ * Version probe timeout. Deliberately short: a healthy shell responds
+ * to `--version` in <100ms; anything slower is almost certainly a
+ * broken PATH entry or a hung binary we should not wait for.
+ */
+const VERSION_PROBE_TIMEOUT_MS = 500;
+
+interface CachedEnv {
+  key: string;
+  env: ShellEnv;
+  expiresAt: number;
+}
+
+let cache: CachedEnv | undefined;
+
+/** Default version probe: shells out to `<shell> --version`. */
+type VersionProbe = (shell: ShellInfo) => string | undefined;
+let versionProbe: VersionProbe = defaultVersionProbe;
+
+/** Default tool probe: `fs.existsSync` walk over `PATH`. */
+type ToolProbe = (name: string, pathEntries: readonly string[]) => boolean;
+let toolProbe: ToolProbe = defaultToolProbe;
+
+/**
+ * Shells that speak POSIX `--version`. PowerShell also accepts
+ * `-Version` but the flag capitalisation varies across releases; we
+ * use `$PSVersionTable.PSVersion.ToString()` via `-NoProfile -Command`
+ * for reliability.
+ */
+function versionArgs(type: ShellType): string[] {
+  switch (type) {
+    case 'powershell':
+      return ['-NoProfile', '-Command', '$PSVersionTable.PSVersion.ToString()'];
+    case 'cmd':
+      // cmd.exe has no version subcommand; `ver` prints the OS version.
+      return ['/d', '/s', '/c', 'ver'];
+    default:
+      return ['--version'];
+  }
+}
+
+function defaultVersionProbe(shell: ShellInfo): string | undefined {
+  try {
+    const result = spawnSync(shell.path, versionArgs(shell.type), {
+      timeout: VERSION_PROBE_TIMEOUT_MS,
+      encoding: 'utf-8',
+      windowsHide: true,
+      // Isolate the probe from parent stdio; we only need stdout.
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    if (result.error || typeof result.stdout !== 'string') {
+      return undefined;
+    }
+    const firstLine = result.stdout.split(/\r?\n/).find((l) => l.trim().length > 0);
+    return firstLine?.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Split `process.env.PATH` (or `Path` on Windows) into a clean array
+ * of directory entries. Falls back to the empty list if PATH is
+ * missing entirely (unusual — most runners always set it).
+ */
+export function splitPath(rawPath: string | undefined = process.env.PATH): string[] {
+  if (!rawPath) {
+    return [];
+  }
+  const sep = process.platform === 'win32' ? ';' : ':';
+  return rawPath
+    .split(sep)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Executable extensions probed on Windows. On POSIX we check the bare
+ * name (no extension), matching how the shell would resolve it.
+ */
+function executableCandidates(name: string): string[] {
+  if (process.platform !== 'win32') {
+    return [name];
+  }
+  const rawExts = process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD';
+  const exts = rawExts
+    .split(';')
+    .map((e) => e.trim().toLowerCase())
+    .filter((e) => e.length > 0);
+  return [name, ...exts.map((ext) => `${name}${ext}`)];
+}
+
+function defaultToolProbe(name: string, pathEntries: readonly string[]): boolean {
+  const candidates = executableCandidates(name);
+  for (const dir of pathEntries) {
+    for (const candidate of candidates) {
+      const full = path.join(dir, candidate);
+      try {
+        if (fs.existsSync(full)) {
+          return true;
+        }
+      } catch {
+        // Continue — an unreadable PATH entry (permissions, dead
+        // symlink) must not abort the probe.
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Test hook: drop the cached probe result. Do not call from production
+ * code paths.
+ */
+export function _resetShellEnvCacheForTests(): void {
+  cache = undefined;
+}
+
+/**
+ * Test hook: replace the version probe. Pass `undefined` to restore
+ * the default `spawnSync`-based probe.
+ */
+export function _setVersionProbeForTests(probe?: VersionProbe): void {
+  versionProbe = probe ?? defaultVersionProbe;
+}
+
+/**
+ * Test hook: replace the tool-existence probe. Pass `undefined` to
+ * restore the default `fs.existsSync`-based probe.
+ */
+export function _setToolProbeForTests(probe?: ToolProbe): void {
+  toolProbe = probe ?? defaultToolProbe;
+}
+
+/**
+ * Detect the shell environment. Cheap on cache hit; on a cache miss
+ * performs one version probe (bounded by `VERSION_PROBE_TIMEOUT_MS`)
+ * and up to `COMMON_TOOLS.length * pathEntries.length` filesystem
+ * existence checks. Both are cached for `PROBE_TTL_MS`.
+ *
+ * Callers usually don't need to pass `shell` — `detectShell()` is
+ * called for them. The parameter exists for tests and for callers
+ * that want to describe a specific shell without re-probing.
+ */
+export function detectShellEnv(shell: ShellInfo = detectShell()): ShellEnv {
+  const pathEntries = splitPath();
+  const key = `${shell.type}|${shell.path}|${pathEntries.join(':')}`;
+
+  const now = Date.now();
+  if (cache && cache.key === key && cache.expiresAt > now) {
+    return cache.env;
+  }
+
+  const version = versionProbe(shell);
+  const availableTools = COMMON_TOOLS.filter((tool) => toolProbe(tool, pathEntries));
+  const pathSummary = pathEntries.slice(0, PATH_SUMMARY_ENTRIES);
+
+  const env: ShellEnv = {
+    shell: version ? { ...shell, version } : shell,
+    version,
+    pathSummary,
+    availableTools,
+  };
+
+  cache = { key, env, expiresAt: now + PROBE_TTL_MS };
+  return env;
+}
+
+/**
+ * Render the environment summary that gets prepended to the bash /
+ * shell tool description. Kept as a separate function so the bash and
+ * shell tools can share exactly the same wording.
+ *
+ * The returned string is either a single line ("Environment: ...") or
+ * empty when we know nothing beyond the shell type (in which case the
+ * caller falls back to its existing static preamble). Newlines inside
+ * the summary are avoided so the resulting description is
+ * cache-friendly.
+ */
+export function formatShellEnvSummary(env: ShellEnv): string {
+  const parts: string[] = [];
+
+  if (env.version) {
+    parts.push(`shell: ${env.version}`);
+  } else {
+    parts.push(`shell: ${env.shell.type}`);
+  }
+
+  if (env.pathSummary.length > 0) {
+    const shown = env.pathSummary.join(process.platform === 'win32' ? ';' : ':');
+    const total = splitPath().length;
+    const suffix =
+      total > env.pathSummary.length ? ` (+${total - env.pathSummary.length} more)` : '';
+    parts.push(`PATH: ${shown}${suffix}`);
+  }
+
+  if (env.availableTools.length > 0) {
+    parts.push(`Available tools: ${env.availableTools.join(', ')}`);
+  }
+
+  return `Environment: ${parts.join('. ')}.`;
+}

--- a/tests/tool/tools/shell-env.test.ts
+++ b/tests/tool/tools/shell-env.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for the shell environment probe that feeds the dynamic
+ * bash / shell tool descriptions.
+ *
+ * Issue #1123 / Cline PR #12331: the description surfaced to the LLM
+ * includes the shell version, a `PATH` summary, and which common
+ * developer tools are present, so the model can pick the right syntax
+ * and avoid attempting commands whose binaries are not installed.
+ *
+ * The version probe (`spawnSync`) and tool probe (`fs.existsSync` over
+ * PATH) are dependency-injected via `_setVersionProbeForTests` /
+ * `_setToolProbeForTests` because both real implementations touch the
+ * filesystem and subprocess table in ways vitest cannot easily mock.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  detectShellEnv,
+  formatShellEnvSummary,
+  splitPath,
+  COMMON_TOOLS,
+  PATH_SUMMARY_ENTRIES,
+  _resetShellEnvCacheForTests,
+  _setVersionProbeForTests,
+  _setToolProbeForTests,
+} from '../../../src/tool/tools/shell/env.js';
+import {
+  _resetDetectShellCacheForTests,
+  _setFsProbeForTests,
+  type ShellInfo,
+} from '../../../src/tool/tools/shell/id.js';
+import { buildBashDescription } from '../../../src/tool/tools/bash.js';
+import { buildShellDescription } from '../../../src/tool/tools/shell.js';
+
+const ORIGINAL_PLATFORM = process.platform;
+const ORIGINAL_ENV = { ...process.env };
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+function restorePlatform(): void {
+  Object.defineProperty(process, 'platform', {
+    value: ORIGINAL_PLATFORM,
+    configurable: true,
+  });
+}
+
+function cleanup(): void {
+  _resetShellEnvCacheForTests();
+  _resetDetectShellCacheForTests();
+  _setVersionProbeForTests(undefined);
+  _setToolProbeForTests(undefined);
+  _setFsProbeForTests(undefined);
+  restorePlatform();
+  process.env = { ...ORIGINAL_ENV };
+}
+
+const BASH_INFO: ShellInfo = { type: 'bash', path: '/bin/bash' };
+const PWSH_INFO: ShellInfo = {
+  type: 'powershell',
+  path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+};
+
+describe('splitPath', () => {
+  afterEach(cleanup);
+
+  it('splits POSIX PATH on colons', () => {
+    setPlatform('linux');
+    expect(splitPath('/usr/local/bin:/usr/bin:/bin')).toEqual([
+      '/usr/local/bin',
+      '/usr/bin',
+      '/bin',
+    ]);
+  });
+
+  it('splits Windows PATH on semicolons', () => {
+    setPlatform('win32');
+    expect(splitPath('C:\\Windows;C:\\Windows\\System32')).toEqual([
+      'C:\\Windows',
+      'C:\\Windows\\System32',
+    ]);
+  });
+
+  it('drops empty and whitespace-only entries', () => {
+    setPlatform('linux');
+    expect(splitPath('/usr/bin::  :/bin')).toEqual(['/usr/bin', '/bin']);
+  });
+
+  it('returns an empty array when PATH is undefined', () => {
+    // Pass an explicit empty string to exercise the missing-PATH path
+    // (the default-parameter form resolves to `process.env.PATH` when
+    // `undefined` is passed, which on CI is populated).
+    expect(splitPath('')).toEqual([]);
+  });
+});
+
+describe('detectShellEnv', () => {
+  beforeEach(() => {
+    _resetShellEnvCacheForTests();
+    _resetDetectShellCacheForTests();
+    setPlatform('linux');
+    process.env.PATH = '/usr/local/bin:/usr/bin:/bin';
+  });
+
+  afterEach(cleanup);
+
+  it('reports the version when the probe returns a first line', () => {
+    _setVersionProbeForTests(() => 'GNU bash, version 5.1.16(1)-release');
+    _setToolProbeForTests(() => false);
+
+    const env = detectShellEnv(BASH_INFO);
+
+    expect(env.version).toBe('GNU bash, version 5.1.16(1)-release');
+    // The version is also mirrored onto the returned shell for convenience.
+    expect(env.shell.version).toBe('GNU bash, version 5.1.16(1)-release');
+  });
+
+  it('omits version when the probe returns undefined (broken binary)', () => {
+    _setVersionProbeForTests(() => undefined);
+    _setToolProbeForTests(() => false);
+
+    const env = detectShellEnv(BASH_INFO);
+
+    expect(env.version).toBeUndefined();
+    // shell.version is only set when we actually captured one.
+    expect(env.shell.version).toBeUndefined();
+  });
+
+  it('captures the first PATH_SUMMARY_ENTRIES entries of PATH', () => {
+    process.env.PATH = ['/a', '/b', '/c', '/d', '/e', '/f', '/g'].join(':');
+    _resetShellEnvCacheForTests();
+    _setVersionProbeForTests(() => undefined);
+    _setToolProbeForTests(() => false);
+
+    const env = detectShellEnv(BASH_INFO);
+
+    expect(env.pathSummary).toHaveLength(PATH_SUMMARY_ENTRIES);
+    expect(env.pathSummary[0]).toBe('/a');
+    expect(env.pathSummary[PATH_SUMMARY_ENTRIES - 1]).toBe('/e');
+  });
+
+  it('returns the available tools in the order defined by COMMON_TOOLS', () => {
+    _setVersionProbeForTests(() => undefined);
+    // Pretend git, npm and docker are installed but nothing else.
+    _setToolProbeForTests((name) => name === 'git' || name === 'npm' || name === 'docker');
+
+    const env = detectShellEnv(BASH_INFO);
+
+    expect(env.availableTools).toEqual(['git', 'npm', 'docker']);
+    // Sanity check the order matches the COMMON_TOOLS declaration.
+    const idx = env.availableTools.map((t) => COMMON_TOOLS.indexOf(t));
+    expect(idx).toEqual([...idx].sort((a, b) => a - b));
+  });
+
+  it('caches results across calls with the same shell + PATH', () => {
+    let versionCalls = 0;
+    let toolCalls = 0;
+    _setVersionProbeForTests(() => {
+      versionCalls += 1;
+      return 'bash 5';
+    });
+    _setToolProbeForTests(() => {
+      toolCalls += 1;
+      return false;
+    });
+
+    detectShellEnv(BASH_INFO);
+    const afterFirstV = versionCalls;
+    const afterFirstT = toolCalls;
+
+    detectShellEnv(BASH_INFO);
+
+    expect(versionCalls).toBe(afterFirstV);
+    expect(toolCalls).toBe(afterFirstT);
+  });
+
+  it('re-probes when PATH changes (profile change simulation)', () => {
+    let versionCalls = 0;
+    _setVersionProbeForTests(() => {
+      versionCalls += 1;
+      return 'bash 5';
+    });
+    _setToolProbeForTests(() => false);
+
+    detectShellEnv(BASH_INFO);
+    expect(versionCalls).toBe(1);
+
+    // User installs Homebrew and prepends /opt/homebrew/bin to PATH.
+    process.env.PATH = '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin';
+    detectShellEnv(BASH_INFO);
+
+    expect(versionCalls).toBe(2);
+  });
+});
+
+describe('formatShellEnvSummary', () => {
+  beforeEach(() => {
+    _resetShellEnvCacheForTests();
+    _resetDetectShellCacheForTests();
+    setPlatform('linux');
+    process.env.PATH = '/usr/local/bin:/usr/bin:/bin';
+  });
+
+  afterEach(cleanup);
+
+  it('renders a single-line summary with shell version and available tools', () => {
+    _setVersionProbeForTests(() => 'GNU bash, version 5.1.16(1)-release');
+    _setToolProbeForTests((name) => ['git', 'npm', 'node'].includes(name));
+
+    const summary = formatShellEnvSummary(detectShellEnv(BASH_INFO));
+
+    expect(summary).toContain('shell: GNU bash, version 5.1.16');
+    expect(summary).toContain('PATH: /usr/local/bin:/usr/bin:/bin');
+    expect(summary).toContain('Available tools: git, npm, node');
+    expect(summary).not.toContain('\n');
+  });
+
+  it('falls back to the shell type when no version was captured', () => {
+    _setVersionProbeForTests(() => undefined);
+    _setToolProbeForTests(() => false);
+
+    const summary = formatShellEnvSummary(detectShellEnv(BASH_INFO));
+
+    expect(summary).toContain('shell: bash');
+    // No "Available tools:" fragment when the tool list is empty.
+    expect(summary).not.toContain('Available tools:');
+  });
+
+  it('appends a "(+N more)" suffix when PATH has more entries than fit', () => {
+    process.env.PATH = ['/a', '/b', '/c', '/d', '/e', '/f', '/g', '/h'].join(':');
+    _resetShellEnvCacheForTests();
+    _setVersionProbeForTests(() => 'bash 5');
+    _setToolProbeForTests(() => false);
+
+    const summary = formatShellEnvSummary(detectShellEnv(BASH_INFO));
+
+    expect(summary).toMatch(/PATH: \/a:\/b:\/c:\/d:\/e \(\+3 more\)/);
+  });
+
+  it('uses ";" as the PATH separator on Windows', () => {
+    setPlatform('win32');
+    process.env.PATH = 'C:\\Windows;C:\\Windows\\System32';
+    _resetShellEnvCacheForTests();
+    _setVersionProbeForTests(() => 'PowerShell 7.4.0');
+    _setToolProbeForTests(() => false);
+
+    const summary = formatShellEnvSummary(detectShellEnv(PWSH_INFO));
+
+    expect(summary).toContain('PATH: C:\\Windows;C:\\Windows\\System32');
+    expect(summary).toContain('shell: PowerShell 7.4.0');
+  });
+});
+
+describe('bash / shell tool descriptions include environment info', () => {
+  beforeEach(() => {
+    _resetShellEnvCacheForTests();
+    _resetDetectShellCacheForTests();
+    setPlatform('linux');
+    delete process.env.SHELL;
+    process.env.PATH = '/usr/local/bin:/usr/bin:/bin';
+    // Make the id-detector pick a deterministic /bin/bash.
+    _setFsProbeForTests((p) => p === '/bin/bash');
+  });
+
+  afterEach(cleanup);
+
+  it('bash description contains the environment summary line', () => {
+    _setVersionProbeForTests(() => 'GNU bash, version 5.1.16');
+    _setToolProbeForTests((name) => ['git', 'npm'].includes(name));
+
+    const desc = buildBashDescription();
+
+    expect(desc).toContain('Environment:');
+    expect(desc).toContain('GNU bash, version 5.1.16');
+    expect(desc).toContain('Available tools: git, npm');
+    // Keeps the original opening line and downstream sections.
+    expect(desc).toMatch(/^Execute a bash command/);
+    expect(desc).toContain('Security');
+  });
+
+  it('shell description contains the environment summary line', () => {
+    _setVersionProbeForTests(() => 'GNU bash, version 5.1.16');
+    _setToolProbeForTests((name) => name === 'docker');
+
+    const desc = buildShellDescription();
+
+    expect(desc).toContain('Environment:');
+    expect(desc).toContain('Available tools: docker');
+    expect(desc).toMatch(/^Execute a bash command in the user's environment/);
+  });
+
+  it('description survives a broken version probe (no throw, no version fragment)', () => {
+    _setVersionProbeForTests(() => undefined);
+    _setToolProbeForTests(() => false);
+
+    const desc = buildBashDescription();
+
+    expect(desc).toContain('shell: bash');
+    expect(desc).toMatch(/^Execute a bash command/);
+  });
+});


### PR DESCRIPTION
Closes #1123

## Summary

Extend the bash / shell tool description with a per-request "Environment" line so the LLM sees the actual shell version, a summary of the runtime `PATH`, and which of a fixed set of common developer tools (`git`, `gh`, `npm`, `node`, `docker`, `kubectl`) are installed. Previously the description exposed only the shell TYPE, which left the model guessing when commands failed because a binary was missing or a shell built-in behaved differently across shells.

Motivated by Cline PR #12331; complements the existing dynamic shell-id detection introduced in `src/tool/tools/shell/id.ts`.

## Changes

- **New:** `src/tool/tools/shell/env.ts`
  - `detectShellEnv(shell?)` probes the shell version via `spawnSync` with a hard **500 ms** timeout (a broken binary must not hang description building) and walks `process.env.PATH` with `fs.existsSync` to find which of `COMMON_TOOLS` resolve.
  - Result is cached for **30 s**, keyed by `shell.path` + `PATH` so profile changes are picked up.
  - Version, tool-existence and (via id.ts) shell-fs probes are dependency-injectable through `_setVersionProbeForTests` / `_setToolProbeForTests` / `_setFsProbeForTests` — tests can exercise all platforms without spawning real binaries.
  - `formatShellEnvSummary()` renders a single-line summary (`shell: ..., PATH: ..., Available tools: ...`) so the description stays cache-friendly.
- **Modified:** `src/tool/tools/bash.ts`, `src/tool/tools/shell.ts`
  - `buildBashDescription` / `buildShellDescription` now prepend the environment summary between the opening line and the existing `Usage` block.
  - All original sections (Usage, Output, Security, parallel-call hint) are preserved so the regression suites (`parallel-call-hint.test.ts`, `shell-detect.test.ts`) keep passing.
- **New tests:** `tests/tool/tools/shell-env.test.ts` (17 tests)
  - `splitPath` on POSIX + Windows separators, empty PATH.
  - `detectShellEnv`: version captured/omitted, PATH truncated to `PATH_SUMMARY_ENTRIES`, tools returned in `COMMON_TOOLS` order, cache hit + invalidation on PATH change.
  - `formatShellEnvSummary`: full summary, fallback when version probe fails, "(+N more)" PATH suffix, `;` separator on Windows.
  - Integration: `buildBashDescription` / `buildShellDescription` include `Environment:` and survive a broken version probe without throwing.

## Verification

```
npm run typecheck   # ok
npm run lint        # 0 errors (warnings unchanged)
npm run format:check # ok
npm run test        # 3271 passed | 3 skipped
npm run build       # ok
Coverage: 65.55% lines (>= 40% threshold)
```

## Done-when checklist

- [x] Shell detection helper added (`src/tool/tools/shell/env.ts`)
- [x] Probes: `$SHELL`, platform defaults, shell candidates (delegated to existing `shell/id.ts`)
- [x] Shell version captured (`--version` / `$PSVersionTable.PSVersion` / `ver`)
- [x] PATH + common tools captured (`git`, `gh`, `npm`, `node`, `docker`, `kubectl`)
- [x] Bash tool description is dynamic and includes shell info
- [x] Test asserts description reflects the shell environment
- [x] `lint`, `typecheck`, `test` all green