### PR TITLE
feat(config): support custom file extensions via indexing config

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,6 +184,60 @@ Alexi registers **30 built-in tools** via `registerBuiltInTools()`:
 | `apply-patch` | `apply-patch.ts` | write | Apply code patches |
 | `repo-clone` | `repo-clone.ts` | execute | Clone repositories |
 
+#### Indexing config: custom file extensions
+
+`glob`, `grep`, and `codesearch` extend their default extension whitelist
+with a user-configurable list, so modern stacks (`.mdx`, `.astro`,
+`.svelte`, `.vue`, `.proto`, `.graphql`, `.tf`, ...) are indexed without
+the caller having to spell them out in every `include` pattern.
+
+Extensions are collected from three sources and merged additively (later
+sources add to earlier ones; duplicates are de-duped case-insensitively):
+
+1. **Global user config** – `~/.alexi/config.json`
+2. **Project config** – `<repo>/.alexi/config.json`
+3. **Project extensions file** – `<repo>/.alexi/extensions`
+
+Both config files use the same `indexing` section and accept two fields:
+
+```jsonc
+{
+  "indexing": {
+    // Canonical form: leading dot required, strictly validated.
+    "additionalExtensions": [".proto", ".graphql"],
+    // Alias: accepts bare names (mdx) OR dotted names (.mdx).
+    "extensions": ["mdx", "astro", "svelte", "vue"]
+  }
+}
+```
+
+The `.alexi/extensions` file is a flat text file with one extension per
+line. Blank lines and lines starting with `#` are ignored; inline
+comments after `#` are stripped. Names may be written with or without a
+leading dot.
+
+```text
+# Custom extensions for indexing
+mdx
+astro
+svelte    # Svelte components
+.vue
+```
+
+**Semantics.** Additional extensions are always ADDITIVE — they extend
+the set of files a tool considers, they never restrict a caller-provided
+`include`. When a caller passes `--include '*.ts'` and the config
+declares `mdx`, the effective pattern becomes `*.{ts,mdx}`. When no
+`include` is passed, extensions do not narrow the search (`grep` still
+searches all files, matching historical behavior).
+
+**Validation.** `additionalExtensions` requires the strict dotted form
+(`.proto`); invalid entries throw when written via
+`setConfigAdditionalExtensions` and are silently dropped when read
+(so a corrupt config never crashes tools). The `extensions` alias is
+more permissive (accepts `mdx`, `.mdx`, `MDX`) and normalizes to lower
+case dotted form. See `src/config/userConfig.ts` for details.
+
 ### Support Systems
 
 | Module | File | Description |

