### PR TITLE
feat(deps): move tree-sitter grammars to optional peerDependencies

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1144,6 +1144,68 @@ Custom agents support:
 - Tool allowlists and denylists
 - Model and temperature preferences
 
+## Optional Peer Dependencies
+
+Some features rely on native or heavy libraries whose install cost is not
+justified for users who never invoke them. These are declared as
+`peerDependencies` with `peerDependenciesMeta.<pkg>.optional = true` in
+`package.json`, so `npm install` succeeds without them and prints an
+informational message rather than a hard failure.
+
+### Tree-sitter grammars (~67MB combined install size)
+
+The repo-map (`src/context/repoMap.ts`) and symbol extractor
+(`src/context/symbols.ts`) parse TypeScript, JavaScript, and Bash source
+files with tree-sitter to produce a ranked list of top-level definitions
+for the LLM system prompt. The parser runtime and the three grammars are
+optional peer dependencies:
+
+- `tree-sitter`
+- `tree-sitter-typescript`
+- `tree-sitter-javascript`
+- `tree-sitter-bash`
+
+`src/context/treeSitter.ts` lazy-loads every grammar the first time a file
+of the matching extension is parsed. Loading is done via a
+`createRequire(import.meta.url)`-backed shim wrapped in `try / catch`, and
+each successful or failed load is memoised so subsequent parses are cheap.
+When a grammar cannot be loaded, `parseSource()` returns `null`, which
+`extractSymbols()` and `generateRepoMap()` treat as "no symbols for this
+file" — the map is still produced, just without symbol detail for the
+missing language.
+
+If a user wants full repo-map support (or a downstream tool needs
+tree-sitter parsing), they should install the optional peers:
+
+```bash
+npm install tree-sitter tree-sitter-typescript tree-sitter-javascript tree-sitter-bash
+```
+
+For diagnostics, `treeSitter.ts` also exports:
+
+- `getMissingGrammars(): Grammar[]` — returns the list of optional packages
+  that failed to load.
+- `formatMissingGrammarError(): string | null` — returns a copy-paste-ready
+  install hint (`Install optional dependencies to enable definitions
+  tool: \`npm install ...\``), or `null` when every optional grammar is
+  available.
+- `preloadGrammars(): Promise<void>` — eager async warm-up for
+  long-running processes (e.g. the embedded server) that want to detect
+  missing grammars at boot rather than on first parse.
+
+The `definitions` tool (`src/tool/tools/definitions.ts`) uses regex-based
+extraction and does NOT depend on the tree-sitter grammars, so it
+continues to work even when the optional peers are absent. The install
+hint above is however the recommended remediation any time a caller
+observes the repo-map / symbol pipeline degrading to "no symbols".
+
+### Puppeteer (headless browser screenshots)
+
+`puppeteer` remains a regular `optionalDependencies` entry (not a peer)
+because its install failure mode is more subtle — Chromium download can
+fail behind corporate proxies but the JS package still lands. Consumers
+that need browser automation should install it explicitly.
+
 ## Security Considerations
 
 1. **Secrets Management**: AICORE_SERVICE_KEY stored in environment, never in config files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alexi",
-  "version": "1.18.12",
+  "version": "1.18.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alexi",
-      "version": "1.18.12",
+      "version": "1.18.13",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^8.5.2",
@@ -34,10 +34,6 @@
         "simple-git": "^3.36.0",
         "terminal-image": "^5.0.1",
         "terminal-link": "^5.0.0",
-        "tree-sitter": "^0.21.1",
-        "tree-sitter-bash": "^0.21.0",
-        "tree-sitter-javascript": "^0.21.4",
-        "tree-sitter-typescript": "^0.23.2",
         "xlsx": "^0.18.5",
         "zod": "^4.4.3"
       },
