### PR TITLE
feat(core): add StreamStalledError for stalled LLM streams (#1164)

### DIFF
--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -8,7 +8,12 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { execSync } from 'child_process';
-import { streamChat, resolveModelId, isAbortError } from '../core/streamingOrchestrator.js';
+import {
+  streamChat,
+  resolveModelId,
+  isAbortError,
+  isStreamStalledError,
+} from '../core/streamingOrchestrator.js';
 import { isOrchestrationModel } from '../providers/sapOrchestration.js';
 import { SessionManager } from '../core/sessionManager.js';
 import { colors, c } from './utils/colors.js';
@@ -2617,6 +2622,14 @@ export async function startInteractive(options: InteractiveOptions = {}): Promis
 
       if (isAbortError(err)) {
         // Already handled in SIGINT
+      } else if (isStreamStalledError(err)) {
+        // Stalled provider stream (issue #1164). Show a retry-oriented
+        // hint so users know the process is not frozen — they can just
+        // re-issue the prompt or switch models.
+        console.log();
+        console.log(
+          c('red', `\n  ${err.message} You can retry the request or switch models with /model.\n`)
+        );
       } else {
         console.log();
         console.log(c('red', `\n  Error: ${err instanceof Error ? err.message : String(err)}\n`));

--- a/src/cli/tui/hooks/useStreamChat.ts
+++ b/src/cli/tui/hooks/useStreamChat.ts
@@ -4,6 +4,7 @@ import { useChat } from '../context/ChatContext.js';
 import { useSession } from '../context/SessionContext.js';
 import { useAttachments } from '../context/AttachmentContext.js';
 import { buildUserMessage, type MultimodalContentItem } from '../../../utils/multimodal.js';
+import { isStreamStalledError } from '../../../core/streamWatchdog.js';
 
 export interface UseStreamChatReturn {
   sendMessage: (text: string) => Promise<void>;
@@ -78,6 +79,10 @@ export function useStreamChat(): UseStreamChatReturn {
         // Handle abort gracefully — not an error
         if (err instanceof Error && err.name === 'AbortError') {
           // Aborted by user; no error to display
+        } else if (isStreamStalledError(err)) {
+          // Stalled provider stream (issue #1164). Surface a friendly,
+          // retry-oriented message instead of the raw watchdog text.
+          chat.setError(`${err.message} You can retry the request or switch models.`);
         } else {
           const message = err instanceof Error ? err.message : String(err);
           chat.setError(message);

--- a/src/core/streamWatchdog.ts
+++ b/src/core/streamWatchdog.ts
@@ -33,6 +33,51 @@
 import type { StreamChunk } from '../providers/index.js';
 
 /**
+ * Error raised when the streaming watchdog detects a stalled provider
+ * stream — i.e. no chunk arrived within the configured idle window.
+ *
+ * The error is thrown from the pending `next()` call on the watchdog
+ * iterator and propagates up through `streamChat`. Callers can
+ * distinguish a stall from a user-initiated abort via
+ * `err instanceof StreamStalledError`. For legacy call sites that
+ * key off `err.name === 'AbortError'`, the name is set to
+ * `'StreamStalledError'` but a companion boolean flag `isStreamStalled`
+ * and `code: 'STREAM_STALLED'` are attached so the router can classify
+ * it as transient without a string-compare.
+ *
+ * See issue #1164.
+ */
+export class StreamStalledError extends Error {
+  /** Discriminator for `router.classifyRouteError` and TUI/CLI branches. */
+  readonly isStreamStalled = true;
+  /** Machine-readable code kept stable across message revisions. */
+  readonly code = 'STREAM_STALLED';
+  /** Idle window (ms) that had elapsed with no chunk when the timer fired. */
+  readonly timeoutMs: number;
+  constructor(timeoutMs: number, message?: string) {
+    super(message ?? `Stream stalled. No response for ${Math.round(timeoutMs / 1000)}s.`);
+    this.name = 'StreamStalledError';
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Type-guard for {@link StreamStalledError} that also matches plain
+ * objects wearing the `isStreamStalled` marker (defensive against error
+ * instances re-created across module boundaries).
+ */
+export function isStreamStalledError(err: unknown): err is StreamStalledError {
+  if (err instanceof StreamStalledError) {
+    return true;
+  }
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { isStreamStalled?: unknown }).isStreamStalled === true
+  );
+}
+
+/**
  * Names of tools whose in-flight tool-call chunks should extend the idle
  * timeout window. These are tools that legitimately produce long silent
  * periods (e.g. shell commands, background processes, sub-agents). The
@@ -49,8 +94,34 @@ export const DEFAULT_LONG_RUNNING_TOOL_NAMES: ReadonlySet<string> = new Set([
   'agent_manager',
 ]);
 
-/** Default idle-timeout window before a stalled stream is aborted. */
-export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 30_000;
+/**
+ * Resolve the effective default idle timeout, honouring the
+ * `STREAM_STALL_TIMEOUT_MS` environment variable when set to a positive
+ * integer. Falls back to 30_000 ms otherwise.
+ *
+ * The env var is read on each call (not cached at import time) so tests
+ * and long-running processes can adjust the value at runtime.
+ */
+export function resolveDefaultStreamIdleTimeoutMs(): number {
+  const raw = process.env.STREAM_STALL_TIMEOUT_MS;
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    const parsed = parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return 30_000;
+}
+
+/**
+ * Default idle-timeout window before a stalled stream is aborted.
+ *
+ * NOTE: Read at import time. For env-var-aware resolution use
+ * {@link resolveDefaultStreamIdleTimeoutMs} — the streaming orchestrator
+ * calls the function on every stream so a mid-session `STREAM_STALL_TIMEOUT_MS`
+ * change takes effect on the next request.
+ */
+export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = resolveDefaultStreamIdleTimeoutMs();
 
 /** Default extended idle window when a long-running tool is in-flight. */
 export const DEFAULT_STREAM_TOOL_EXTENSION_MS = 10 * 60 * 1000;
@@ -185,12 +256,11 @@ export function createStreamWatchdog(
     if (currentWindowMs <= 0 || !Number.isFinite(currentWindowMs)) {
       return;
     }
+    const armedWindowMs = currentWindowMs;
     idleTimer = setTimeout(() => {
       idleTimer = null;
       if (!finished && !controller.signal.aborted) {
-        controller.abort(
-          new DOMException(`stream idle timeout after ${currentWindowMs}ms`, 'AbortError')
-        );
+        controller.abort(new StreamStalledError(armedWindowMs));
       }
     }, currentWindowMs);
     // Do not keep the Node event loop alive solely for a watchdog timer.

--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -19,8 +19,8 @@ import { buildSessionHeaders } from '../providers/sessionHeaders.js';
 import type { CompletionOptions } from '../providers/sapOrchestration.js';
 import {
   createStreamWatchdog,
-  DEFAULT_STREAM_IDLE_TIMEOUT_MS,
   DEFAULT_STREAM_TOOL_EXTENSION_MS,
+  resolveDefaultStreamIdleTimeoutMs,
 } from './streamWatchdog.js';
 
 export interface StreamingOptions {
@@ -67,6 +67,11 @@ export interface StreamingResult {
 
 // Re-export StreamChunk for consumers
 export type { StreamChunk };
+
+// Re-export the stall-error surface so CLI/TUI can `import { ... } from
+// '../core/streamingOrchestrator.js'` without reaching into the watchdog
+// module.
+export { StreamStalledError, isStreamStalledError } from './streamWatchdog.js';
 
 /**
  * The hand-rolled iterator returned by {@link streamChat}. Mirrors the
@@ -228,7 +233,9 @@ export function streamChat(
         provider.streamComplete(messages, { ...providerOpts, signal: effectiveSignal }),
       {
         signal: options?.signal,
-        idleTimeoutMs: options?.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+        // Resolve the idle timeout on every stream so a mid-session
+        // `STREAM_STALL_TIMEOUT_MS` env change takes effect immediately.
+        idleTimeoutMs: options?.streamIdleTimeoutMs ?? resolveDefaultStreamIdleTimeoutMs(),
         toolExtensionMs: options?.streamToolExtensionMs ?? DEFAULT_STREAM_TOOL_EXTENSION_MS,
       }
     );

--- a/tests/core/streamWatchdog.test.ts
+++ b/tests/core/streamWatchdog.test.ts
@@ -13,12 +13,15 @@
  * `createStreamWatchdog` directly with hand-written sources to keep the
  * cause/effect link tight when a regression appears.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   createStreamWatchdog,
   DEFAULT_STREAM_IDLE_TIMEOUT_MS,
   DEFAULT_STREAM_TOOL_EXTENSION_MS,
   DEFAULT_LONG_RUNNING_TOOL_NAMES,
+  StreamStalledError,
+  isStreamStalledError,
+  resolveDefaultStreamIdleTimeoutMs,
 } from '../../src/core/streamWatchdog.js';
 import type { StreamChunk } from '../../src/providers/index.js';
 
@@ -193,7 +196,7 @@ describe('createStreamWatchdog', () => {
       await expect(pull).rejects.toBeInstanceOf(Error);
     });
 
-    it('carries a descriptive abort reason on idle timeout', async () => {
+    it('throws a StreamStalledError with a friendly message on idle timeout', async () => {
       const { factory } = stalledAsyncSource();
       const iter = createStreamWatchdog(factory, { idleTimeoutMs: 50 });
       await iter.next();
@@ -205,8 +208,15 @@ describe('createStreamWatchdog', () => {
         caught = err;
       }
       expect(caught).toBeInstanceOf(Error);
-      expect((caught as Error).name).toBe('AbortError');
-      expect((caught as Error).message).toMatch(/stream idle timeout/i);
+      // Post-#1164: idle-timeout aborts surface as StreamStalledError
+      // (not the generic AbortError DOMException) so the CLI/TUI can
+      // distinguish a stall from a user-initiated cancel.
+      expect(caught).toBeInstanceOf(StreamStalledError);
+      expect(isStreamStalledError(caught)).toBe(true);
+      expect((caught as Error).name).toBe('StreamStalledError');
+      expect((caught as Error).message).toMatch(/Stream stalled\. No response for /i);
+      expect((caught as StreamStalledError).timeoutMs).toBe(50);
+      expect((caught as StreamStalledError).code).toBe('STREAM_STALLED');
     });
   });
 
@@ -435,5 +445,95 @@ describe('createStreamWatchdog', () => {
         ({ notAnIterator: true }) as unknown as AsyncIterable<StreamChunk>;
       expect(() => createStreamWatchdog(factory, { idleTimeoutMs: 0 })).toThrow(TypeError);
     });
+  });
+});
+
+/**
+ * Dedicated coverage for the {@link StreamStalledError} surface and the
+ * env-var-driven default timeout resolver introduced in issue #1164.
+ * These do not touch the watchdog loop — they lock the error shape and
+ * env-var contract so consumers (TUI/CLI, router) can rely on them.
+ */
+describe('StreamStalledError', () => {
+  it('is an Error subclass with a stable name and machine-readable code', () => {
+    const err = new StreamStalledError(30_000);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(StreamStalledError);
+    expect(err.name).toBe('StreamStalledError');
+    expect(err.code).toBe('STREAM_STALLED');
+    expect(err.isStreamStalled).toBe(true);
+    expect(err.timeoutMs).toBe(30_000);
+  });
+
+  it('renders a human-friendly default message that includes the timeout in seconds', () => {
+    expect(new StreamStalledError(30_000).message).toBe('Stream stalled. No response for 30s.');
+    expect(new StreamStalledError(60_000).message).toBe('Stream stalled. No response for 60s.');
+    // Rounds sub-second timeouts to the nearest whole second (still
+    // useful for the user; sub-second stalls are effectively "no wait").
+    expect(new StreamStalledError(500).message).toMatch(/^Stream stalled\. No response for /);
+  });
+
+  it('accepts an explicit override message', () => {
+    const err = new StreamStalledError(1000, 'custom stall text');
+    expect(err.message).toBe('custom stall text');
+    expect(err.timeoutMs).toBe(1000);
+  });
+});
+
+describe('isStreamStalledError', () => {
+  it('returns true for a real StreamStalledError instance', () => {
+    expect(isStreamStalledError(new StreamStalledError(1000))).toBe(true);
+  });
+
+  it('returns true for a duck-typed error carrying isStreamStalled=true', () => {
+    // Guards against realm/module-boundary issues where `instanceof` fails
+    // but the marker survives (e.g. errors serialized across a worker).
+    const duck = { isStreamStalled: true, message: 'stalled' };
+    expect(isStreamStalledError(duck)).toBe(true);
+  });
+
+  it('returns false for unrelated errors and non-error values', () => {
+    expect(isStreamStalledError(new Error('boom'))).toBe(false);
+    expect(isStreamStalledError(new DOMException('nope', 'AbortError'))).toBe(false);
+    expect(isStreamStalledError(null)).toBe(false);
+    expect(isStreamStalledError(undefined)).toBe(false);
+    expect(isStreamStalledError('stalled')).toBe(false);
+    expect(isStreamStalledError({ isStreamStalled: false })).toBe(false);
+  });
+});
+
+describe('resolveDefaultStreamIdleTimeoutMs', () => {
+  const ORIGINAL = process.env.STREAM_STALL_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.STREAM_STALL_TIMEOUT_MS;
+    } else {
+      process.env.STREAM_STALL_TIMEOUT_MS = ORIGINAL;
+    }
+  });
+
+  it('defaults to 30_000 ms when the env var is unset', () => {
+    delete process.env.STREAM_STALL_TIMEOUT_MS;
+    expect(resolveDefaultStreamIdleTimeoutMs()).toBe(30_000);
+  });
+
+  it('honours a positive integer STREAM_STALL_TIMEOUT_MS override', () => {
+    process.env.STREAM_STALL_TIMEOUT_MS = '60000';
+    expect(resolveDefaultStreamIdleTimeoutMs()).toBe(60_000);
+  });
+
+  it('accepts 0 (watchdog effectively disabled) as a valid override', () => {
+    process.env.STREAM_STALL_TIMEOUT_MS = '0';
+    expect(resolveDefaultStreamIdleTimeoutMs()).toBe(0);
+  });
+
+  it('falls back to the default for garbage / negative / empty values', () => {
+    process.env.STREAM_STALL_TIMEOUT_MS = 'not-a-number';
+    expect(resolveDefaultStreamIdleTimeoutMs()).toBe(30_000);
+    process.env.STREAM_STALL_TIMEOUT_MS = '-42';
+    expect(resolveDefaultStreamIdleTimeoutMs()).toBe(30_000);
+    process.env.STREAM_STALL_TIMEOUT_MS = '   ';
+    expect(resolveDefaultStreamIdleTimeoutMs()).toBe(30_000);
   });
 });

--- a/tests/core/streamingOrchestrator.test.ts
+++ b/tests/core/streamingOrchestrator.test.ts
@@ -25,7 +25,11 @@ vi.mock('../../src/core/router.js', () => ({
   classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
 }));
 
-import { streamChat } from '../../src/core/streamingOrchestrator.js';
+import {
+  streamChat,
+  StreamStalledError,
+  isStreamStalledError,
+} from '../../src/core/streamingOrchestrator.js';
 import { getProviderForModelWithFallback, getDefaultModel } from '../../src/providers/index.js';
 import type { StreamChunk } from '../../src/providers/index.js';
 
@@ -338,6 +342,72 @@ describe('streamChat hand-rolled iterator preemption (issue #1115)', () => {
     expect(chunks.join('')).toBe('ab');
     expect(finalResult.modelUsed).toBe('gpt-4o');
     expect(finalResult.usage?.total_tokens).toBe(5);
+  });
+
+  it('surfaces a StreamStalledError (not a generic AbortError) when the stream stalls (#1164)', async () => {
+    const { provider } = makeStalledProvider();
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: provider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: false,
+    });
+
+    const iter = streamChat('hi', {
+      modelOverride: 'gpt-4o',
+      streamIdleTimeoutMs: 80,
+    });
+
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+
+    let caught: unknown;
+    try {
+      await iter.next();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(StreamStalledError);
+    expect(isStreamStalledError(caught)).toBe(true);
+    expect((caught as Error).message).toMatch(/Stream stalled\. No response for /i);
+    // The error must NOT collapse into a generic AbortError so CLI/TUI
+    // can render a distinct, retry-oriented message.
+    expect((caught as Error).name).toBe('StreamStalledError');
+  });
+
+  it('picks up STREAM_STALL_TIMEOUT_MS env var when streamIdleTimeoutMs is not provided (#1164)', async () => {
+    const originalEnv = process.env.STREAM_STALL_TIMEOUT_MS;
+    process.env.STREAM_STALL_TIMEOUT_MS = '75';
+    try {
+      const { provider } = makeStalledProvider();
+      vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+        provider: provider as never,
+        effectiveModelId: 'gpt-4o',
+        usedFallback: false,
+      });
+
+      // NOTE: no streamIdleTimeoutMs — the orchestrator should resolve
+      // the timeout from the env var on each stream.
+      const iter = streamChat('hi', { modelOverride: 'gpt-4o' });
+      await iter.next(); // first chunk
+
+      const start = Date.now();
+      let caught: unknown;
+      try {
+        await iter.next();
+      } catch (err) {
+        caught = err;
+      }
+      const elapsed = Date.now() - start;
+      expect(caught).toBeInstanceOf(StreamStalledError);
+      // The 75ms window should fire well under the pre-#1164 30s default.
+      expect(elapsed).toBeLessThan(2_000);
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.STREAM_STALL_TIMEOUT_MS;
+      } else {
+        process.env.STREAM_STALL_TIMEOUT_MS = originalEnv;
+      }
+    }
   });
 
   it('is drivable via `for await` (Symbol.asyncIterator)', async () => {


### PR DESCRIPTION
## Summary

Formalizes the streaming watchdog's idle-timeout failure mode with a distinct `StreamStalledError` type, an env-var-configurable timeout, and friendlier CLI/TUI messaging.

## Changes

- **`src/core/streamWatchdog.ts`**
  - Add `StreamStalledError` (extends `Error`) with:
    - stable `name = 'StreamStalledError'`
    - machine-readable `code = 'STREAM_STALLED'`
    - `timeoutMs` field carrying the idle window that elapsed
    - default human-friendly message: `Stream stalled. No response for Xs.`
  - Add `isStreamStalledError()` type-guard (also matches duck-typed `isStreamStalled: true` markers for cross-realm safety).
  - Add `resolveDefaultStreamIdleTimeoutMs()` that reads `STREAM_STALL_TIMEOUT_MS` env var (positive integer, or 0 to disable) and falls back to `30_000` ms. Read at call time, not import time, so mid-session env changes take effect.
  - Watchdog now aborts idle-timed-out streams with the new error type instead of a generic `AbortError` `DOMException`.

- **`src/core/streamingOrchestrator.ts`**
  - Call `resolveDefaultStreamIdleTimeoutMs()` on every stream when no explicit `streamIdleTimeoutMs` option is provided.
  - Re-export `StreamStalledError` and `isStreamStalledError` for CLI/TUI consumers.

- **`src/cli/interactive.ts`** and **`src/cli/tui/hooks/useStreamChat.ts`**
  - Catch `StreamStalledError` and render a retry-oriented message (`You can retry the request or switch models`) instead of collapsing into the silent user-abort path or the generic red `Error: ...` path.

- **Tests**
  - Update the existing `streamWatchdog.test.ts` idle-timeout test to assert the new `StreamStalledError` shape.
  - Add dedicated `describe('StreamStalledError')`, `describe('isStreamStalledError')`, and `describe('resolveDefaultStreamIdleTimeoutMs')` blocks.
  - Add end-to-end tests in `streamingOrchestrator.test.ts` verifying the error surfaces through `streamChat` and that `STREAM_STALL_TIMEOUT_MS` is honoured.

## Backwards compatibility

- Public API surface only adds new symbols. No removed exports.
- The old idle-timeout path still throws an `Error` — callers that only check `err instanceof Error` are unaffected.
- Callers that relied on `err.name === 'AbortError'` to swallow idle timeouts silently will now see the friendly stall message instead. This is the intended behaviour change per the issue.
- Router error classification is unaffected: `StreamStalledError` falls into the `'unknown'` bucket, so a stall does not count toward the route auto-disable threshold.

## Verification

```
npm run lint         # 0 errors (warnings pre-existing)
npm run typecheck    # clean
npm run format:check # clean
npm test             # 3374 pass / 3 skip
npm run build        # clean
```

Coverage summary: Lines 66.17%, well above the 40% CI threshold.

Closes #1164