--- a/src/config/userConfig.ts
+++ b/src/config/userConfig.ts
@@ -222,6 +222,14 @@ export function clearConfigDefaultAgent(): void {
 const EXTENSION_PATTERN = /^\.[A-Za-z0-9_-]+$/;
 
 /**
+ * Regex describing a bare extension (no leading dot). Used when parsing
+ * the `indexing.extensions` field of `.alexi/config.json` and the flat
+ * `.alexi/extensions` file, where the user may write `mdx` or `.mdx`
+ * interchangeably.
+ */
+const BARE_EXTENSION_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/**
  * Validate a single additional-extension entry.
  * Returns the trimmed extension when valid, or throws when invalid.
  */
@@ -239,39 +247,191 @@ export function validateAdditionalExtension(ext: unknown): string {
 }
 
 /**
- * Load the configured additional file extensions for indexing.
- *
- * Returns an array of normalized extensions (each starting with `.` and
- * lower-cased). Invalid entries are silently dropped so that a corrupt
- * config never crashes tool execution — callers wanting strict validation
- * should use {@link setConfigAdditionalExtensions} instead.
+ * Normalize an extension entry to dotted lower-case form.
+ * Accepts both `.mdx` and `mdx` shapes; returns `null` for anything
+ * else (including empty strings, non-strings, path-like values).
  */
-export function getConfigAdditionalExtensions(): string[] {
-  const config = loadFullConfig();
-  const indexing = config.indexing;
+function normalizeExtension(raw: unknown): string | null {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  if (EXTENSION_PATTERN.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  if (BARE_EXTENSION_PATTERN.test(trimmed)) {
+    return `.${trimmed.toLowerCase()}`;
+  }
+  return null;
+}
+
+/**
+ * Extract dotted, lower-cased, deduped extensions from an `indexing`
+ * section of a parsed config object. Reads both `additionalExtensions`
+ * (canonical, strictly dotted) and `extensions` (alias, accepts bare
+ * or dotted names). Invalid entries are silently dropped.
+ */
+function extractIndexingExtensions(indexing: unknown): string[] {
   if (!indexing || typeof indexing !== 'object' || Array.isArray(indexing)) {
     return [];
   }
-  const raw = (indexing as Record<string, unknown>).additionalExtensions;
-  if (!Array.isArray(raw)) {
+  const rec = indexing as Record<string, unknown>;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (normalized: string | null): void => {
+    if (normalized === null) {
+      return;
+    }
+    if (seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    out.push(normalized);
+  };
+
+  // `additionalExtensions`: strict dotted form (backward compatible).
+  if (Array.isArray(rec.additionalExtensions)) {
+    for (const entry of rec.additionalExtensions) {
+      if (typeof entry !== 'string') {
+        continue;
+      }
+      const trimmed = entry.trim();
+      if (!EXTENSION_PATTERN.test(trimmed)) {
+        continue;
+      }
+      push(trimmed.toLowerCase());
+    }
+  }
+  // `extensions`: lax alias, accepts `mdx` or `.mdx`.
+  if (Array.isArray(rec.extensions)) {
+    for (const entry of rec.extensions) {
+      push(normalizeExtension(entry));
+    }
+  }
+  return out;
+}
+
+/**
+ * Load the configured additional file extensions for indexing from the
+ * user's global config at `~/.alexi/config.json`.
+ *
+ * Returns an array of normalized extensions (each starting with `.` and
+ * lower-cased). Reads both `indexing.additionalExtensions` (canonical,
+ * dotted) and `indexing.extensions` (alias, accepts bare names).
+ * Invalid entries are silently dropped so that a corrupt config never
+ * crashes tool execution.
+ */
+export function getConfigAdditionalExtensions(): string[] {
+  const config = loadFullConfig();
+  return extractIndexingExtensions(config.indexing);
+}
+
+/**
+ * Read extensions from a project-local `.alexi/config.json` file at the
+ * given directory. Returns an empty array when the file is missing,
+ * unreadable, or does not declare any indexing extensions. Never throws.
+ */
+export function readProjectConfigExtensions(cwd: string): string[] {
+  const projectConfigPath = path.join(cwd, '.alexi', 'config.json');
+  let content: string;
+  try {
+    content = fs.readFileSync(projectConfigPath, 'utf-8');
+  } catch {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return [];
+  }
+  return extractIndexingExtensions((parsed as Record<string, unknown>).indexing);
+}
+
+/**
+ * Read extensions from a flat `.alexi/extensions` file at the given
+ * directory. Format: one extension per line, blank lines are ignored,
+ * lines starting with `#` (after optional leading whitespace) are
+ * treated as comments. Extensions may be written with or without a
+ * leading dot (`mdx`, `.mdx`). Returns an empty array when the file is
+ * missing or unreadable. Never throws.
+ */
+export function readProjectExtensionsFile(cwd: string): string[] {
+  const extensionsFilePath = path.join(cwd, '.alexi', 'extensions');
+  let content: string;
+  try {
+    content = fs.readFileSync(extensionsFilePath, 'utf-8');
+  } catch {
     return [];
   }
   const seen = new Set<string>();
   const out: string[] = [];
-  for (const entry of raw) {
-    if (typeof entry !== 'string') {
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
       continue;
     }
-    const trimmed = entry.trim();
-    if (!EXTENSION_PATTERN.test(trimmed)) {
+    if (line.startsWith('#')) {
       continue;
     }
-    const normalized = trimmed.toLowerCase();
+    // Support inline comments: `mdx  # markdown extended`
+    const withoutComment = line.split('#', 1)[0].trim();
+    if (withoutComment.length === 0) {
+      continue;
+    }
+    const normalized = normalizeExtension(withoutComment);
+    if (normalized === null) {
+      continue;
+    }
     if (seen.has(normalized)) {
       continue;
     }
     seen.add(normalized);
     out.push(normalized);
+  }
+  return out;
+}
+
+/**
+ * Return the effective set of indexing extensions for a given working
+ * directory. Merges (in this precedence order, later sources add to
+ * earlier ones):
+ *
+ *   1. Global user config (`~/.alexi/config.json`, `indexing.extensions`
+ *      or `indexing.additionalExtensions`)
+ *   2. Project config (`<cwd>/.alexi/config.json`, same fields)
+ *   3. Project extensions file (`<cwd>/.alexi/extensions`)
+ *
+ * Result is deduplicated case-insensitively and normalized to dotted
+ * lower-case form (e.g. `.mdx`, `.astro`). Never throws.
+ */
+export function getIndexingExtensions(cwd?: string): string[] {
+  const globalExts = getConfigAdditionalExtensions();
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (ext: string): void => {
+    if (seen.has(ext)) {
+      return;
+    }
+    seen.add(ext);
+    out.push(ext);
+  };
+  for (const ext of globalExts) {
+    push(ext);
+  }
+  if (cwd) {
+    for (const ext of readProjectConfigExtensions(cwd)) {
+      push(ext);
+    }
+    for (const ext of readProjectExtensionsFile(cwd)) {
+      push(ext);
+    }
   }
   return out;
 }

--- a/src/tool/tools/codesearch.ts
+++ b/src/tool/tools/codesearch.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { defineTool, truncateOutput, type ToolResult } from '../index.js';
-import { getConfigAdditionalExtensions } from '../../config/userConfig.js';
+import { getIndexingExtensions } from '../../config/userConfig.js';
 import { mergeExtensionSet, mergeIncludePattern } from './includePattern.js';
 
 // Hard cap on matches/symbols returned per query, to prevent context-window
@@ -382,12 +382,13 @@ When independent reads, searches, or edits are also needed, emit those tool call
       : context.workdir;
 
     try {
-      // Merge configured `indexing.additionalExtensions` into both the
-      // built-in CODE_EXTENSIONS whitelist and the caller's include
-      // filter. Additional extensions are ADDITIVE: they extend the
-      // pool of files considered "code" but never narrow an existing
-      // include.
-      const additionalExtensions = getConfigAdditionalExtensions();
+      // Merge configured indexing extensions (global user config plus
+      // project-local `.alexi/config.json` and `.alexi/extensions`) into
+      // both the built-in CODE_EXTENSIONS whitelist and the caller's
+      // include filter. Additional extensions are ADDITIVE: they extend
+      // the pool of files considered "code" but never narrow an
+      // existing include.
+      const additionalExtensions = getIndexingExtensions(context.workdir);
       const effectiveExtensions = mergeExtensionSet(CODE_EXTENSIONS, additionalExtensions);
       const effectiveInclude = mergeIncludePattern(include, additionalExtensions);
 

--- a/src/tool/tools/glob.ts
+++ b/src/tool/tools/glob.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { defineTool, type ToolResult } from '../index.js';
 import { getReferenceService } from '../../reference/reference.js';
-import { getConfigAdditionalExtensions } from '../../config/userConfig.js';
+import { getIndexingExtensions } from '../../config/userConfig.js';
 
 const GlobParamsSchema = z.object({
   pattern: z.string().describe("Glob pattern to match files (e.g., '**/*.ts')"),
@@ -229,12 +229,13 @@ When independent reads, searches, or edits are also needed, emit those tool call
       }
 
       // Extend the caller's pattern with any additional extensions
-      // configured via `indexing.additionalExtensions`. Only the last
-      // segment is touched (e.g. `**/*.ts` -> `**/*.{ts,proto}`), so
-      // directory scoping is preserved. Patterns whose last segment is
-      // not a recognized extension shape (e.g. exact filenames) pass
-      // through unchanged.
-      const additionalExtensions = getConfigAdditionalExtensions();
+      // configured via `indexing.additionalExtensions` (global) or
+      // `indexing.extensions` in a project-local `.alexi/config.json` /
+      // `.alexi/extensions` file. Only the last segment is touched
+      // (e.g. `**/*.ts` -> `**/*.{ts,mdx}`), so directory scoping is
+      // preserved. Patterns whose last segment is not a recognized
+      // extension shape (e.g. exact filenames) pass through unchanged.
+      const additionalExtensions = getIndexingExtensions(context.workdir);
       const effectivePattern = extendGlobPattern(params.pattern, additionalExtensions);
 
       let matches = await globMatch(searchPath, effectivePattern, context.signal);

--- a/src/tool/tools/grep.ts
+++ b/src/tool/tools/grep.ts
@@ -17,7 +17,7 @@ import { defineTool, type ToolResult } from '../index.js';
 import { getReferenceService } from '../../reference/reference.js';
 import { logger } from '../../utils/logger.js';
 import { attachAgentsMdRemindersForPaths } from '../../agent/agentsMdReminders.js';
-import { getConfigAdditionalExtensions } from '../../config/userConfig.js';
+import { getIndexingExtensions } from '../../config/userConfig.js';
 import { mergeIncludePattern } from './includePattern.js';
 
 const GrepParamsSchema = z.object({
@@ -570,10 +570,12 @@ When independent reads, searches, or edits are also needed, emit those tool call
       }
 
       // Merge the caller's include filter with any additional extensions
-      // configured via `indexing.additionalExtensions` in the user config.
-      // When no include was passed, the pattern remains undefined and the
-      // tool retains its historical "search all files" behavior.
-      const additionalExtensions = getConfigAdditionalExtensions();
+      // configured via `indexing.additionalExtensions` (global) or
+      // `indexing.extensions` in a project-local `.alexi/config.json` /
+      // `.alexi/extensions` file. When no include was passed, the pattern
+      // remains undefined and the tool retains its historical "search
+      // all files" behavior.
+      const additionalExtensions = getIndexingExtensions(context.workdir);
       const effectiveInclude = mergeIncludePattern(params.include, additionalExtensions);
 
       // Fast path: ripgrep when available.

--- a/tests/config/userConfig.test.ts
+++ b/tests/config/userConfig.test.ts
@@ -20,6 +20,9 @@ import {
   getConfigAdditionalExtensions,
   setConfigAdditionalExtensions,
   validateAdditionalExtension,
+  getIndexingExtensions,
+  readProjectConfigExtensions,
+  readProjectExtensionsFile,
 } from '../../src/config/userConfig.js';
 
 describe('userConfig', () => {
@@ -347,6 +350,218 @@ describe('userConfig', () => {
       expect(() => setConfigAdditionalExtensions('proto' as unknown as string[])).toThrow(
         /must be an array/
       );
+    });
+
+    it('should accept the `indexing.extensions` alias with bare names', () => {
+      saveFullConfig({ indexing: { extensions: ['mdx', 'astro', 'svelte'] } });
+      expect(getConfigAdditionalExtensions()).toEqual(['.mdx', '.astro', '.svelte']);
+    });
+
+    it('should accept the `indexing.extensions` alias with dotted names', () => {
+      saveFullConfig({ indexing: { extensions: ['.mdx', '.vue'] } });
+      expect(getConfigAdditionalExtensions()).toEqual(['.mdx', '.vue']);
+    });
+
+    it('should merge `indexing.extensions` and `indexing.additionalExtensions`', () => {
+      saveFullConfig({
+        indexing: {
+          additionalExtensions: ['.proto'],
+          extensions: ['mdx', 'astro'],
+        },
+      });
+      expect(getConfigAdditionalExtensions()).toEqual(['.proto', '.mdx', '.astro']);
+    });
+
+    it('should dedupe across the two field names', () => {
+      saveFullConfig({
+        indexing: {
+          additionalExtensions: ['.mdx'],
+          extensions: ['mdx', '.MDX'],
+        },
+      });
+      expect(getConfigAdditionalExtensions()).toEqual(['.mdx']);
+    });
+  });
+
+  describe('readProjectConfigExtensions', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-project-config-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('returns [] when .alexi/config.json is missing', () => {
+      expect(readProjectConfigExtensions(tempDir)).toEqual([]);
+    });
+
+    it('returns [] when .alexi/config.json is not valid JSON', () => {
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(path.join(tempDir, '.alexi', 'config.json'), 'not json', 'utf-8');
+      expect(readProjectConfigExtensions(tempDir)).toEqual([]);
+    });
+
+    it('reads indexing.extensions with bare names', () => {
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'config.json'),
+        JSON.stringify({ indexing: { extensions: ['mdx', 'astro', 'svelte'] } }),
+        'utf-8'
+      );
+      expect(readProjectConfigExtensions(tempDir)).toEqual(['.mdx', '.astro', '.svelte']);
+    });
+
+    it('reads indexing.additionalExtensions with dotted names', () => {
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'config.json'),
+        JSON.stringify({ indexing: { additionalExtensions: ['.proto'] } }),
+        'utf-8'
+      );
+      expect(readProjectConfigExtensions(tempDir)).toEqual(['.proto']);
+    });
+
+    it('silently drops invalid entries', () => {
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'config.json'),
+        JSON.stringify({
+          indexing: { extensions: ['mdx', 'has space', 'foo/bar', 42, null, '.vue'] },
+        }),
+        'utf-8'
+      );
+      expect(readProjectConfigExtensions(tempDir)).toEqual(['.mdx', '.vue']);
+    });
+  });
+
+  describe('readProjectExtensionsFile', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-project-ext-file-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('returns [] when .alexi/extensions is missing', () => {
+      expect(readProjectExtensionsFile(tempDir)).toEqual([]);
+    });
+
+    it('parses one extension per line, ignoring blanks and comments', () => {
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'extensions'),
+        [
+          '# markdown extended',
+          'mdx',
+          '',
+          '   ',
+          '# comment',
+          '.astro',
+          'svelte # inline comment',
+          '  vue  ',
+        ].join('\n'),
+        'utf-8'
+      );
+      expect(readProjectExtensionsFile(tempDir)).toEqual(['.mdx', '.astro', '.svelte', '.vue']);
+    });
+
+    it('dedupes case-insensitively', () => {
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'extensions'),
+        ['mdx', 'MDX', '.Mdx'].join('\n'),
+        'utf-8'
+      );
+      expect(readProjectExtensionsFile(tempDir)).toEqual(['.mdx']);
+    });
+
+    it('silently drops invalid entries', () => {
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'extensions'),
+        ['mdx', 'has space', 'foo/bar', '.astro'].join('\n'),
+        'utf-8'
+      );
+      // 'has space' -> becomes 'has' after inline-comment strip? No, no '#'.
+      // 'has space' matches BARE_EXTENSION_PATTERN? No, contains space. Dropped.
+      // 'foo/bar' -> dropped.
+      expect(readProjectExtensionsFile(tempDir)).toEqual(['.mdx', '.astro']);
+    });
+  });
+
+  describe('getIndexingExtensions', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-get-idx-ext-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('returns global extensions when no project config exists', () => {
+      saveFullConfig({ indexing: { additionalExtensions: ['.proto'] } });
+      expect(getIndexingExtensions(tempDir)).toEqual(['.proto']);
+    });
+
+    it('merges global and project config additively', () => {
+      saveFullConfig({ indexing: { additionalExtensions: ['.proto'] } });
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'config.json'),
+        JSON.stringify({ indexing: { extensions: ['mdx', 'astro'] } }),
+        'utf-8'
+      );
+      expect(getIndexingExtensions(tempDir)).toEqual(['.proto', '.mdx', '.astro']);
+    });
+
+    it('merges .alexi/extensions file on top of both configs', () => {
+      saveFullConfig({ indexing: { additionalExtensions: ['.proto'] } });
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'config.json'),
+        JSON.stringify({ indexing: { extensions: ['mdx'] } }),
+        'utf-8'
+      );
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'extensions'),
+        ['# custom', 'svelte', 'vue'].join('\n'),
+        'utf-8'
+      );
+      expect(getIndexingExtensions(tempDir)).toEqual(['.proto', '.mdx', '.svelte', '.vue']);
+    });
+
+    it('dedupes across all three sources', () => {
+      saveFullConfig({ indexing: { additionalExtensions: ['.mdx'] } });
+      fs.mkdirSync(path.join(tempDir, '.alexi'));
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'config.json'),
+        JSON.stringify({ indexing: { extensions: ['mdx', 'astro'] } }),
+        'utf-8'
+      );
+      fs.writeFileSync(
+        path.join(tempDir, '.alexi', 'extensions'),
+        ['MDX', 'ASTRO', 'svelte'].join('\n'),
+        'utf-8'
+      );
+      expect(getIndexingExtensions(tempDir)).toEqual(['.mdx', '.astro', '.svelte']);
+    });
+
+    it('returns only global extensions when cwd is not provided', () => {
+      saveFullConfig({ indexing: { additionalExtensions: ['.proto'] } });
+      expect(getIndexingExtensions()).toEqual(['.proto']);
+    });
+
+    it('returns [] when no config exists anywhere', () => {
+      saveFullConfig({});
+      expect(getIndexingExtensions(tempDir)).toEqual([]);
     });
   });
 });