@@ -75,6 +71,26 @@
       },
       "optionalDependencies": {
         "puppeteer": "^25.3.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-bash": "^0.21.0",
+        "tree-sitter-javascript": "^0.21.4",
+        "tree-sitter-typescript": "^0.23.2"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        },
+        "tree-sitter-bash": {
+          "optional": true
+        },
+        "tree-sitter-javascript": {
+          "optional": true
+        },
+        "tree-sitter-typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -7378,6 +7394,8 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
       "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -7423,6 +7441,8 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -9158,6 +9178,8 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -9169,6 +9191,8 @@
       "integrity": "sha512-UuXf+wliu1mmS/O2Iz7OQghExM4a+lk+GaVPndZVpAJnFuzanaN33UcHOsrmngHxaOXHz5JSZrwp6i2qM/PKag==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^7.1.0",
         "node-gyp-build": "^4.8.0",
@@ -9187,7 +9211,9 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tree-sitter-javascript": {
       "version": "0.21.4",
@@ -9195,6 +9221,8 @@
       "integrity": "sha512-Lrk8yahebwrwc1sWJE9xPcz1OnnqiEV7Dh5fbN6EN3wNAdu9r06HpTqLqDwUUbnG4EB46Sfk+FJFAOldfoKLOw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.1"
@@ -9214,6 +9242,8 @@
       "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.2.2",
         "node-gyp-build": "^4.8.2",
@@ -9234,6 +9264,8 @@
       "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.2.2",
         "node-gyp-build": "^4.8.2"
@@ -9664,7 +9696,9 @@
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.21.0.tgz",
       "integrity": "sha512-iJ+QJ6ikN9D9cG7Kh6q3KtAstYFUQbYZ8OjuPEJYWfj2kLrmp5I3C2n6WjE1Y3jvj7nJbkcrJytJGWUEhCxn+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,28 @@
     "simple-git": "^3.36.0",
     "terminal-image": "^5.0.1",
     "terminal-link": "^5.0.0",
