### PR TITLE
feat(ci): add rolling PR management and verification for docs-sync (#1135)

### DIFF
--- a/src/ci/docsSync/upsertPr.ts
+++ b/src/ci/docsSync/upsertPr.ts
@@ -1,0 +1,306 @@
+/**
+ * docs-sync: rolling PR upsert.
+ *
+ * Maintains a single rolling "[auto-docs]" pull request that accumulates
+ * documentation changes across daily runs. When the accumulated file count
+ * would exceed the draft cap, a fresh branch and PR are opened so no single
+ * PR grows unbounded. The PR body carries a machine-readable
+ * `processed-through` watermark that other modules use to derive the next
+ * processing window.
+ *
+ * All GitHub side effects (branch commit, PR list/create/update) are injected
+ * so this module remains pure and testable without a real API client.
+ */
+
+/** Draft cap: at or above this file count, roll over to a fresh branch. */
+export const FILE_DRAFT_CAP = 15;
+
+/** Prefix used to identify bot-authored PRs during list queries. */
+export const PR_TITLE_PREFIX = '[auto-docs]';
+
+/** Default title when opening a fresh PR. */
+export const DEFAULT_PR_TITLE = '[auto-docs] Sync docs with merged PRs';
+
+/** Regex used both to detect and to strip existing watermarks in PR bodies. */
+const WATERMARK_RE = /<!--\s*processed-through:\s*([0-9T:\-Z]+)\s*-->/;
+
+/**
+ * Files considered "docs" for the purpose of the draft-mode decision. Any
+ * change to a path outside this allowlist forces the PR to draft so a human
+ * reviews build-executable modifications.
+ */
+const DOCS_PATH_PREFIXES = ['docs/'] as const;
+const DOCS_ROOT_FILES = new Set(['AGENTS.md', 'README.md', 'CHANGELOG.md']);
+
+export interface ProcessedPR {
+  /** PR number in the upstream repo. */
+  number: number;
+  /** PR title (already-sanitized by the caller). */
+  title: string;
+  /** PR URL (may be empty; rendered as plain number when missing). */
+  url?: string;
+}
+
+export interface ExistingBotPR {
+  /** PR number in the docs repo. */
+  number: number;
+  /** PR title (should start with {@link PR_TITLE_PREFIX}). */
+  title: string;
+  /** Existing body of the PR (may contain a prior watermark). */
+  body: string;
+  /** Head branch of the PR. */
+  branch: string;
+  /** Number of files currently touched by the PR. */
+  changedFiles: number;
+  /** Whether the PR is already marked as draft. */
+  isDraft: boolean;
+}
+
+/**
+ * Adapter surface for GitHub side effects. Concrete implementations (Octokit,
+ * gh CLI wrapper, in-memory fake) plug in here.
+ */
+export interface DocsPRClient {
+  /** Returns the newest open bot PR whose title starts with the prefix. */
+  findExistingBotPR: () => Promise<ExistingBotPR | null>;
+  /**
+   * Commit staged changes to the given branch. Called for both the existing
+   * branch (append path) and freshly created branches (rollover path).
+   */
+  commitToBranch: (input: {
+    branch: string;
+    message: string;
+    createBranch: boolean;
+  }) => Promise<void>;
+  /**
+   * Update an existing PR's body (and optionally its draft flag).
+   * Called only on the append path.
+   */
+  updatePR: (input: { number: number; body: string; draft: boolean }) => Promise<void>;
+  /**
+   * Create a brand new PR. Called on rollover and cold-start paths.
+   * The returned number is used by callers to log the outcome.
+   */
+  createPR: (input: {
+    branch: string;
+    title: string;
+    body: string;
+    draft: boolean;
+  }) => Promise<{ number: number }>;
+}
+
+export interface UpsertDocsPROptions {
+  /** Repo-relative paths of files staged in the working tree. */
+  modifiedFiles: readonly string[];
+  /** PRs merged since the previous watermark, in chronological order. */
+  processedPRs: readonly ProcessedPR[];
+  /** Timestamp to embed in the new watermark, ISO8601 with `Z` suffix. */
+  watermark: string;
+  /** GitHub adapter. */
+  client: DocsPRClient;
+  /**
+   * Optional clock used to generate the rollover branch suffix. Defaults to
+   * `Date.now()`; tests inject a fixed instant for determinism.
+   */
+  now?: () => Date;
+  /** Optional override for the base title on rollover / cold-start. */
+  title?: string;
+}
+
+export type UpsertAction = 'appended' | 'rolled-over' | 'created';
+
+export interface UpsertDocsPRResult {
+  /** Which branch of the decision tree fired. */
+  action: UpsertAction;
+  /** PR number that was updated or created. */
+  prNumber: number;
+  /** Branch that was committed to. */
+  branch: string;
+  /** True when the PR ended up in draft state. */
+  draft: boolean;
+  /** Total file count considered for the draft cap. */
+  totalFiles: number;
+}
+
+/**
+ * Escapes any HTML comment sequences in agent-provided text so they cannot
+ * forge or overwrite the machine-readable watermark. The transformation is
+ * intentionally irreversible: dashes inside comments are replaced with a
+ * lookalike that renders identically in Markdown but does not close a comment.
+ */
+export function sanitizeBody(body: string): string {
+  if (!body) {
+    return '';
+  }
+  return body
+    .replace(/<!--/g, '&lt;!--')
+    .replace(/-->/g, '--&gt;')
+    .replace(/<!\[CDATA\[/g, '&lt;![CDATA[');
+}
+
+/**
+ * Formats a Date (or ISO string) into the canonical watermark timestamp:
+ * `YYYY-MM-DDTHH:MM:SSZ` (no fractional seconds, always UTC).
+ */
+export function formatWatermarkTimestamp(input: Date | string): string {
+  const date = typeof input === 'string' ? new Date(input) : input;
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid watermark timestamp: ${String(input)}`);
+  }
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/** Extracts the watermark timestamp from a PR body, or null when missing. */
+export function extractWatermark(body: string): string | null {
+  if (!body) {
+    return null;
+  }
+  const match = body.match(WATERMARK_RE);
+  return match ? match[1] : null;
+}
+
+/** Removes any existing watermark comment from a body (idempotent). */
+function stripWatermark(body: string): string {
+  return body
+    .replace(WATERMARK_RE, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+}
+
+/**
+ * Builds a full PR body from the list of processed PRs and the watermark. The
+ * processed-PR list is rendered as a Markdown table so reviewers can scan the
+ * digest without expanding the PR. Any prior watermark in `previousBody` is
+ * dropped before the new marker is appended.
+ */
+export function buildPRBody(
+  processedPRs: readonly ProcessedPR[],
+  watermark: string,
+  previousBody = ''
+): string {
+  const sections: string[] = [];
+
+  const sanitizedPrevious = stripWatermark(sanitizeBody(previousBody));
+  if (sanitizedPrevious) {
+    sections.push(sanitizedPrevious);
+  } else {
+    sections.push(
+      'Rolling documentation sync PR. New entries are appended by the docs-sync bot on each run.'
+    );
+  }
+
+  if (processedPRs.length > 0) {
+    const rows = processedPRs.map((pr) => {
+      const link = pr.url ? `[#${pr.number}](${pr.url})` : `#${pr.number}`;
+      const title = sanitizeBody(pr.title).replace(/\|/g, '\\|');
+      return `| ${link} | ${title} |`;
+    });
+    sections.push(['## Processed PRs', '', '| PR | Title |', '| --- | --- |', ...rows].join('\n'));
+  }
+
+  sections.push(`<!-- processed-through: ${watermark} -->`);
+  return sections.join('\n\n') + '\n';
+}
+
+/**
+ * Returns true when every modified path is a documentation file. Anything
+ * outside {@link DOCS_PATH_PREFIXES} or {@link DOCS_ROOT_FILES} is considered
+ * build-executable and forces the PR to draft.
+ */
+export function isDocsOnly(modifiedFiles: readonly string[]): boolean {
+  if (modifiedFiles.length === 0) {
+    return true;
+  }
+  for (const file of modifiedFiles) {
+    const normalized = file.replace(/^\.\//, '');
+    if (DOCS_ROOT_FILES.has(normalized)) {
+      continue;
+    }
+    const isDocsPath = DOCS_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+    if (!isDocsPath) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Produces a rollover branch name that includes an ISO-derived timestamp so
+ * concurrent runs never collide. Format: `auto-docs-YYYY-MM-DD-HHMMSS`.
+ */
+export function rolloverBranchName(now: Date): string {
+  const iso = now.toISOString();
+  const [datePart, timePart] = iso.split('T');
+  const hhmmss = timePart.slice(0, 8).replace(/:/g, '');
+  return `auto-docs-${datePart}-${hhmmss}`;
+}
+
+/**
+ * Rolling PR upsert. Chooses between three actions based on the current state
+ * of the docs repo:
+ *
+ * - `appended`: an existing open bot PR is under the draft cap; new commits
+ *   and processed-PR entries are added, watermark bumped.
+ * - `rolled-over`: an existing open bot PR is at or above the cap; a fresh
+ *   branch is opened and a new PR is created.
+ * - `created`: no existing bot PR was found; a fresh branch + PR are created.
+ *
+ * In all cases the PR is marked as draft when any non-docs file was touched.
+ */
+export async function upsertDocsPR(options: UpsertDocsPROptions): Promise<UpsertDocsPRResult> {
+  const { modifiedFiles, processedPRs, watermark, client } = options;
+  const title = options.title ?? DEFAULT_PR_TITLE;
+  const nowFn = options.now ?? ((): Date => new Date());
+
+  const nonDocsChange = !isDocsOnly(modifiedFiles);
+  const existing = await client.findExistingBotPR();
+  const commitMessage = `docs(ci): sync docs with merged PRs [alexi-bot]`;
+
+  if (existing) {
+    const totalFiles = existing.changedFiles + modifiedFiles.length;
+    if (totalFiles < FILE_DRAFT_CAP) {
+      const newBody = buildPRBody(processedPRs, watermark, existing.body);
+      const draft = existing.isDraft || nonDocsChange;
+      await client.commitToBranch({
+        branch: existing.branch,
+        message: commitMessage,
+        createBranch: false,
+      });
+      await client.updatePR({ number: existing.number, body: newBody, draft });
+      return {
+        action: 'appended',
+        prNumber: existing.number,
+        branch: existing.branch,
+        draft,
+        totalFiles,
+      };
+    }
+    // At/over cap: roll over to a fresh branch and PR.
+    const branch = rolloverBranchName(nowFn());
+    const body = buildPRBody(processedPRs, watermark);
+    const draft = nonDocsChange;
+    await client.commitToBranch({ branch, message: commitMessage, createBranch: true });
+    const created = await client.createPR({ branch, title, body, draft });
+    return {
+      action: 'rolled-over',
+      prNumber: created.number,
+      branch,
+      draft,
+      totalFiles,
+    };
+  }
+
+  // Cold start: no bot PR currently open.
+  const branch = rolloverBranchName(nowFn());
+  const body = buildPRBody(processedPRs, watermark);
+  const draft = nonDocsChange;
+  await client.commitToBranch({ branch, message: commitMessage, createBranch: true });
+  const created = await client.createPR({ branch, title, body, draft });
+  return {
+    action: 'created',
+    prNumber: created.number,
+    branch,
+    draft,
+    totalFiles: modifiedFiles.length,
+  };
+}

--- a/src/ci/docsSync/verify.ts
+++ b/src/ci/docsSync/verify.ts
@@ -1,0 +1,122 @@
+/**
+ * docs-sync: verification module.
+ *
+ * Runs the project's build + test gates against the working tree of the
+ * bot-authored docs branch. When they fail, an optional single "fix pass"
+ * (typically a bounded `kilo run` invocation) is executed and the gates are
+ * rerun once. The result is machine-readable so the upsert step can decide
+ * whether to mark the PR as draft.
+ *
+ * The runner and fix pass are injectable so tests can mock process spawning
+ * without touching real child processes.
+ */
+
+export interface CommandResult {
+  /** Exit code of the child process (0 = success). */
+  exitCode: number;
+  /** Combined stdout+stderr, best-effort. */
+  output: string;
+}
+
+/** Runs a shell command and resolves once the child process exits. */
+export type CommandRunner = (command: string, args: readonly string[]) => Promise<CommandResult>;
+
+/**
+ * Attempts a single autonomous fix pass on the working tree. Should resolve
+ * once the fix attempt has been made (regardless of outcome). The subsequent
+ * gate run decides whether the fix actually helped.
+ */
+export type FixPass = (context: { failedCommand: string; output: string }) => Promise<void>;
+
+export interface VerifyBuildOptions {
+  /** Command runner used to spawn build + test processes. */
+  run: CommandRunner;
+  /**
+   * Optional fix pass. When omitted, `verifyBuild` returns after the first
+   * failure without retrying.
+   */
+  fix?: FixPass;
+  /**
+   * Ordered list of gate commands. Defaults to `npm run build` followed by
+   * `npm run test`. Each entry is `[command, ...args]`.
+   */
+  gates?: readonly (readonly [string, ...string[]])[];
+}
+
+export interface VerifyBuildResult {
+  /** True when every gate passed (possibly after a fix pass). */
+  success: boolean;
+  /** True when the fix pass was invoked at least once. */
+  fixAttempted: boolean;
+  /** Which gate command failed, if any (empty when success is true). */
+  failedCommand: string;
+  /** Tail of the last failed gate's output; empty on success. */
+  failedOutput: string;
+}
+
+const DEFAULT_GATES: readonly (readonly [string, ...string[]])[] = [
+  ['npm', 'run', 'build'],
+  ['npm', 'run', 'test'],
+] as const;
+
+/** Formats a gate tuple back into a printable command string. */
+function formatCommand(gate: readonly [string, ...string[]]): string {
+  return gate.join(' ');
+}
+
+/**
+ * Runs every gate command in order. Returns the first failure encountered, or
+ * a success sentinel when all gates pass.
+ */
+async function runGates(
+  gates: readonly (readonly [string, ...string[]])[],
+  run: CommandRunner
+): Promise<{ success: true } | { success: false; command: string; output: string }> {
+  for (const gate of gates) {
+    const [cmd, ...args] = gate;
+    const result = await run(cmd, args);
+    if (result.exitCode !== 0) {
+      return { success: false, command: formatCommand(gate), output: result.output };
+    }
+  }
+  return { success: true };
+}
+
+/**
+ * Verifies the docs branch by running the configured gates. On failure a
+ * single fix pass may run, followed by exactly one retry. Callers observe the
+ * outcome via {@link VerifyBuildResult}.
+ */
+export async function verifyBuild(options: VerifyBuildOptions): Promise<VerifyBuildResult> {
+  const gates = options.gates ?? DEFAULT_GATES;
+  if (gates.length === 0) {
+    return { success: true, fixAttempted: false, failedCommand: '', failedOutput: '' };
+  }
+
+  const first = await runGates(gates, options.run);
+  if (first.success) {
+    return { success: true, fixAttempted: false, failedCommand: '', failedOutput: '' };
+  }
+
+  if (!options.fix) {
+    return {
+      success: false,
+      fixAttempted: false,
+      failedCommand: first.command,
+      failedOutput: first.output,
+    };
+  }
+
+  await options.fix({ failedCommand: first.command, output: first.output });
+
+  const second = await runGates(gates, options.run);
+  if (second.success) {
+    return { success: true, fixAttempted: true, failedCommand: '', failedOutput: '' };
+  }
+  return {
+    success: false,
+    fixAttempted: true,
+    failedCommand: second.command,
+    failedOutput: second.output,
+  };
+}

--- a/tests/ci/docs-sync/upsert-pr.test.ts
+++ b/tests/ci/docs-sync/upsert-pr.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  FILE_DRAFT_CAP,
+  buildPRBody,
+  extractWatermark,
+  formatWatermarkTimestamp,
+  isDocsOnly,
+  rolloverBranchName,
+  sanitizeBody,
+  upsertDocsPR,
+  type DocsPRClient,
+  type ExistingBotPR,
+  type ProcessedPR,
+} from '../../../src/ci/docsSync/upsertPr.js';
+
+/**
+ * Builds a mock DocsPRClient. Callers override individual methods when they
+ * want to assert on inputs; the defaults record the calls for later
+ * inspection.
+ */
+function makeClient(overrides: Partial<DocsPRClient> = {}): {
+  client: DocsPRClient;
+  commitToBranch: ReturnType<typeof vi.fn>;
+  updatePR: ReturnType<typeof vi.fn>;
+  createPR: ReturnType<typeof vi.fn>;
+  findExistingBotPR: ReturnType<typeof vi.fn>;
+} {
+  const client: DocsPRClient = {
+    findExistingBotPR:
+      overrides.findExistingBotPR ??
+      vi.fn<DocsPRClient['findExistingBotPR']>().mockResolvedValue(null),
+    commitToBranch:
+      overrides.commitToBranch ??
+      vi.fn<DocsPRClient['commitToBranch']>().mockResolvedValue(undefined),
+    updatePR: overrides.updatePR ?? vi.fn<DocsPRClient['updatePR']>().mockResolvedValue(undefined),
+    createPR:
+      overrides.createPR ?? vi.fn<DocsPRClient['createPR']>().mockResolvedValue({ number: 42 }),
+  };
+  return {
+    client,
+    commitToBranch: client.commitToBranch as ReturnType<typeof vi.fn>,
+    updatePR: client.updatePR as ReturnType<typeof vi.fn>,
+    createPR: client.createPR as ReturnType<typeof vi.fn>,
+    findExistingBotPR: client.findExistingBotPR as ReturnType<typeof vi.fn>,
+  };
+}
+
+const FIXED_NOW = new Date('2026-07-27T13:25:00.000Z');
+const WATERMARK = '2026-07-27T13:25:00Z';
+
+describe('sanitizeBody', () => {
+  it('returns empty string for empty input', () => {
+    expect(sanitizeBody('')).toBe('');
+  });
+
+  it('escapes HTML comment openers and closers', () => {
+    const input = 'hello <!-- processed-through: fake --> world';
+    const output = sanitizeBody(input);
+    expect(output).not.toContain('<!--');
+    expect(output).not.toContain('-->');
+    expect(output).toContain('&lt;!--');
+    expect(output).toContain('--&gt;');
+  });
+
+  it('escapes CDATA openers to prevent injection', () => {
+    const input = '<![CDATA[danger]]>';
+    expect(sanitizeBody(input)).toContain('&lt;![CDATA[');
+  });
+
+  it('leaves ordinary markdown untouched', () => {
+    const input = '## Heading\n\nSome **bold** text.';
+    expect(sanitizeBody(input)).toBe(input);
+  });
+});
+
+describe('formatWatermarkTimestamp', () => {
+  it('strips fractional seconds from an ISO string', () => {
+    const result = formatWatermarkTimestamp('2026-07-27T13:25:00.123Z');
+    expect(result).toBe('2026-07-27T13:25:00Z');
+  });
+
+  it('accepts a Date instance', () => {
+    const result = formatWatermarkTimestamp(new Date('2026-01-02T03:04:05.999Z'));
+    expect(result).toBe('2026-01-02T03:04:05Z');
+  });
+
+  it('throws for invalid input', () => {
+    expect(() => formatWatermarkTimestamp('not a date')).toThrow(/Invalid watermark/);
+  });
+});
+
+describe('extractWatermark', () => {
+  it('returns the timestamp when the marker is present', () => {
+    const body = 'blah\n<!-- processed-through: 2026-07-27T13:25:00Z -->\n';
+    expect(extractWatermark(body)).toBe('2026-07-27T13:25:00Z');
+  });
+
+  it('returns null when no marker is present', () => {
+    expect(extractWatermark('nothing here')).toBeNull();
+  });
+
+  it('returns null for empty body', () => {
+    expect(extractWatermark('')).toBeNull();
+  });
+});
+
+describe('rolloverBranchName', () => {
+  it('formats the branch name deterministically from the clock', () => {
+    expect(rolloverBranchName(FIXED_NOW)).toBe('auto-docs-2026-07-27-132500');
+  });
+});
+
+describe('isDocsOnly', () => {
+  it('is true for docs/ paths', () => {
+    expect(isDocsOnly(['docs/API.md', 'docs/ROUTING.md'])).toBe(true);
+  });
+
+  it('is true for AGENTS.md and README.md at repo root', () => {
+    expect(isDocsOnly(['AGENTS.md', 'README.md', 'CHANGELOG.md'])).toBe(true);
+  });
+
+  it('is true for an empty modified-file list', () => {
+    expect(isDocsOnly([])).toBe(true);
+  });
+
+  it('is false when a source file is included', () => {
+    expect(isDocsOnly(['docs/API.md', 'src/core/orchestrator.ts'])).toBe(false);
+  });
+
+  it('is false for workflow file changes', () => {
+    expect(isDocsOnly(['.github/workflows/docs-sync.yml'])).toBe(false);
+  });
+
+  it('normalises leading ./ prefix', () => {
+    expect(isDocsOnly(['./docs/API.md'])).toBe(true);
+  });
+});
+
+describe('buildPRBody', () => {
+  const prs: ProcessedPR[] = [
+    { number: 100, title: 'feat: add thing', url: 'https://example.test/pr/100' },
+    { number: 101, title: 'fix(core): pipe|separated title' },
+  ];
+
+  it('includes a processed-through watermark comment in the canonical format', () => {
+    const body = buildPRBody(prs, WATERMARK);
+    expect(body).toContain(`<!-- processed-through: ${WATERMARK} -->`);
+    expect(extractWatermark(body)).toBe(WATERMARK);
+  });
+
+  it('renders processed PRs as a markdown table with linked numbers', () => {
+    const body = buildPRBody(prs, WATERMARK);
+    expect(body).toContain('| PR | Title |');
+    expect(body).toContain('| [#100](https://example.test/pr/100) | feat: add thing |');
+  });
+
+  it('escapes pipes in PR titles so the table stays intact', () => {
+    const body = buildPRBody(prs, WATERMARK);
+    expect(body).toContain('fix(core): pipe\\|separated title');
+  });
+
+  it('drops any existing watermark and appends a fresh one', () => {
+    const previous = 'earlier body\n<!-- processed-through: 2026-01-01T00:00:00Z -->\n';
+    const body = buildPRBody([], WATERMARK, previous);
+    const matches = body.match(/<!-- processed-through:/g) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(extractWatermark(body)).toBe(WATERMARK);
+    expect(body).toContain('earlier body');
+  });
+
+  it('sanitizes HTML comments from prior body content', () => {
+    const previous = 'attacker <!-- processed-through: 1999-01-01T00:00:00Z --> content';
+    const body = buildPRBody([], WATERMARK, previous);
+    // The attacker's fake watermark must not have survived as a real marker.
+    expect(extractWatermark(body)).toBe(WATERMARK);
+    expect(body).toContain('attacker &lt;!--');
+  });
+
+  it('renders a default preamble when no previous body is provided', () => {
+    const body = buildPRBody([], WATERMARK);
+    expect(body).toMatch(/Rolling documentation sync PR/);
+  });
+
+  it('renders unlinked PR references when url is missing', () => {
+    const body = buildPRBody([{ number: 55, title: 'chore: bump' }], WATERMARK);
+    expect(body).toContain('| #55 | chore: bump |');
+  });
+});
+
+describe('upsertDocsPR', () => {
+  const processedPRs: ProcessedPR[] = [{ number: 200, title: 'feat: add' }];
+
+  it('creates a fresh PR when no existing bot PR is found (cold start)', async () => {
+    const { client, commitToBranch, createPR, updatePR } = makeClient();
+
+    const result = await upsertDocsPR({
+      modifiedFiles: ['docs/API.md'],
+      processedPRs,
+      watermark: WATERMARK,
+      client,
+      now: () => FIXED_NOW,
+    });
+
+    expect(result.action).toBe('created');
+    expect(result.branch).toBe('auto-docs-2026-07-27-132500');
+    expect(result.draft).toBe(false);
+    expect(result.totalFiles).toBe(1);
+    expect(commitToBranch).toHaveBeenCalledWith({
+      branch: 'auto-docs-2026-07-27-132500',
+      message: 'docs(ci): sync docs with merged PRs [alexi-bot]',
+      createBranch: true,
+    });
+    expect(createPR).toHaveBeenCalledTimes(1);
+    expect(updatePR).not.toHaveBeenCalled();
+    const created = createPR.mock.calls[0]![0];
+    expect(created.title).toBe('[auto-docs] Sync docs with merged PRs');
+    expect(created.draft).toBe(false);
+    expect(extractWatermark(created.body)).toBe(WATERMARK);
+  });
+
+  it('appends to an existing PR when the combined file count is below the cap', async () => {
+    const existing: ExistingBotPR = {
+      number: 77,
+      title: '[auto-docs] Sync docs with merged PRs',
+      body: 'previous body\n<!-- processed-through: 2026-07-26T00:00:00Z -->',
+      branch: 'auto-docs-2026-07-26-000000',
+      changedFiles: 3,
+      isDraft: false,
+    };
+    const { client, commitToBranch, updatePR, createPR } = makeClient({
+      findExistingBotPR: vi.fn().mockResolvedValue(existing),
+    });
+
+    const result = await upsertDocsPR({
+      modifiedFiles: ['docs/A.md', 'docs/B.md'],
+      processedPRs,
+      watermark: WATERMARK,
+      client,
+      now: () => FIXED_NOW,
+    });
+
+    expect(result.action).toBe('appended');
+    expect(result.prNumber).toBe(77);
+    expect(result.branch).toBe(existing.branch);
+    expect(result.totalFiles).toBe(5);
+    expect(result.draft).toBe(false);
+    expect(commitToBranch).toHaveBeenCalledWith({
+      branch: existing.branch,
+      message: 'docs(ci): sync docs with merged PRs [alexi-bot]',
+      createBranch: false,
+    });
+    expect(updatePR).toHaveBeenCalledTimes(1);
+    expect(createPR).not.toHaveBeenCalled();
+    const updated = updatePR.mock.calls[0]![0];
+    expect(extractWatermark(updated.body)).toBe(WATERMARK);
+    // Old watermark must have been dropped, not duplicated.
+    expect(updated.body.match(/<!-- processed-through:/g)).toHaveLength(1);
+    expect(updated.body).toContain('previous body');
+  });
+
+  it('rolls over to a fresh branch when the combined file count hits the cap', async () => {
+    const existing: ExistingBotPR = {
+      number: 88,
+      title: '[auto-docs] Sync docs with merged PRs',
+      body: 'body',
+      branch: 'auto-docs-old',
+      changedFiles: FILE_DRAFT_CAP - 1, // 14
+      isDraft: false,
+    };
+    const { client, commitToBranch, createPR, updatePR } = makeClient({
+      findExistingBotPR: vi.fn().mockResolvedValue(existing),
+      createPR: vi.fn().mockResolvedValue({ number: 99 }),
+    });
+
+    const result = await upsertDocsPR({
+      modifiedFiles: ['docs/A.md', 'docs/B.md'], // brings total to 16, >= 15
+      processedPRs,
+      watermark: WATERMARK,
+      client,
+      now: () => FIXED_NOW,
+    });
+
+    expect(result.action).toBe('rolled-over');
+    expect(result.prNumber).toBe(99);
+    expect(result.branch).toBe('auto-docs-2026-07-27-132500');
+    expect(result.totalFiles).toBeGreaterThanOrEqual(FILE_DRAFT_CAP);
+    expect(commitToBranch).toHaveBeenCalledWith({
+      branch: 'auto-docs-2026-07-27-132500',
+      message: 'docs(ci): sync docs with merged PRs [alexi-bot]',
+      createBranch: true,
+    });
+    expect(createPR).toHaveBeenCalledTimes(1);
+    expect(updatePR).not.toHaveBeenCalled();
+  });
+
+  it('marks the PR as draft when a non-docs file is touched (cold start path)', async () => {
+    const { client, createPR } = makeClient();
+
+    const result = await upsertDocsPR({
+      modifiedFiles: ['docs/API.md', 'src/core/orchestrator.ts'],
+      processedPRs,
+      watermark: WATERMARK,
+      client,
+      now: () => FIXED_NOW,
+    });
+
+    expect(result.draft).toBe(true);
+    expect(createPR.mock.calls[0]![0].draft).toBe(true);
+  });
+
+  it('marks the PR as draft when a non-docs file is touched (append path)', async () => {
+    const existing: ExistingBotPR = {
+      number: 12,
+      title: '[auto-docs] Sync docs with merged PRs',
+      body: 'body',
+      branch: 'auto-docs-branch',
+      changedFiles: 2,
+      isDraft: false,
+    };
+    const { client, updatePR } = makeClient({
+      findExistingBotPR: vi.fn().mockResolvedValue(existing),
+    });
+
+    const result = await upsertDocsPR({
+      modifiedFiles: ['src/tool/index.ts'],
+      processedPRs,
+      watermark: WATERMARK,
+      client,
+      now: () => FIXED_NOW,
+    });
+
+    expect(result.draft).toBe(true);
+    expect(updatePR.mock.calls[0]![0].draft).toBe(true);
+  });
+
+  it('preserves an existing draft flag on the append path even for docs-only changes', async () => {
+    const existing: ExistingBotPR = {
+      number: 15,
+      title: '[auto-docs] Sync docs with merged PRs',
+      body: 'body',
+      branch: 'auto-docs-branch',
+      changedFiles: 1,
+      isDraft: true,
+    };
+    const { client, updatePR } = makeClient({
+      findExistingBotPR: vi.fn().mockResolvedValue(existing),
+    });
+
+    const result = await upsertDocsPR({
+      modifiedFiles: ['docs/A.md'],
+      processedPRs,
+      watermark: WATERMARK,
+      client,
+      now: () => FIXED_NOW,
+    });
+
+    expect(result.draft).toBe(true);
+    expect(updatePR.mock.calls[0]![0].draft).toBe(true);
+  });
+
+  it('sanitizes agent-provided content in the existing body when appending', async () => {
+    const existing: ExistingBotPR = {
+      number: 21,
+      title: '[auto-docs] Sync docs with merged PRs',
+      body: 'good stuff\n<!-- processed-through: 2000-01-01T00:00:00Z --> more <!-- other -->',
+      branch: 'auto-docs-branch',
+      changedFiles: 1,
+      isDraft: false,
+    };
+    const { client, updatePR } = makeClient({
+      findExistingBotPR: vi.fn().mockResolvedValue(existing),
+    });
+
+    await upsertDocsPR({
+      modifiedFiles: ['docs/A.md'],
+      processedPRs,
+      watermark: WATERMARK,
+      client,
+      now: () => FIXED_NOW,
+    });
+
+    const body = updatePR.mock.calls[0]![0].body;
+    // Only the real watermark, not the attacker-embedded one, may remain.
+    expect(body.match(/<!-- processed-through:/g)).toHaveLength(1);
+    expect(extractWatermark(body)).toBe(WATERMARK);
+    // Any surviving comment openers must be escaped.
+    expect(body).not.toMatch(/<!--\s*other/);
+  });
+
+  it('uses a custom title when provided', async () => {
+    const { client, createPR } = makeClient();
+
+    await upsertDocsPR({
+      modifiedFiles: ['docs/A.md'],
+      processedPRs,
+      watermark: WATERMARK,
+      client,
+      now: () => FIXED_NOW,
+      title: '[auto-docs] Custom Title',
+    });
+
+    expect(createPR.mock.calls[0]![0].title).toBe('[auto-docs] Custom Title');
+  });
+});

--- a/tests/ci/docs-sync/verify.test.ts
+++ b/tests/ci/docs-sync/verify.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import { verifyBuild } from '../../../src/ci/docsSync/verify.js';
+import type { CommandResult, CommandRunner, FixPass } from '../../../src/ci/docsSync/verify.js';
+
+/**
+ * Builds a mock CommandRunner from a queue of results. Each spawn shifts the
+ * next result off the queue; missing entries default to a passing exit code
+ * so tests only need to list the failures.
+ */
+function makeRunner(results: readonly CommandResult[]): {
+  run: CommandRunner;
+  calls: Array<{ command: string; args: readonly string[] }>;
+} {
+  const calls: Array<{ command: string; args: readonly string[] }> = [];
+  const queue = [...results];
+  const run: CommandRunner = async (command, args) => {
+    calls.push({ command, args });
+    return queue.shift() ?? { exitCode: 0, output: '' };
+  };
+  return { run, calls };
+}
+
+describe('verifyBuild', () => {
+  it('returns success without fix pass when all gates pass', async () => {
+    const { run, calls } = makeRunner([
+      { exitCode: 0, output: 'built' },
+      { exitCode: 0, output: 'tested' },
+    ]);
+    const fix = vi.fn<FixPass>();
+
+    const result = await verifyBuild({ run, fix });
+
+    expect(result).toEqual({
+      success: true,
+      fixAttempted: false,
+      failedCommand: '',
+      failedOutput: '',
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual({ command: 'npm', args: ['run', 'build'] });
+    expect(calls[1]).toEqual({ command: 'npm', args: ['run', 'test'] });
+    expect(fix).not.toHaveBeenCalled();
+  });
+
+  it('returns success=true and fixAttempted=true when fix pass rescues the build', async () => {
+    const { run, calls } = makeRunner([
+      { exitCode: 1, output: 'ts error' }, // build fails
+      { exitCode: 0, output: 'built after fix' },
+      { exitCode: 0, output: 'tested' },
+    ]);
+    const fix = vi.fn<FixPass>().mockResolvedValue(undefined);
+
+    const result = await verifyBuild({ run, fix });
+
+    expect(result.success).toBe(true);
+    expect(result.fixAttempted).toBe(true);
+    expect(result.failedCommand).toBe('');
+    expect(fix).toHaveBeenCalledTimes(1);
+    expect(fix).toHaveBeenCalledWith({ failedCommand: 'npm run build', output: 'ts error' });
+    // Order: build (fail) -> fix -> build (pass) -> test (pass).
+    expect(calls.map((c) => `${c.command} ${c.args.join(' ')}`)).toEqual([
+      'npm run build',
+      'npm run build',
+      'npm run test',
+    ]);
+  });
+
+  it('returns success=false when the fix pass fails to rescue the gate', async () => {
+    const { run } = makeRunner([
+      { exitCode: 1, output: 'first fail' },
+      { exitCode: 1, output: 'still broken' },
+    ]);
+    const fix = vi.fn<FixPass>().mockResolvedValue(undefined);
+
+    const result = await verifyBuild({ run, fix });
+
+    expect(result).toEqual({
+      success: false,
+      fixAttempted: true,
+      failedCommand: 'npm run build',
+      failedOutput: 'still broken',
+    });
+    expect(fix).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke the fix pass when no fix is provided', async () => {
+    const { run } = makeRunner([{ exitCode: 2, output: 'nope' }]);
+
+    const result = await verifyBuild({ run });
+
+    expect(result).toEqual({
+      success: false,
+      fixAttempted: false,
+      failedCommand: 'npm run build',
+      failedOutput: 'nope',
+    });
+  });
+
+  it('reports the failing test gate correctly on a fresh failure', async () => {
+    const { run } = makeRunner([
+      { exitCode: 0, output: '' },
+      { exitCode: 1, output: 'vitest failure' },
+    ]);
+
+    const result = await verifyBuild({ run });
+
+    expect(result.success).toBe(false);
+    expect(result.failedCommand).toBe('npm run test');
+    expect(result.failedOutput).toBe('vitest failure');
+  });
+
+  it('honours a custom gate list', async () => {
+    const { run, calls } = makeRunner([
+      { exitCode: 0, output: '' },
+      { exitCode: 0, output: '' },
+    ]);
+
+    const result = await verifyBuild({
+      run,
+      gates: [
+        ['npm', 'run', 'lint'],
+        ['npm', 'run', 'typecheck'],
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls[0]).toEqual({ command: 'npm', args: ['run', 'lint'] });
+    expect(calls[1]).toEqual({ command: 'npm', args: ['run', 'typecheck'] });
+  });
+
+  it('returns success for an empty gate list without spawning anything', async () => {
+    const { run, calls } = makeRunner([]);
+
+    const result = await verifyBuild({ run, gates: [] });
+
+    expect(result.success).toBe(true);
+    expect(result.fixAttempted).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('does not run later gates once an earlier gate fails', async () => {
+    const { run, calls } = makeRunner([
+      { exitCode: 5, output: 'boom' },
+      { exitCode: 0, output: 'never reached' },
+    ]);
+
+    await verifyBuild({ run });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ command: 'npm', args: ['run', 'build'] });
+  });
+
+  it('propagates errors thrown by the fix pass', async () => {
+    const { run } = makeRunner([{ exitCode: 1, output: 'fail' }]);
+    const fix = vi.fn<FixPass>().mockRejectedValue(new Error('fix crashed'));
+
+    await expect(verifyBuild({ run, fix })).rejects.toThrow('fix crashed');
+  });
+});


### PR DESCRIPTION
Closes #1135

## Summary

Ships the pure, testable core logic for the docs-sync bot's rolling PR + verification pipeline. All GitHub side effects and process spawning are injected so the modules are covered by fast unit tests with no live API calls.

### `src/ci/docsSync/verify.ts` — `verifyBuild()`

- Runs a configurable gate list (default: `npm run build`, `npm run test`) via an injected `CommandRunner`.
- On failure, invokes an optional single fix pass (typically a bounded `kilo run`) and retries the gates exactly once.
- Returns `{ success, fixAttempted, failedCommand, failedOutput }` so the upsert step can flip the PR to draft when verification stays red.

### `src/ci/docsSync/upsertPr.ts` — `upsertDocsPR()`

- Maintains one rolling `[auto-docs]` PR.
- **15-file draft cap**: when the combined file count would reach `FILE_DRAFT_CAP`, opens a fresh `auto-docs-YYYY-MM-DD-HHMMSS` branch and PR instead of piling onto the existing one.
- **Machine-readable watermark**: `<!-- processed-through: YYYY-MM-DDTHH:MM:SSZ -->` inserted in the PR body; `extractWatermark(body)` parses it back for the next run's window.
- **Sanitization**: HTML comment sequences (`<!--`, `-->`, `<![CDATA[`) in any agent-authored body content are escaped so a poisoned PR title or previous body cannot forge/overwrite the marker.
- **Draft on non-docs changes**: any modified path outside `docs/`, `AGENTS.md`, `README.md`, or `CHANGELOG.md` forces the PR to draft so a human reviews build-executable modifications.
- Three decision branches: `appended`, `rolled-over`, `created`.
- GitHub adapter (`DocsPRClient`) is fully injected — Octokit / `gh` CLI wrapper / in-memory fake all plug in the same way.

### Tests (`tests/ci/docs-sync/`)

41 unit tests, no real child processes and no live API calls:

- `verify.test.ts`: success without fix, fix rescues, fix fails, no fix provided, custom gates, empty gate list, ordering guarantees, error propagation from the fix pass.
- `upsert-pr.test.ts`: sanitize + extract + format watermark, `buildPRBody` with linked/unlinked PR references and pipe escaping, `isDocsOnly` allowlist, rollover branch naming, all three decision branches, draft-mode logic on both the append and cold-start paths, existing-draft preservation, HTML-comment sanitization in append path, custom title.

Local v8 coverage on `src/ci/docsSync`: **100% lines, 98.93% statements** — well above the per-issue 80% target.

## Gate results (all green)

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (only pre-existing style warnings in the repo)
- `npm run format:check` — clean
- `npm test` — 240 files, 3329 passed, 3 skipped
- `npm run build` — clean
- `npm run test:coverage` — global lines 65.91% (CI threshold: 40%)

## Scope note

Issue #1135 also asks for two artifacts under `.github/`:

1. `.github/scripts/docs-sync/verify.mjs` — thin shim that boots `verifyBuild()`.
2. `.github/scripts/docs-sync/upsert-pr.mjs` — thin shim that boots `upsertDocsPR()`.
3. `.github/workflows/docs-sync.yml` — scheduled orchestrator wiring the whole pipeline.

These live under `.github/` and are **role-infrastructure** territory per the T-shape factory boundary declared in `role-engineering.md`:

> **What you must NOT do**: Do not change `.github/` files. Workflow changes are `role-infrastructure`.

This PR ships the core logic behind a stable typed surface so the follow-up infrastructure PR is a thin wiring job: a couple of `.mjs` shims that `import` from `dist/ci/docsSync/` + the scheduled workflow YAML.

[alexi-bot]