### PR TITLE
fix(core): honor per-server MCP timeouts across all client requests (#1190)

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -123,6 +123,35 @@ const DEFAULT_TOOL_CALL_TIMEOUT_MS = 60000; // 60 seconds for per-tool call
 const MAX_PAGES = 100; // Safety cap for paginated tools/list
 
 /**
+ * Which timeout budget was exceeded when an MCP request aborts.
+ *
+ * `startup` covers the stdio handshake / cold-spawn phase (`client.connect`).
+ * `request` covers every metadata or tool call made after the handshake
+ * (`callTool`, `listTools`, `listResources`, `listPrompts`, `readResource`,
+ * `getPrompt`, ...). Naming the bound in error messages lets operators
+ * pick the correct config field to raise.
+ */
+type TimeoutKind = 'startup' | 'request';
+
+/**
+ * Produce a human-readable timeout error message that names the exceeded
+ * bound and points at the exact `mcp-servers.json` field to change.
+ */
+function formatTimeoutError(
+  serverName: string,
+  operation: string,
+  kind: TimeoutKind,
+  timeoutMs: number
+): string {
+  const field = kind === 'startup' ? 'timeout.startup' : 'timeout.request';
+  return (
+    `MCP ${operation} timed out after ${timeoutMs}ms ` +
+    `(${kind} timeout for server '${serverName}'); ` +
+    `increase '${field}' in mcp-servers.json to raise this bound.`
+  );
+}
+
+/**
  * Format a single MCP content part into a string suitable for the model.
  *
  * - `text` parts pass through their text verbatim.
@@ -163,6 +192,41 @@ export class McpClientManager {
   private toolCache: Map<string, ToolCache> = new Map();
 
   /**
+   * Run an MCP request under a per-server `request` timeout budget.
+   *
+   * Creates an `AbortController` bound to `timeoutMs`, hands its signal to
+   * the SDK method through the shared `RequestOptions` shape, and on abort
+   * throws an error whose message names the exceeded bound and the exact
+   * config field to raise. Non-timeout errors are rethrown unchanged so
+   * caller-side categorisation (retry, cache invalidation, etc.) still
+   * works.
+   *
+   * `operation` is a short human label (`'tools/list'`, `'callTool'`, ...)
+   * used only in the error message.
+   */
+  private async withRequestTimeout<T>(
+    serverName: string,
+    operation: string,
+    run: (options: { signal: AbortSignal }) => Promise<T>
+  ): Promise<T> {
+    const { request: timeoutMs } = this.getTimeoutsForServer(serverName);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await run({ signal: controller.signal });
+    } catch (error) {
+      if (controller.signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
+        throw new Error(formatTimeoutError(serverName, operation, 'request', timeoutMs), {
+          cause: error,
+        });
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
    * Fetch all tools from an MCP client, handling paginated responses.
    *
    * Loops manually with explicit `{ cursor }` params so the per-page contract
@@ -171,8 +235,14 @@ export class McpClientManager {
    * which we do not configure). Stops when no `nextCursor` is returned or
    * `MAX_PAGES` is reached; a `nextCursor` that repeats also stops the walk
    * as a defence against a non-converging server.
+   *
+   * Each page is guarded by an independent `request`-timeout budget so a
+   * slow server cannot burn through the caller's overall deadline silently
+   * — the `AbortController` is reset per page and named in the error so
+   * operators know which `mcp-servers.json` field to raise.
    */
   private async listAllTools(
+    serverName: string,
     client: Client
   ): Promise<Array<{ name: string; description?: string; inputSchema: unknown }>> {
     const allTools: Array<{ name: string; description?: string; inputSchema: unknown }> = [];
@@ -181,7 +251,9 @@ export class McpClientManager {
     let previousCursor: string | undefined;
 
     do {
-      const result = await client.listTools({ cursor });
+      const result = await this.withRequestTimeout(serverName, 'tools/list', (opts) =>
+        client.listTools({ cursor }, opts)
+      );
       allTools.push(...(result.tools || []));
       previousCursor = cursor;
       cursor = result.nextCursor;
@@ -275,8 +347,11 @@ export class McpClientManager {
         throw new Error(`Transport ${config.transport} not yet implemented`);
       }
 
-      // Fetch available tools (with pagination support)
-      const rawTools = await this.listAllTools(connection.client);
+      // Fetch available tools (with pagination support). Each page is bound
+      // by the per-server `request` timeout so a slow server can't stall
+      // startup indefinitely — the `startup` budget covered the handshake
+      // above; metadata fetches use the `request` budget going forward.
+      const rawTools = await this.listAllTools(config.name, connection.client);
       connection.tools = rawTools.map((tool) => this.mapToolInfo(tool, config.name));
 
       connection.status = 'connected';
@@ -368,8 +443,29 @@ export class McpClientManager {
       env: cleanEnv,
     });
 
+    // Bind the handshake to the per-server `startup` budget. The SDK also
+    // honours `timeout` internally, but we additionally guard with an
+    // `AbortController` so a slow spawn produces a named, actionable error
+    // that points at `timeout.startup` in `mcp-servers.json` instead of a
+    // generic SDK message.
     const { startup } = this.getTimeoutsForServer(config.name);
-    await connection.client.connect(transport, { timeout: startup });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), startup);
+    try {
+      await connection.client.connect(transport, {
+        timeout: startup,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (controller.signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
+        throw new Error(formatTimeoutError(config.name, 'connect', 'startup', startup), {
+          cause: error,
+        });
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /**
@@ -514,7 +610,7 @@ export class McpClientManager {
     }
 
     try {
-      const rawTools = await this.listAllTools(connection.client);
+      const rawTools = await this.listAllTools(connection.config.name, connection.client);
       connection.tools = rawTools.map((tool) => this.mapToolInfo(tool, connection.config.name));
       connection.toolsCachedAt = Date.now();
 
@@ -583,16 +679,10 @@ export class McpClientManager {
       return { success: false, error: `Server not ready: ${serverName} (${connection.status})` };
     }
 
-    const { request: timeoutMs } = this.getTimeoutsForServer(serverName);
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-
     try {
-      const result = await connection.client.callTool(
-        { name: toolName, arguments: args },
-        { signal: controller.signal }
+      const result = await this.withRequestTimeout(serverName, 'callTool', (opts) =>
+        connection.client.callTool({ name: toolName, arguments: args }, opts)
       );
-      clearTimeout(timer);
 
       // Per the MCP spec, `content` is the canonical narrated output and
       // `structuredContent` is a supplementary machine-readable payload.
@@ -634,10 +724,8 @@ export class McpClientManager {
       }
       return { success: true, result: '' };
     } catch (error) {
-      clearTimeout(timer);
-      if (error instanceof Error && error.name === 'AbortError') {
-        return { success: false, error: `MCP tool call timed out after ${timeoutMs}ms` };
-      }
+      // `withRequestTimeout` translates AbortError into a rich, named
+      // timeout message. Any other error propagates its message verbatim.
       return {
         success: false,
         error: error instanceof Error ? error.message : String(error),

--- a/tests/mcp/client-pagination.test.ts
+++ b/tests/mcp/client-pagination.test.ts
@@ -100,8 +100,12 @@ describe('McpClientManager - Paginated tools/list', () => {
       expect(connection.tools[1].name).toBe('tool-b');
       expect(mockClientListTools).toHaveBeenCalledTimes(1);
       // v2 SDK: pass explicit `{ cursor }` params so the per-page contract is
-      // used instead of the SDK's auto-aggregate walk.
-      expect(mockClientListTools).toHaveBeenCalledWith({ cursor: undefined });
+      // used instead of the SDK's auto-aggregate walk. Second arg carries
+      // the per-page AbortSignal enforcing the `request` timeout budget.
+      expect(mockClientListTools).toHaveBeenCalledWith(
+        { cursor: undefined },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
     });
 
     it('should handle empty tools list', async () => {
@@ -159,10 +163,24 @@ describe('McpClientManager - Paginated tools/list', () => {
       expect(connection.tools[2].name).toBe('tool-3');
       expect(mockClientListTools).toHaveBeenCalledTimes(3);
       // v2 SDK: every call passes an explicit `{ cursor }` params object so
-      // the per-page contract is used (auto-aggregate is bypassed).
-      expect(mockClientListTools).toHaveBeenNthCalledWith(1, { cursor: undefined });
-      expect(mockClientListTools).toHaveBeenNthCalledWith(2, { cursor: 'cursor-page-2' });
-      expect(mockClientListTools).toHaveBeenNthCalledWith(3, { cursor: 'cursor-page-3' });
+      // the per-page contract is used (auto-aggregate is bypassed). Each
+      // call also receives its own `AbortSignal` — the `request` timeout is
+      // enforced per page so a slow server can't stall the whole walk.
+      expect(mockClientListTools).toHaveBeenNthCalledWith(
+        1,
+        { cursor: undefined },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+      expect(mockClientListTools).toHaveBeenNthCalledWith(
+        2,
+        { cursor: 'cursor-page-2' },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+      expect(mockClientListTools).toHaveBeenNthCalledWith(
+        3,
+        { cursor: 'cursor-page-3' },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
     });
 
     it('should aggregate tools across pages in refreshTools()', async () => {

--- a/tests/mcp/client-timeout-lifecycle.test.ts
+++ b/tests/mcp/client-timeout-lifecycle.test.ts
@@ -1,0 +1,328 @@
+/**
+ * MCP timeout lifecycle tests.
+ *
+ * Covers the audit gap tracked in issue #1190: every MCP client method
+ * (metadata fetches AND tool calls) must honour the per-server `request`
+ * timeout, and `client.connect()` must honour the per-server `startup`
+ * timeout. Failure messages must name the exceeded bound and point at the
+ * exact `mcp-servers.json` field to change so operators know how to raise
+ * it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock child_process.spawn
+const mockSpawn = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Mock @modelcontextprotocol/client
+const mockClientConnect = vi.fn();
+const mockClientListTools = vi.fn();
+const mockClientCallTool = vi.fn();
+const mockClientClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@modelcontextprotocol/client', () => {
+  return {
+    Client: class MockClient {
+      connect = mockClientConnect;
+      listTools = mockClientListTools;
+      callTool = mockClientCallTool;
+      close = mockClientClose;
+    },
+  };
+});
+
+vi.mock('@modelcontextprotocol/client/stdio', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+// Mock config loading
+vi.mock('../../src/mcp/config.js', () => ({
+  loadMcpConfig: vi.fn().mockReturnValue({ version: '1.0', servers: [] }),
+  resolveEnvVars: vi.fn((env?: Record<string, string>) => env ?? {}),
+}));
+
+import { McpClientManager } from '../../src/mcp/client.js';
+import type { McpServerConfig } from '../../src/mcp/config.js';
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdin = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.pid = 42;
+  return proc;
+}
+
+/**
+ * Build a hang-until-aborted mock for any SDK method that accepts a
+ * `RequestOptions`-shaped second arg. The returned promise rejects with an
+ * `AbortError` as soon as the signal fires, which is exactly the shape the
+ * SDK produces when a caller-supplied signal aborts.
+ */
+function hangUntilAborted() {
+  return (_params: unknown, options?: { signal?: AbortSignal }) =>
+    new Promise((_resolve, reject) => {
+      if (options?.signal) {
+        options.signal.addEventListener('abort', () => {
+          const error = new Error('The operation was aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      }
+    });
+}
+
+const baseConfig: McpServerConfig = {
+  name: 'lifecycle-server',
+  transport: 'stdio',
+  command: 'node',
+  args: ['server.js'],
+  enabled: true,
+};
+
+describe('MCP timeout lifecycle', () => {
+  let manager: McpClientManager;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    manager = new McpClientManager();
+    mockSpawn.mockReturnValue(createMockProcess());
+    mockClientConnect.mockResolvedValue(undefined);
+    mockClientListTools.mockResolvedValue({ tools: [] });
+    process.env = { ...originalEnv };
+    delete process.env.MCP_TOOL_TIMEOUT;
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await manager.disconnectAll();
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  describe('startup phase', () => {
+    it('aborts client.connect() when the startup budget elapses and names the bound', async () => {
+      // Make the SDK connect hang until its signal aborts.
+      mockClientConnect.mockImplementation(hangUntilAborted());
+
+      const cfg: McpServerConfig = {
+        ...baseConfig,
+        name: 'startup-slow',
+        timeout: { startup: 4000, request: 60000 },
+      };
+
+      const connectPromise = manager.connect(cfg);
+      await vi.advanceTimersByTimeAsync(4000);
+      const connection = await connectPromise;
+
+      expect(connection.status).toBe('error');
+      expect(connection.error).toMatch(/^MCP connect timed out after 4000ms /);
+      expect(connection.error).toContain("(startup timeout for server 'startup-slow')");
+      expect(connection.error).toContain("increase 'timeout.startup' in mcp-servers.json");
+    });
+
+    it('does NOT charge the startup message when only the request phase times out', async () => {
+      // Startup succeeds instantly, but tools/list hangs.
+      mockClientConnect.mockResolvedValue(undefined);
+      mockClientListTools.mockImplementation(hangUntilAborted());
+
+      const cfg: McpServerConfig = {
+        ...baseConfig,
+        name: 'req-slow',
+        timeout: { startup: 30000, request: 1500 },
+      };
+
+      const connectPromise = manager.connect(cfg);
+      await vi.advanceTimersByTimeAsync(1500);
+      const connection = await connectPromise;
+
+      expect(connection.status).toBe('error');
+      // The failing phase is a metadata request, not the handshake, so the
+      // message must call out `request` / `timeout.request` — not `startup`.
+      expect(connection.error).toMatch(/^MCP tools\/list timed out after 1500ms /);
+      expect(connection.error).toContain("(request timeout for server 'req-slow')");
+      expect(connection.error).toContain("increase 'timeout.request' in mcp-servers.json");
+      expect(connection.error).not.toContain('startup timeout');
+    });
+  });
+
+  describe('request phase - listAllTools pagination', () => {
+    it('applies the request timeout to EACH page, not just the first', async () => {
+      // Page 1 resolves fast; page 2 hangs until its signal aborts.
+      let callCount = 0;
+      mockClientListTools.mockImplementation(
+        (_params: unknown, options?: { signal?: AbortSignal }) => {
+          callCount++;
+          if (callCount === 1) {
+            return Promise.resolve({
+              tools: [{ name: 'fast-tool', inputSchema: { type: 'object', properties: {} } }],
+              nextCursor: 'page-2',
+            });
+          }
+          return new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => {
+              const err = new Error('aborted');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          });
+        }
+      );
+
+      const cfg: McpServerConfig = {
+        ...baseConfig,
+        name: 'paginated',
+        timeout: { startup: 30000, request: 2000 },
+      };
+
+      const connectPromise = manager.connect(cfg);
+      // First page returns instantly (microtask); advance for the second
+      // page's timeout budget only.
+      await vi.advanceTimersByTimeAsync(2000);
+      const connection = await connectPromise;
+
+      expect(connection.status).toBe('error');
+      expect(callCount).toBe(2);
+      expect(connection.error).toMatch(/^MCP tools\/list timed out after 2000ms /);
+      expect(connection.error).toContain("(request timeout for server 'paginated')");
+    });
+
+    it('produces the same rich error shape when refreshTools() page times out', async () => {
+      // First, connect successfully with a single-page list.
+      mockClientListTools.mockResolvedValueOnce({
+        tools: [{ name: 'seed', inputSchema: { type: 'object', properties: {} } }],
+      });
+
+      const cfg: McpServerConfig = {
+        ...baseConfig,
+        name: 'refresh-slow',
+        timeout: { startup: 30000, request: 1000 },
+      };
+
+      const connectPromise = manager.connect(cfg);
+      await vi.advanceTimersByTimeAsync(0);
+      const connection = await connectPromise;
+      expect(connection.status).toBe('connected');
+
+      // Now refresh, and make listTools hang.
+      mockClientListTools.mockImplementation(hangUntilAborted());
+
+      // refreshTools swallows errors into logger.error; we detect the
+      // timeout by inspecting the logger call.
+      const { logger } = await import('../../src/utils/logger.js');
+      const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+      const refreshPromise = manager.refreshTools('refresh-slow');
+      await vi.advanceTimersByTimeAsync(1000);
+      await refreshPromise;
+
+      // logger.error(`Failed to refresh tools from ${name}:`, error)
+      // The Error object is the second argument.
+      const call = errorSpy.mock.calls.find(([msg]) =>
+        String(msg).includes('Failed to refresh tools from refresh-slow')
+      );
+      expect(call).toBeDefined();
+      const err = call![1] as Error;
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toMatch(/^MCP tools\/list timed out after 1000ms /);
+      expect(err.message).toContain("(request timeout for server 'refresh-slow')");
+      expect(err.message).toContain("increase 'timeout.request' in mcp-servers.json");
+    });
+  });
+
+  describe('request phase - callTool', () => {
+    it('names the bound in callTool timeout errors', async () => {
+      mockClientListTools.mockResolvedValueOnce({ tools: [] });
+
+      const cfg: McpServerConfig = {
+        ...baseConfig,
+        name: 'call-slow',
+        timeout: { startup: 30000, request: 3000 },
+      };
+      await manager.connect(cfg);
+
+      mockClientCallTool.mockImplementation(hangUntilAborted());
+
+      const resultPromise = manager.callTool('call-slow', 'some-tool', {});
+      await vi.advanceTimersByTimeAsync(3000);
+      const result = await resultPromise;
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/^MCP callTool timed out after 3000ms /);
+      expect(result.error).toContain("(request timeout for server 'call-slow')");
+      expect(result.error).toContain("increase 'timeout.request' in mcp-servers.json");
+    });
+
+    it('preserves non-timeout errors verbatim (no false-positive timeout wrap)', async () => {
+      mockClientListTools.mockResolvedValueOnce({ tools: [] });
+
+      const cfg: McpServerConfig = {
+        ...baseConfig,
+        name: 'bad-server',
+        timeout: { startup: 30000, request: 5000 },
+      };
+      await manager.connect(cfg);
+
+      mockClientCallTool.mockRejectedValueOnce(new Error('server exploded'));
+
+      const result = await manager.callTool('bad-server', 'boom', {});
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('server exploded');
+    });
+  });
+
+  describe('AbortSignal wiring', () => {
+    it('passes an AbortSignal to every listTools page call', async () => {
+      mockClientListTools.mockResolvedValueOnce({
+        tools: [{ name: 't1', inputSchema: { type: 'object', properties: {} } }],
+        nextCursor: 'c2',
+      });
+      mockClientListTools.mockResolvedValueOnce({
+        tools: [{ name: 't2', inputSchema: { type: 'object', properties: {} } }],
+      });
+
+      const cfg: McpServerConfig = { ...baseConfig, name: 'signal-wired' };
+      const connection = await manager.connect(cfg);
+      expect(connection.status).toBe('connected');
+
+      expect(mockClientListTools).toHaveBeenCalledTimes(2);
+      for (const call of mockClientListTools.mock.calls) {
+        // Second arg is a RequestOptions-shaped object with a signal.
+        expect(call[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
+      }
+    });
+
+    it('passes an AbortSignal to callTool', async () => {
+      mockClientListTools.mockResolvedValueOnce({ tools: [] });
+      const cfg: McpServerConfig = { ...baseConfig, name: 'call-signal' };
+      await manager.connect(cfg);
+
+      mockClientCallTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'ok' }],
+        isError: false,
+      });
+
+      const result = await manager.callTool('call-signal', 'noop', {});
+      expect(result.success).toBe(true);
+
+      expect(mockClientCallTool).toHaveBeenCalledWith(
+        { name: 'noop', arguments: {} },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+  });
+});

--- a/tests/mcp/client-timeout.test.ts
+++ b/tests/mcp/client-timeout.test.ts
@@ -110,7 +110,9 @@ describe('MCP Tool Call Timeout', () => {
 
       const result = await resultPromise;
       expect(result.success).toBe(false);
-      expect(result.error).toBe('MCP tool call timed out after 60000ms');
+      expect(result.error).toMatch(/^MCP callTool timed out after 60000ms /);
+      expect(result.error).toContain("(request timeout for server 'test-server')");
+      expect(result.error).toContain("increase 'timeout.request' in mcp-servers.json");
     });
 
     it('should use per-server config timeout', async () => {
@@ -143,7 +145,8 @@ describe('MCP Tool Call Timeout', () => {
 
       const result = await resultPromise;
       expect(result.success).toBe(false);
-      expect(result.error).toBe('MCP tool call timed out after 5000ms');
+      expect(result.error).toMatch(/^MCP callTool timed out after 5000ms /);
+      expect(result.error).toContain("(request timeout for server 'timeout-server')");
     });
 
     it('should use MCP_TOOL_TIMEOUT env var when no per-server config', async () => {
@@ -172,7 +175,7 @@ describe('MCP Tool Call Timeout', () => {
 
       const result = await resultPromise;
       expect(result.success).toBe(false);
-      expect(result.error).toBe('MCP tool call timed out after 10000ms');
+      expect(result.error).toMatch(/^MCP callTool timed out after 10000ms /);
     });
 
     it('should prefer per-server config over MCP_TOOL_TIMEOUT env var', async () => {
@@ -207,7 +210,8 @@ describe('MCP Tool Call Timeout', () => {
 
       const result = await resultPromise;
       expect(result.success).toBe(false);
-      expect(result.error).toBe('MCP tool call timed out after 3000ms');
+      expect(result.error).toMatch(/^MCP callTool timed out after 3000ms /);
+      expect(result.error).toContain("(request timeout for server 'priority-server')");
     });
 
     it('should succeed when call completes within timeout', async () => {
@@ -251,7 +255,9 @@ describe('MCP Tool Call Timeout', () => {
 
       const result = await resultPromise;
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/^MCP tool call timed out after \d+ms$/);
+      expect(result.error).toMatch(/^MCP callTool timed out after 15000ms /);
+      expect(result.error).toContain("(request timeout for server 'format-server')");
+      expect(result.error).toContain("increase 'timeout.request' in mcp-servers.json");
     });
   });
 

--- a/tests/mcp/timeout.test.ts
+++ b/tests/mcp/timeout.test.ts
@@ -123,7 +123,8 @@ describe('MCP split startup / request timeouts', () => {
 
     const result = await runTimingCall(manager, 'legacy', 5000);
     expect(result.success).toBe(false);
-    expect(result.error).toBe('MCP tool call timed out after 5000ms');
+    expect(result.error).toMatch(/^MCP callTool timed out after 5000ms /);
+    expect(result.error).toContain("(request timeout for server 'legacy')");
   });
 
   it('object form: both startup and request set independently', async () => {
@@ -142,7 +143,7 @@ describe('MCP split startup / request timeouts', () => {
 
     const result = await runTimingCall(manager, 'both', 2000);
     expect(result.success).toBe(false);
-    expect(result.error).toBe('MCP tool call timed out after 2000ms');
+    expect(result.error).toMatch(/^MCP callTool timed out after 2000ms /);
   });
 
   it('object form: partial (startup only) uses default request', async () => {
@@ -162,7 +163,7 @@ describe('MCP split startup / request timeouts', () => {
     // Default request timeout is 60000ms
     const result = await runTimingCall(manager, 'startup-only', 60000);
     expect(result.success).toBe(false);
-    expect(result.error).toBe('MCP tool call timed out after 60000ms');
+    expect(result.error).toMatch(/^MCP callTool timed out after 60000ms /);
   });
 
   it('object form: partial (request only) uses default startup', async () => {
@@ -182,7 +183,7 @@ describe('MCP split startup / request timeouts', () => {
 
     const result = await runTimingCall(manager, 'request-only', 2000);
     expect(result.success).toBe(false);
-    expect(result.error).toBe('MCP tool call timed out after 2000ms');
+    expect(result.error).toMatch(/^MCP callTool timed out after 2000ms /);
   });
 
   it('no timeout config: both phases use their respective defaults', async () => {
@@ -199,7 +200,7 @@ describe('MCP split startup / request timeouts', () => {
     // Default request: 60000ms
     const result = await runTimingCall(manager, 'defaults', 60000);
     expect(result.success).toBe(false);
-    expect(result.error).toBe('MCP tool call timed out after 60000ms');
+    expect(result.error).toMatch(/^MCP callTool timed out after 60000ms /);
   });
 
   it('MCP_TOOL_TIMEOUT env var applies to BOTH phases (backwards-compat)', async () => {
@@ -215,6 +216,6 @@ describe('MCP split startup / request timeouts', () => {
 
     const result = await runTimingCall(manager, 'env-both', 7000);
     expect(result.success).toBe(false);
-    expect(result.error).toBe('MCP tool call timed out after 7000ms');
+    expect(result.error).toMatch(/^MCP callTool timed out after 7000ms /);
   });
 });


### PR DESCRIPTION
Closes #1190

## Summary

Every MCP client method must honour the configured per-server timeout so a slow server can't stall despite explicit config. This PR audits `McpClientManager`, closes the timeout gap in `listAllTools()` pagination, and rewrites timeout errors to be self-diagnostic.

## Audit findings before this PR

| Method                | Timeout applied? | Which bound |
| --------------------- | ---------------- | ----------- |
| `client.connect()`    | Yes (SDK arg)    | `startup` |
| `client.callTool()`   | Yes (AbortController) | `request` |
| `listAllTools()` page | **No**           | *none*      |
| Future `readResource`/`listPrompts`/`listResources`/`getPrompt` | N/A | *would repeat mistake* |

## Changes

- **New helper `withRequestTimeout(serverName, operation, run)`** — binds any SDK request to an `AbortController` driven by the resolved `request` budget from `getTimeoutsForServer`. Any future metadata/resource/prompt method just wraps its SDK call with this helper.
- **`listAllTools()` uses the helper per-page** — the request budget resets between pages so a slow server can't burn through the full walk silently. Applies to both initial `connect()` and `refreshTools()`.
- **`callTool()` routed through the helper** — same error shape and `AbortController` lifecycle as the metadata path.
- **`client.connect()` guarded by an explicit `AbortController`** — a slow spawn now produces our named error (points at `timeout.startup`) instead of the SDK's generic message.
- **Rich timeout error messages** naming the exceeded bound and pointing at the config field to change:
  > `MCP tools/list timed out after 2000ms (request timeout for server 'foo'); increase 'timeout.request' in mcp-servers.json to raise this bound.`
  The original `AbortError` is attached as `.cause` for downstream inspection.

## Tests

- **New**: `tests/mcp/client-timeout-lifecycle.test.ts`
  - startup timeout on `connect()` (rich message)
  - request timeout on `tools/list` during `connect()` does **not** call itself a startup error
  - per-page timeout inside `listAllTools()` pagination (page 1 fast, page 2 hangs → error names request bound)
  - `refreshTools()` failure carries the same rich error (asserted via logger.error spy)
  - non-timeout `callTool` errors pass through verbatim (no false-positive timeout wrap)
  - AbortSignal wiring verified for both `listTools` (all pages) and `callTool`
- **Updated** existing timeout tests (`client-timeout.test.ts`, `timeout.test.ts`) to assert against the new richer error message.
- **Updated** `client-pagination.test.ts` to assert each `listTools` page call receives a second-arg `{ signal: AbortSignal }`.

## Quality gates (local)

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm test` — 3363 passed, 62 skipped, all 11 MCP suites green
- `npm run build` — clean
- Line coverage: 65.7% overall; `src/mcp/client.ts` is at 72.4% lines (up from prior).

## Compatibility

- Existing `mcp-servers.json` files are untouched — timeout config resolution order (`number` → `{ startup, request }` → `MCP_TOOL_TIMEOUT` env → defaults) is unchanged.
- Backwards-compat: legacy `timeout: <number>` still applies to both phases.

[alexi-bot]