+    "xlsx": "^0.18.5",
+    "zod": "^4.4.3"
+  },
+  "peerDependencies": {
     "tree-sitter": "^0.21.1",
     "tree-sitter-bash": "^0.21.0",
     "tree-sitter-javascript": "^0.21.4",
-    "tree-sitter-typescript": "^0.23.2",
-    "xlsx": "^0.18.5",
-    "zod": "^4.4.3"
+    "tree-sitter-typescript": "^0.23.2"
+  },
+  "peerDependenciesMeta": {
+    "tree-sitter": {
+      "optional": true
+    },
+    "tree-sitter-bash": {
+      "optional": true
+    },
+    "tree-sitter-javascript": {
+      "optional": true
+    },
+    "tree-sitter-typescript": {
+      "optional": true
+    }
   },
   "optionalDependencies": {
     "puppeteer": "^25.3.0"

--- a/src/context/symbols.ts
+++ b/src/context/symbols.ts
@@ -6,7 +6,13 @@
  * the tree-sitter AST produced by treeSitter.ts.
  */
 
-import { parseSource, walkNode, getNameNode, findChildOfType } from './treeSitter.js';
+import {
+  parseSource,
+  walkNode,
+  getNameNode,
+  findChildOfType,
+  type TreeSitterSyntaxNode,
+} from './treeSitter.js';
 
 // ─── Public interfaces ────────────────────────────────────────────────────────
 
@@ -54,7 +60,7 @@ const TRANSPARENT_WRAPPERS = new Set([
  * Extract a condensed single-line signature from a node.
  * We take only the first non-trivial line of the node's text and truncate.
  */
-function extractSignature(node: import('tree-sitter').SyntaxNode): string {
+function extractSignature(node: TreeSitterSyntaxNode): string {
   const raw = node.text ?? '';
   // Take just the first line and strip the body (everything after '{' or '=>')
   const firstLine = raw.split('\n')[0].replace(/\{.*/, '').replace(/=>.*/, '').trim();
@@ -66,7 +72,7 @@ function extractSignature(node: import('tree-sitter').SyntaxNode): string {
  * Returns null if the node is not a recognisable top-level declaration.
  */
 function extractDeclaration(
-  node: import('tree-sitter').SyntaxNode
+  node: TreeSitterSyntaxNode
 ): { name: string; kind: CodeSymbol['kind']; signature: string } | null {
   let target = node;
 
@@ -86,7 +92,7 @@ function extractDeclaration(
   if (!kind) return null;
 
   // For variable declarations, look at the first declarator
-  let nameNode: import('tree-sitter').SyntaxNode | null = null;
+  let nameNode: TreeSitterSyntaxNode | null = null;
   if (kind === 'variable') {
     // lexical_declaration → variable_declarator → identifier
     for (let i = 0; i < target.childCount; i++) {
@@ -124,7 +130,7 @@ function isBashFile(filePath: string): boolean {
  * Produces either `name()` or `function name` / `function name()` to match
  * the two supported syntaxes.
  */
-function extractBashSignature(node: import('tree-sitter').SyntaxNode, name: string): string {
+function extractBashSignature(node: TreeSitterSyntaxNode, name: string): string {
   const raw = node.text ?? '';
   const firstLine = raw.split('\n')[0].trim();
   // Detect Bash-style `function name [()] { ... }`
@@ -146,10 +152,7 @@ function extractBashSignature(node: import('tree-sitter').SyntaxNode, name: stri
  * are considered so that helpers defined inside other functions do not
  * leak into the top-level symbol list.
  */
-function extractBashSymbols(
-  root: import('tree-sitter').SyntaxNode,
-  filePath: string
-): CodeSymbol[] {
+function extractBashSymbols(root: TreeSitterSyntaxNode, filePath: string): CodeSymbol[] {
   const symbols: CodeSymbol[] = [];
 
   for (let i = 0; i < root.childCount; i++) {

--- a/src/context/treeSitter.ts
+++ b/src/context/treeSitter.ts
@@ -2,73 +2,198 @@
  * Tree-sitter AST parsing helpers
  *
  * Provides lazy-initialised parsers for TypeScript, JavaScript, and Bash.
- * The parsers are created on first use to avoid startup overhead.
+ *
+ * Grammars (`tree-sitter-typescript`, `tree-sitter-javascript`, `tree-sitter-bash`)
+ * and the `tree-sitter` runtime itself are declared as optional peer
+ * dependencies so users who never touch code-analysis features do not pay
+ * their ~67MB install cost. They are loaded on first parser use via a
+ * `createRequire` shim wrapped in try/catch; if the load fails we cache the
+ * failure and every subsequent parse for that language returns null. Callers
+ * that need to surface an actionable error to the end user can consult
+ * `getMissingGrammars()` / `formatMissingGrammarError()`.
  */
 
-import Parser from 'tree-sitter';
-import TypeScript from 'tree-sitter-typescript';
-import JavaScript from 'tree-sitter-javascript';
-import Bash from 'tree-sitter-bash';
+import { createRequire } from 'module';
 import { getExtension } from './extensions.js';
 
-// Lazily initialised parsers (one per language to avoid setLanguage races)
-let tsParser: Parser | null = null;
-let jsParser: Parser | null = null;
-let tsxParser: Parser | null = null;
-let bashParser: Parser | null = null;
+// The `tree-sitter` package is an optional peer dependency, so we cannot
+// import its types statically. We describe the subset of the SyntaxNode
+// surface actually used across the codebase so downstream consumers stay
+// well-typed without pulling the peer-dep's types.
+export interface TreeSitterSyntaxNode {
+  readonly type: string;
+  readonly text: string;
+  readonly childCount: number;
+  readonly isNamed: boolean;
+  readonly parent: TreeSitterSyntaxNode | null;
+  readonly startPosition: { row: number; column: number };
+  child(i: number): TreeSitterSyntaxNode | null;
+  childForFieldName?(field: string): TreeSitterSyntaxNode | null;
+}
+
+type AnyParser = {
+  setLanguage(lang: unknown): void;
+  parse(source: string): { rootNode: TreeSitterSyntaxNode };
+};
+
+const requireOptional = createRequire(import.meta.url);
+
+/** Grammar identifiers we support. */
+export type Grammar =
+  'tree-sitter' | 'tree-sitter-typescript' | 'tree-sitter-javascript' | 'tree-sitter-bash';
+
+const OPTIONAL_GRAMMAR_PACKAGES: readonly Grammar[] = [
+  'tree-sitter',
+  'tree-sitter-typescript',
+  'tree-sitter-javascript',
+  'tree-sitter-bash',
+];
 
 /**
- * Get (or lazily create) the TypeScript parser
+ * Human-readable install hint listing the optional peer dependencies.
+ * Kept as a single string constant so tests and docs can assert on the
+ * exact wording.
  */
-function getTsParser(): Parser | null {
-  if (!Parser) {
+export const MISSING_GRAMMAR_INSTALL_HINT =
+  'Install optional dependencies to enable definitions tool: `npm install tree-sitter tree-sitter-typescript tree-sitter-javascript tree-sitter-bash`';
+
+// Cached module loads. `undefined` means "not attempted yet".
+// `null` means "attempted and failed" (memoised so we do not retry on every call).
+const loadedModules: Map<Grammar, unknown | null> = new Map();
+
+/**
+ * Attempt to load an optional grammar/runtime package synchronously.
+ * Returns the module on success or `null` on failure (and memoises the null).
+ */
+function loadOptionalModule<T = unknown>(pkg: Grammar): T | null {
+  if (loadedModules.has(pkg)) {
+    return loadedModules.get(pkg) as T | null;
+  }
+  try {
+    const mod = requireOptional(pkg) as T;
+    loadedModules.set(pkg, mod);
+    return mod;
+  } catch {
+    loadedModules.set(pkg, null);
     return null;
   }
+}
+
+/**
+ * Return the list of optional grammar packages that failed to load so far
+ * (or would fail if attempted). Useful for producing an actionable error
+ * message when a caller wanted to parse a file but the grammar is missing.
+ */
+export function getMissingGrammars(): Grammar[] {
+  const missing: Grammar[] = [];
+  for (const pkg of OPTIONAL_GRAMMAR_PACKAGES) {
+    if (loadOptionalModule(pkg) === null) {
+      missing.push(pkg);
+    }
+  }
+  return missing;
+}
+
+/**
+ * Build a user-facing error message describing which optional grammars are
+ * missing and how to install them. Returns null when every optional grammar
+ * is available.
+ */
+export function formatMissingGrammarError(): string | null {
+  const missing = getMissingGrammars();
+  if (missing.length === 0) {
+    return null;
+  }
+  return `${MISSING_GRAMMAR_INSTALL_HINT} (missing: ${missing.join(', ')})`;
+}
+
+/**
+ * Eagerly load all optional grammars via dynamic import. Intended for
+ * ahead-of-time warm-up (e.g. from a long-running server). All failures are
+ * swallowed; use `getMissingGrammars()` afterwards to check the result.
+ */
+export async function preloadGrammars(): Promise<void> {
+  for (const pkg of OPTIONAL_GRAMMAR_PACKAGES) {
+    if (loadedModules.has(pkg)) {
+      continue;
+    }
+    try {
+      const mod = await import(pkg);
+      // dynamic imports expose CJS exports on `.default` under NodeNext.
+      const resolved = (mod as { default?: unknown }).default ?? mod;
+      loadedModules.set(pkg, resolved);
+    } catch {
+      loadedModules.set(pkg, null);
+    }
+  }
+}
+
+// Lazily initialised parsers (one per language to avoid setLanguage races)
+let tsParser: AnyParser | null = null;
+let jsParser: AnyParser | null = null;
+let tsxParser: AnyParser | null = null;
+let bashParser: AnyParser | null = null;
+
+/**
+ * Instantiate a parser with the given language, returning null when either
+ * the `tree-sitter` runtime or the language grammar is unavailable.
+ */
+function makeParser(
+  languageAccessor: (grammar: unknown) => unknown,
+  grammarPkg: Grammar
+): AnyParser | null {
+  const ParserCtor = loadOptionalModule<{ new (): AnyParser } | { default: { new (): AnyParser } }>(
+    'tree-sitter'
+  );
+  const grammarModule = loadOptionalModule(grammarPkg);
+  if (!ParserCtor || !grammarModule) {
+    return null;
+  }
+  // Handle both CJS default-only exports and ES module wrappers.
+  const Ctor =
+    typeof ParserCtor === 'function'
+      ? (ParserCtor as { new (): AnyParser })
+      : (ParserCtor as { default: { new (): AnyParser } }).default;
+  const grammar = languageAccessor(grammarModule);
+  if (!grammar) {
+    return null;
+  }
+  try {
+    const parser: AnyParser = new Ctor();
+    parser.setLanguage(grammar);
+    return parser;
+  } catch {
+    return null;
+  }
+}
+
+function getTsParser(): AnyParser | null {
   if (!tsParser) {
-    tsParser = new Parser();
-    tsParser.setLanguage(TypeScript.typescript);
+    tsParser = makeParser(
+      (g) => (g as { typescript?: unknown }).typescript,
+      'tree-sitter-typescript'
+    );
   }
   return tsParser;
 }
 
-/**
- * Get (or lazily create) the TSX parser
- */
-function getTsxParser(): Parser | null {
-  if (!Parser) {
-    return null;
-  }
+function getTsxParser(): AnyParser | null {
   if (!tsxParser) {
-    tsxParser = new Parser();
-    tsxParser.setLanguage(TypeScript.tsx);
+    tsxParser = makeParser((g) => (g as { tsx?: unknown }).tsx, 'tree-sitter-typescript');
   }
   return tsxParser;
 }
 
-/**
- * Get (or lazily create) the JavaScript parser
- */
-function getJsParser(): Parser | null {
-  if (!Parser) {
-    return null;
-  }
+function getJsParser(): AnyParser | null {
   if (!jsParser) {
-    jsParser = new Parser();
-    jsParser.setLanguage(JavaScript);
+    jsParser = makeParser((g) => g, 'tree-sitter-javascript');
   }
   return jsParser;
 }
 
-/**
- * Get (or lazily create) the Bash parser
- */
-function getBashParser(): Parser | null {
-  if (!Parser) {
-    return null;
-  }
+function getBashParser(): AnyParser | null {
   if (!bashParser) {
-    bashParser = new Parser();
-    bashParser.setLanguage(Bash);
+    bashParser = makeParser((g) => g, 'tree-sitter-bash');
   }
   return bashParser;
 }
@@ -97,7 +222,10 @@ const SUPPORTED_EXTENSIONS: ReadonlySet<string> = new Set<SupportedExtension>([
 ]);
 
 /**
- * Returns true if the file extension is supported by tree-sitter parsers
+ * Returns true if the file extension is supported by tree-sitter parsers.
+ * NOTE: this is a static check on the extension; it does not verify whether
+ * the corresponding grammar package is installed. Use `getMissingGrammars()`
+ * for the runtime capability check.
  */
 export function isSupportedFile(filePath: string): boolean {
   return SUPPORTED_EXTENSIONS.has(getExtension(filePath));
@@ -105,12 +233,13 @@ export function isSupportedFile(filePath: string): boolean {
 
 /**
  * Parse source code using the appropriate parser for the file extension.
- * Returns the root node of the AST, or null if the file is not supported.
+ * Returns the root node of the AST, or null if the file is not supported
+ * OR the required grammar is not installed OR parsing failed.
  */
-export function parseSource(source: string, filePath: string): Parser.SyntaxNode | null {
+export function parseSource(source: string, filePath: string): TreeSitterSyntaxNode | null {
   const ext = getExtension(filePath);
 
-  let parser: Parser | null;
+  let parser: AnyParser | null;
   switch (ext) {
     case '.ts':
     case '.mts':
@@ -135,14 +264,16 @@ export function parseSource(source: string, filePath: string): Parser.SyntaxNode
       return null;
   }
 
-  // Return null if parser initialization failed
+  // Return null if parser initialization failed (unsupported ext, missing
+  // grammar, or setLanguage error). Callers that need to distinguish
+  // "missing grammar" from "parse failure" can call getMissingGrammars().
   if (!parser) {
     return null;
   }
 
   try {
     const tree = parser.parse(source);
-    return tree.rootNode;
+    return tree.rootNode as TreeSitterSyntaxNode;
   } catch {
     // Parser errors are non-fatal; return null so callers can skip the file
     return null;
@@ -154,15 +285,19 @@ export function parseSource(source: string, filePath: string): Parser.SyntaxNode
  * Skips nodes whose type is in the `skipTypes` set.
  */
 export function walkNode(
-  node: Parser.SyntaxNode,
-  visitor: (node: Parser.SyntaxNode) => void,
+  node: TreeSitterSyntaxNode,
+  visitor: (node: TreeSitterSyntaxNode) => void,
   skipTypes?: Set<string>
 ): void {
-  if (skipTypes?.has(node.type)) return;
+  if (skipTypes?.has(node.type)) {
+    return;
+  }
   visitor(node);
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
-    if (child) walkNode(child, visitor, skipTypes);
+    if (child) {
+      walkNode(child, visitor, skipTypes);
+    }
   }
 }
 
@@ -170,20 +305,35 @@ export function walkNode(
  * Find the first child node of `node` with type in `types`, or null.
  */
 export function findChildOfType(
-  node: Parser.SyntaxNode,
+  node: TreeSitterSyntaxNode,
   ...types: string[]
-): Parser.SyntaxNode | null {
+): TreeSitterSyntaxNode | null {
   const typeSet = new Set(types);
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
-    if (child && typeSet.has(child.type)) return child;
+    if (child && typeSet.has(child.type)) {
+      return child;
+    }
   }
   return null;
 }
 
 /**
- * Find the `identifier` or `type_identifier` child of a node (for name extraction)
+ * Find the `identifier` or `type_identifier` child of a node (for name extraction).
  */
-export function getNameNode(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+export function getNameNode(node: TreeSitterSyntaxNode): TreeSitterSyntaxNode | null {
   return findChildOfType(node, 'identifier', 'type_identifier', 'property_identifier');
+}
+
+/**
+ * @internal Reset all cached parsers and module loads. Test-only helper —
+ * exported so unit tests can simulate a fresh process after mutating module
+ * availability. Not part of the public API.
+ */
+export function __resetGrammarCache(): void {
+  loadedModules.clear();
+  tsParser = null;
+  jsParser = null;
+  tsxParser = null;
+  bashParser = null;
 }

--- a/tests/context/treeSitter.test.ts
+++ b/tests/context/treeSitter.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the optional-peer-dependency handling in `src/context/treeSitter.ts`.
+ *
+ * These complement the pre-existing grammar-installed tests under
+ * `src/context/__tests__/treeSitter.test.ts` (which run in the normal
+ * repo state where the grammars are dev-installed). Here we focus on:
+ *
+ *  1. The happy path: `parseSource` still returns a SyntaxNode when the
+ *     grammars are available, and no missing-grammar error is reported.
+ *  2. The degraded path: when a grammar package cannot be `require`d
+ *     (simulated by module-cache poisoning), `parseSource` returns null
+ *     and `getMissingGrammars()` / `formatMissingGrammarError()` surface
+ *     the actionable install command from the issue spec.
+ *
+ * The module-cache poisoning approach lets us keep the tests hermetic —
+ * we never actually uninstall the grammar packages — while still
+ * exercising the real `createRequire`-backed lazy loader.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import {
+  parseSource,
+  getMissingGrammars,
+  formatMissingGrammarError,
+  MISSING_GRAMMAR_INSTALL_HINT,
+  __resetGrammarCache,
+} from '../../src/context/treeSitter.js';
+
+const nodeRequire = createRequire(import.meta.url);
+
+/**
+ * Resolve the on-disk path of an optional grammar package, or null if the
+ * package is not installed in the current environment.
+ */
+function resolveOptional(pkg: string): string | null {
+  try {
+    return nodeRequire.resolve(pkg);
+  } catch {
+    return null;
+  }
+}
+
+describe('treeSitter — grammars available (happy path)', () => {
+  beforeEach(() => {
+    __resetGrammarCache();
+  });
+
+  it('parseSource returns a program node for TypeScript when grammars are installed', () => {
+    // Skip if the optional dev-install is missing on this runner.
+    if (!resolveOptional('tree-sitter-typescript')) {
+      return;
+    }
+    const root = parseSource('const answer: number = 42;', 'answer.ts');
+    expect(root).not.toBeNull();
+    expect(root?.type).toBe('program');
+  });
+
+  it('getMissingGrammars() is empty when every optional package is installed', () => {
+    // Only meaningful when all four optional packages are present on the runner.
+    const anyMissing =
+      !resolveOptional('tree-sitter') ||
+      !resolveOptional('tree-sitter-typescript') ||
+      !resolveOptional('tree-sitter-javascript') ||
+      !resolveOptional('tree-sitter-bash');
+    if (anyMissing) {
+      return;
+    }
+    __resetGrammarCache();
+    // Warm the cache by loading each optional module through the public API.
+    parseSource('x', 'a.ts');
+    parseSource('x', 'a.js');
+    parseSource('x', 'a.sh');
+    expect(getMissingGrammars()).toEqual([]);
+    expect(formatMissingGrammarError()).toBeNull();
+  });
+});
+
+describe('treeSitter — grammars missing (degraded path)', () => {
+  const grammarPackages = [
+    'tree-sitter',
+    'tree-sitter-typescript',
+    'tree-sitter-javascript',
+    'tree-sitter-bash',
+  ] as const;
+
+  /**
+   * Snapshot of the Node module cache entries we may poison so we can
+   * restore them after each test. Values may be undefined (entry did not
+   * exist) — that state must also be restored.
+   */
+  let savedCache: Map<string, NodeJS.Module | undefined>;
+
+  beforeEach(() => {
+    savedCache = new Map();
+    __resetGrammarCache();
+
+    // Poison the require cache for each optional grammar so that
+    // `createRequire(...)(pkg)` throws MODULE_NOT_FOUND-equivalent errors.
+    // We do this by resolving the real path (if available) and replacing
+    // the entry with a proxy that throws on any property access when
+    // subsequently required. The simplest, host-safe approach: install a
+    // fake entry under the resolved id whose `exports` throws when read.
+    for (const pkg of grammarPackages) {
+      let resolved: string;
+      try {
+        resolved = nodeRequire.resolve(pkg);
+      } catch {
+        continue;
+      }
+      const cache = (nodeRequire as unknown as { cache: Record<string, NodeJS.Module | undefined> })
+        .cache;
+      savedCache.set(resolved, cache[resolved]);
+      // Replace with a broken stub. Reading `.exports` throws, mimicking
+      // a genuinely missing/unloadable optional dependency.
+      const broken = {
+        id: resolved,
+        filename: resolved,
+        loaded: true,
+        get exports(): never {
+          throw new Error(`Cannot find module '${pkg}'`);
+        },
+      } as unknown as NodeJS.Module;
+      cache[resolved] = broken;
+    }
+  });
+
+  afterEach(() => {
+    const cache = (nodeRequire as unknown as { cache: Record<string, NodeJS.Module | undefined> })
+      .cache;
+    for (const [id, original] of savedCache) {
+      if (original === undefined) {
+        delete cache[id];
+      } else {
+        cache[id] = original;
+      }
+    }
+    __resetGrammarCache();
+  });
+
+  it('parseSource returns null when the required grammar cannot be loaded', () => {
+    const root = parseSource('const answer = 42;', 'answer.ts');
+    expect(root).toBeNull();
+  });
+
+  it('parseSource returns null for JavaScript files without grammars', () => {
+    const root = parseSource('const answer = 42;', 'answer.js');
+    expect(root).toBeNull();
+  });
+
+  it('parseSource returns null for Bash files without grammars', () => {
+    const root = parseSource('foo() { echo hi; }', 'script.sh');
+    expect(root).toBeNull();
+  });
+
+  it('getMissingGrammars() reports all four missing optional packages', () => {
+    // Force load attempts through the public API.
+    parseSource('x', 'a.ts');
+    parseSource('x', 'a.js');
+    parseSource('x', 'a.sh');
+    const missing = getMissingGrammars();
+    // Every optional peer we poisoned should surface as missing.
+    expect(missing).toEqual(
+      expect.arrayContaining([
+        'tree-sitter',
+        'tree-sitter-typescript',
+        'tree-sitter-javascript',
+        'tree-sitter-bash',
+      ])
+    );
+  });
+
+  it('formatMissingGrammarError() returns the documented install hint', () => {
+    const message = formatMissingGrammarError();
+    expect(message).not.toBeNull();
+    expect(message).toContain(MISSING_GRAMMAR_INSTALL_HINT);
+    // Sanity: the hint should mention the exact `npm install` command from
+    // the issue spec so operators can copy-paste it.
+    expect(MISSING_GRAMMAR_INSTALL_HINT).toContain('npm install tree-sitter');
+    expect(MISSING_GRAMMAR_INSTALL_HINT).toContain('tree-sitter-typescript');
+    expect(MISSING_GRAMMAR_INSTALL_HINT).toContain('tree-sitter-javascript');
+    expect(MISSING_GRAMMAR_INSTALL_HINT).toContain('tree-sitter-bash');
+  });
+
+  it('formatMissingGrammarError() memoises failures so repeated calls are cheap', () => {
+    const first = formatMissingGrammarError();
+    const second = formatMissingGrammarError();
+    expect(first).toBe(second === null ? first : second);
+    // Second call must still contain the install hint.
+    expect(second).toContain(MISSING_GRAMMAR_INSTALL_HINT);
+  });
+});


### PR DESCRIPTION
## Summary

Moves the tree-sitter runtime and grammars (~67MB combined install size) from `dependencies` to `peerDependencies` with `peerDependenciesMeta.optional = true`, and lazy-loads them at first parse. Users who never trigger the repo-map / symbol extraction pipeline avoid the install cost entirely.

Closes #1146

## Changes

- **`package.json`**: `tree-sitter`, `tree-sitter-typescript`, `tree-sitter-javascript`, and `tree-sitter-bash` moved to `peerDependencies` + `peerDependenciesMeta` (all four marked `optional: true`).
- **`src/context/treeSitter.ts`**:
  - Lazy-loads every grammar via a `createRequire(import.meta.url)`-backed shim wrapped in `try / catch`.
  - Successful and failed loads are memoised so subsequent parses are cheap.
  - Exposes `getMissingGrammars()`, `formatMissingGrammarError()`, and `MISSING_GRAMMAR_INSTALL_HINT` so downstream consumers can surface an actionable install command (`npm install tree-sitter tree-sitter-typescript tree-sitter-javascript tree-sitter-bash`).
  - Introduces a structural `TreeSitterSyntaxNode` interface so callers no longer need the optional peer's compile-time types.
  - Adds `preloadGrammars()` for async warm-up.
- **`src/context/symbols.ts`**: Switched from `import('tree-sitter').SyntaxNode` to the local `TreeSitterSyntaxNode` structural type.
- **`tests/context/treeSitter.test.ts`**: New test file covering both scenarios required by the issue — grammars installed (happy path) and grammars unavailable (degraded path). The degraded path is simulated by poisoning the `createRequire` cache so the tests stay hermetic without uninstalling the optional peers.
- **`docs/ARCHITECTURE.md`**: New 'Optional Peer Dependencies' section documenting the tree-sitter grammars, the lazy-load model, the diagnostic helpers, and the install command.

## Definition of done

- [x] Tree-sitter grammars in `peerDependencies` with `optional: true`
- [x] `src/context/treeSitter.ts` lazy-loads grammars with try/catch
- [x] Clear install-hint error surfaced when grammars are missing
- [x] Tests pass for with-grammars and without-grammars scenarios (8 new tests, all passing)
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test:coverage` — 3337 passed / 3 skipped, 65.98% line coverage
- [x] `npm run build` — succeeds
- [x] `docs/ARCHITECTURE.md` documents the optional dependency and install command

## Notes

The `definitions` tool (`src/tool/tools/definitions.ts`) uses regex extraction — it does not depend on tree-sitter, so removing the grammars does not break it. The ARCHITECTURE doc calls this out explicitly to avoid confusion.

[alexi-bot]