--- a/tests/tool/tools/additionalExtensions.integration.test.ts
+++ b/tests/tool/tools/additionalExtensions.integration.test.ts
@@ -1,9 +1,10 @@
 /**
- * Integration tests for `indexing.additionalExtensions`.
+ * Integration tests for `indexing.additionalExtensions` /
+ * `indexing.extensions`.
  *
  * Verifies that grep, glob, and codesearch honor the config-driven list
  * of extra file extensions when locating files. We mock
- * `getConfigAdditionalExtensions` rather than writing to the real
+ * `getIndexingExtensions` rather than writing to the real
  * ~/.alexi/config.json so the tests are hermetic.
  */
 
@@ -43,6 +44,7 @@ vi.mock('../../../src/config/userConfig.js', async () => {
   return {
     ...actual,
     getConfigAdditionalExtensions: (): string[] => [...additionalExtensions],
+    getIndexingExtensions: (): string[] => [...additionalExtensions],
   };
 });
 

--- a/tests/tool/tools/projectExtensions.integration.test.ts
+++ b/tests/tool/tools/projectExtensions.integration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Integration tests for project-local `.alexi/config.json` and
+ * `.alexi/extensions` support in the glob and grep tools.
+ *
+ * These tests write real files under an isolated temp `workdir` so the
+ * end-to-end pipeline (tool -> `getIndexingExtensions` -> file readers)
+ * is exercised without mocking. They do NOT touch the real global
+ * `~/.alexi/config.json`; instead, they assert only that
+ * project-configured extensions ARE matched, without asserting that
+ * unrelated extensions are not matched (which would depend on the
+ * runner's global config being empty).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import os from 'os';
+
+// Force the JS fallback path in grep so behavior is deterministic across
+// environments (ripgrep may or may not be installed on the runner).
+process.env.ALEXI_DISABLE_RG = '1';
+
+import { grepTool } from '../../../src/tool/tools/grep.js';
+import { globTool } from '../../../src/tool/tools/glob.js';
+import type { ToolContext } from '../../../src/tool/index.js';
+
+describe('project indexing extensions integration', () => {
+  let tempDir: string;
+  let context: ToolContext;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'alexi-project-idx-'));
+    context = { workdir: tempDir };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('glob', () => {
+    it('matches .mdx files when project .alexi/config.json declares mdx', async () => {
+      await fs.writeFile(path.join(tempDir, 'note.mdx'), 'content');
+      await fs.writeFile(path.join(tempDir, 'readme.md'), 'content');
+      await fs.mkdir(path.join(tempDir, '.alexi'));
+      await fs.writeFile(
+        path.join(tempDir, '.alexi', 'config.json'),
+        JSON.stringify({ indexing: { extensions: ['mdx'] } }),
+        'utf-8'
+      );
+
+      const result = await globTool.execute({ pattern: '**/*.md' }, context);
+      expect(result.success).toBe(true);
+      const matches = result.data?.matches ?? [];
+      expect(matches).toContain('note.mdx');
+      expect(matches).toContain('readme.md');
+    });
+
+    it('matches .astro / .svelte files declared in .alexi/extensions', async () => {
+      await fs.writeFile(path.join(tempDir, 'page.astro'), 'x');
+      await fs.writeFile(path.join(tempDir, 'widget.svelte'), 'x');
+      await fs.writeFile(path.join(tempDir, 'a.ts'), 'x');
+      await fs.mkdir(path.join(tempDir, '.alexi'));
+      await fs.writeFile(
+        path.join(tempDir, '.alexi', 'extensions'),
+        '# custom stacks\nastro\nsvelte\n',
+        'utf-8'
+      );
+
+      const result = await globTool.execute({ pattern: '**/*.ts' }, context);
+      expect(result.success).toBe(true);
+      const matches = result.data?.matches ?? [];
+      expect(matches).toContain('page.astro');
+      expect(matches).toContain('widget.svelte');
+      expect(matches).toContain('a.ts');
+    });
+
+    it('matches .vue via indexing.extensions in project config', async () => {
+      await fs.writeFile(path.join(tempDir, 'App.vue'), 'x');
+      await fs.writeFile(path.join(tempDir, 'main.ts'), 'x');
+      await fs.mkdir(path.join(tempDir, '.alexi'));
+      await fs.writeFile(
+        path.join(tempDir, '.alexi', 'config.json'),
+        JSON.stringify({ indexing: { extensions: ['vue'] } }),
+        'utf-8'
+      );
+
+      const result = await globTool.execute({ pattern: '**/*.ts' }, context);
+      expect(result.success).toBe(true);
+      const matches = result.data?.matches ?? [];
+      expect(matches).toContain('App.vue');
+      expect(matches).toContain('main.ts');
+    });
+  });
+
+  describe('grep', () => {
+    it('searches .mdx files when project config declares mdx', async () => {
+      await fs.writeFile(path.join(tempDir, 'note.mdx'), 'needle in mdx');
+      await fs.writeFile(path.join(tempDir, 'main.ts'), 'needle in ts');
+      await fs.mkdir(path.join(tempDir, '.alexi'));
+      await fs.writeFile(
+        path.join(tempDir, '.alexi', 'config.json'),
+        JSON.stringify({ indexing: { extensions: ['mdx'] } }),
+        'utf-8'
+      );
+
+      const result = await grepTool.execute({ pattern: 'needle', include: '*.ts' }, context);
+      expect(result.success).toBe(true);
+      const files = (result.data?.matches ?? []).map((m) => m.file);
+      expect(files).toContain('main.ts');
+      expect(files).toContain('note.mdx');
+    });
+
+    it('searches .astro / .svelte files from .alexi/extensions', async () => {
+      await fs.writeFile(path.join(tempDir, 'page.astro'), 'const needle = 1;');
+      await fs.writeFile(path.join(tempDir, 'widget.svelte'), 'let needle;');
+      await fs.writeFile(path.join(tempDir, 'main.ts'), 'const needle = 1;');
+      await fs.mkdir(path.join(tempDir, '.alexi'));
+      await fs.writeFile(path.join(tempDir, '.alexi', 'extensions'), 'astro\nsvelte\n', 'utf-8');
+
+      const result = await grepTool.execute({ pattern: 'needle', include: '*.ts' }, context);
+      expect(result.success).toBe(true);
+      const files = (result.data?.matches ?? []).map((m) => m.file);
+      expect(files).toContain('main.ts');
+      expect(files).toContain('page.astro');
+      expect(files).toContain('widget.svelte');
+    });
+  });
+});


