### PR TITLE
feat(tools): add resolveShell helper and Shell: line to bash description

### DIFF
--- a/src/tool/__tests__/shellResolver.test.ts
+++ b/src/tool/__tests__/shellResolver.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for `src/tool/shellResolver.ts`.
+ *
+ * The heavy detection logic (candidate lists, TTL cache, spawn args)
+ * is covered by `tests/tool/tools/shell-detect.test.ts` against the
+ * underlying `detectShell()`. These tests focus on the wrapper's
+ * public API: it must return `{ shell, name }`, honour `$SHELL`,
+ * fall back to `/bin/sh` when nothing is available, and let the
+ * bash tool description include the resolved shell name.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { resolveShell, _resetShellResolverCacheForTests } from '../shellResolver.js';
+import { _setFsProbeForTests } from '../tools/shell/id.js';
+import { buildBashDescription } from '../tools/bash.js';
+
+const ORIGINAL_PLATFORM = process.platform;
+const ORIGINAL_ENV = { ...process.env };
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+function restorePlatform(): void {
+  Object.defineProperty(process, 'platform', {
+    value: ORIGINAL_PLATFORM,
+    configurable: true,
+  });
+}
+
+function setExisting(existing: readonly string[]): void {
+  const set = new Set(existing);
+  _setFsProbeForTests((p) => set.has(p));
+  _resetShellResolverCacheForTests();
+}
+
+function cleanup(): void {
+  _resetShellResolverCacheForTests();
+  _setFsProbeForTests(undefined);
+  restorePlatform();
+  process.env = { ...ORIGINAL_ENV };
+}
+
+describe('resolveShell', () => {
+  beforeEach(() => {
+    setPlatform('linux');
+    _resetShellResolverCacheForTests();
+  });
+
+  afterEach(cleanup);
+
+  it('returns the resolved shell path and short name for zsh', () => {
+    process.env.SHELL = '/bin/zsh';
+    setExisting(['/bin/zsh']);
+
+    const result = resolveShell();
+
+    expect(result.shell).toBe('/bin/zsh');
+    expect(result.name).toBe('zsh');
+  });
+
+  it('returns bash when $SHELL points to bash', () => {
+    process.env.SHELL = '/bin/bash';
+    setExisting(['/bin/bash']);
+
+    const result = resolveShell();
+
+    expect(result.shell).toBe('/bin/bash');
+    expect(result.name).toBe('bash');
+  });
+
+  it('honours $SHELL over the hard-coded candidate ordering', () => {
+    // $SHELL points to bash, but zsh also exists on disk. The
+    // resolver must pick the user-configured shell first rather
+    // than silently upgrading to zsh.
+    process.env.SHELL = '/bin/bash';
+    setExisting(['/bin/bash', '/bin/zsh']);
+
+    const result = resolveShell();
+
+    expect(result.name).toBe('bash');
+    expect(result.shell).toBe('/bin/bash');
+  });
+
+  it('falls back to /bin/sh when $SHELL is unset and no candidates exist', () => {
+    delete process.env.SHELL;
+    setExisting([]);
+
+    const result = resolveShell();
+
+    // With no candidates present and $SHELL unset, the underlying
+    // detector falls through to `/bin/sh` (the POSIX last-resort).
+    expect(result.shell).toBe('/bin/sh');
+    expect(result.name).toBe('sh');
+  });
+
+  it('falls back when $SHELL points to a missing binary', () => {
+    // The user's login shell was uninstalled (e.g. removed fish
+    // package) but $SHELL still names it. The probe must reject the
+    // stale path and land on a real shell instead.
+    process.env.SHELL = '/opt/removed/fish';
+    setExisting(['/bin/bash']);
+
+    const result = resolveShell();
+
+    expect(result.shell).toBe('/bin/bash');
+    expect(result.name).toBe('bash');
+  });
+
+  it('classifies fish correctly when it is the login shell', () => {
+    process.env.SHELL = '/usr/local/bin/fish';
+    setExisting(['/usr/local/bin/fish']);
+
+    const result = resolveShell();
+
+    expect(result.name).toBe('fish');
+    expect(result.shell).toBe('/usr/local/bin/fish');
+  });
+});
+
+describe('bash tool description surfaces resolved shell name', () => {
+  beforeEach(() => {
+    setPlatform('linux');
+    _resetShellResolverCacheForTests();
+  });
+
+  afterEach(cleanup);
+
+  it('includes a `Shell: <name>` line reflecting the detected shell', () => {
+    process.env.SHELL = '/bin/zsh';
+    setExisting(['/bin/zsh']);
+
+    const description = buildBashDescription();
+
+    expect(description).toContain('Shell: zsh');
+  });
+
+  it('reflects a bash environment when zsh is not available', () => {
+    process.env.SHELL = '/bin/bash';
+    setExisting(['/bin/bash']);
+
+    const description = buildBashDescription();
+
+    expect(description).toContain('Shell: bash');
+    expect(description).not.toContain('Shell: zsh');
+  });
+});

--- a/src/tool/shellResolver.ts
+++ b/src/tool/shellResolver.ts
@@ -1,0 +1,60 @@
+/**
+ * Shell Resolver
+ *
+ * Thin, tool-facing helper that returns the shell the bash tool will
+ * actually dispatch to, in the shape `{ shell, name }`. The heavy
+ * filesystem probing lives in `./tools/shell/id.ts` (Cline PR #12331
+ * pattern); this module re-exports a stable API that other tool code
+ * — and the bash tool's description builder in particular — can rely
+ * on without pulling in the deeper `ShellInfo` type.
+ *
+ * The public surface is intentionally minimal:
+ *
+ *   resolveShell(): { shell: string; name: string }
+ *
+ * `shell` is the absolute path of the resolved shell binary (e.g.
+ * `/bin/zsh`); `name` is the short shell identifier the LLM cares
+ * about when picking syntax (`bash`, `zsh`, `fish`, `sh`, `powershell`,
+ * `cmd`, `unknown`).
+ *
+ * Rationale for a wrapper rather than a direct re-export: callers
+ * across `src/tool/` should not have to import from
+ * `./tools/shell/id.js` (which is technically an implementation detail
+ * of the bash/shell tools). Keeping the resolver at
+ * `src/tool/shellResolver.ts` keeps the import graph flat and matches
+ * the shape specified in issue #1181.
+ */
+
+import { detectShell, _resetDetectShellCacheForTests, type ShellType } from './tools/shell/id.js';
+
+export interface ResolvedShell {
+  /** Absolute path of the shell binary (e.g. `/bin/zsh`, `C:\\Windows\\System32\\cmd.exe`). */
+  shell: string;
+  /** Short shell identifier the LLM uses to pick syntax. */
+  name: ShellType;
+}
+
+/**
+ * Detect the shell the bash tool will spawn.
+ *
+ * Reads `process.env.SHELL` on POSIX / `%ComSpec%` on Windows, probes
+ * a small list of well-known candidates via `fs.existsSync`, and falls
+ * back to `/bin/sh` (POSIX) or `cmd.exe` (Windows) when nothing else
+ * matches. Result is cached inside `detectShell()` for a short TTL so
+ * repeated calls per request are cheap.
+ *
+ * This function itself does not cache; call it as often as needed.
+ */
+export function resolveShell(): ResolvedShell {
+  const info = detectShell();
+  return { shell: info.path, name: info.type };
+}
+
+/**
+ * Test hook: clear the underlying detection cache so a subsequent
+ * `resolveShell()` re-probes the filesystem. Do not call from
+ * production code.
+ */
+export function _resetShellResolverCacheForTests(): void {
+  _resetDetectShellCacheForTests();
+}

--- a/src/tool/tools/bash.ts
+++ b/src/tool/tools/bash.ts
@@ -119,7 +119,14 @@ export function buildBashDescription(shell: ShellInfo = detectShell()): string {
   // internally for a short TTL, so calling this on every description
   // render is still cheap.
   const envSummary = formatShellEnvSummary(detectShellEnv(shell));
+  // The explicit `Shell: <name>` line (issue #1181) lets the LLM pick
+  // the right syntax family (bash vs zsh vs fish vs powershell vs cmd)
+  // when composing commands. It duplicates the `Execute a <type>...`
+  // opener on purpose — models that skim the description still see the
+  // shell name in a clearly labelled field.
   return `Execute a ${shell.type} command in a shell.
+
+Shell: ${shell.type}
 
 ${envSummary}
 


### PR DESCRIPTION
## Summary

Implements issue #1181. The bash tool now surfaces the resolved shell in its description as an explicit `Shell: <name>` line so the LLM can pick the right syntax family when composing commands (bash vs zsh vs fish vs powershell vs cmd).

## Changes

- **New** `src/tool/shellResolver.ts`: thin wrapper around the existing `detectShell()` probe (Cline PR #12331 pattern) exposing a minimal `{ shell, name }` API. `resolveShell()` returns the absolute shell path plus its short type, honours `$SHELL`, and falls back to `/bin/sh` when `$SHELL` is unset or points to a missing binary.
- **Updated** `src/tool/tools/bash.ts`: `buildBashDescription()` now emits an explicit `Shell: <type>` line just below the opener. The command-execution path is unchanged — it already spawns the detected shell explicitly.
- **New** `src/tool/__tests__/shellResolver.test.ts`: 8 tests covering zsh/bash/fish resolution, `$SHELL` priority over hardcoded candidates, fallback to `/bin/sh` when nothing exists, fallback when `$SHELL` points to a missing binary, and bash-description assertion.

## Notes

The heavy filesystem probing already existed in `src/tool/tools/shell/id.ts` (`detectShell()`, cached with a 30s TTL). This PR does not duplicate that logic — it adds the exact API shape specified in the issue and wires it into the description string. The AGENTS.md line 13 reference in the issue text does not match the current file (line 13 is unrelated `npm test` documentation); no AGENTS.md changes are required because the tool description is now authoritative.

## Verification

- `npm run typecheck` — passes
- `npm run lint` — passes (0 errors)
- `npm run format:check` — passes
- `npm test` — 244 files / 3355 tests passing (8 new)
- `npm run build` — passes

Closes #1181