### PR DESCRIPTION
Closes #1149

## What

Adds support for configuring custom file extensions (e.g. `.mdx`, `.astro`, `.svelte`, `.vue`) that `glob`, `grep`, and `codesearch` will honor when locating files, so modern stacks are indexed without requiring the caller to spell each extension into every `include` pattern.

## Why

Hardcoded extension lists in file operations caused glob/grep to miss files on stacks using `.mdx`, `.astro`, `.svelte`, and similar. This feature closes the gap through a `.kiloignore`-style configuration surface: a JSON field plus an optional flat file.

## How

- **`src/config/userConfig.ts`**: new `getIndexingExtensions(cwd?)` merges three sources additively:
  1. Global user config (`~/.alexi/config.json`)
  2. Project config (`<cwd>/.alexi/config.json`)
  3. Project extensions file (`<cwd>/.alexi/extensions`)
- Both config files accept `indexing.additionalExtensions` (canonical dotted form, strict) and `indexing.extensions` (alias, accepts bare names like `mdx`).
- `.alexi/extensions` is a flat text file: one ext per line, blank lines and `#` comments ignored, inline `#` comments stripped.
- `src/tool/tools/{glob,grep,codesearch}.ts` now call `getIndexingExtensions(ctx.workdir)` instead of the global-only `getConfigAdditionalExtensions()`.
- Deduplicated case-insensitively; normalized to lower-case dotted form.

## Semantics

- **Additive only.** Extensions extend a caller-provided `include` pattern; they never restrict it. When no `include` is passed, grep still searches all files (historical behavior preserved).
- **Backward compatible.** Existing `indexing.additionalExtensions` usage continues to work; the strict validation on writes is unchanged.

## Tests

- Unit tests for `readProjectConfigExtensions`, `readProjectExtensionsFile`, and `getIndexingExtensions` merger in `tests/config/userConfig.test.ts`.
- Alias / merge cases for `getConfigAdditionalExtensions` covering `indexing.extensions` with bare and dotted names.
- New integration test `tests/tool/tools/projectExtensions.integration.test.ts` writes real `.alexi/config.json` and `.alexi/extensions` files under a temp workdir and asserts glob/grep pick up `.mdx`, `.astro`, `.svelte`, and `.vue` files.
- Updated `tests/tool/tools/additionalExtensions.integration.test.ts` mock to cover both accessor exports.

## Docs

New `Indexing config: custom file extensions` subsection in `docs/ARCHITECTURE.md` documenting sources, precedence, JSON schema, `.alexi/extensions` format, additive semantics, and validation.

## Gates

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm test` — 3361 passed / 3 skipped (242 test files)
- `npm run build` — clean
- Global coverage: 66.13% lines (above the 40% CI floor)

[alexi-bot]