### PR TITLE
feat(config): honor per-server and global MCP timeout precedence

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -416,6 +416,29 @@ export function formatContentPart(part: unknown): string {
 export class McpClientManager {
   private connections: Map<string, McpConnection> = new Map();
   private toolCache: Map<string, ToolCache> = new Map();
+  /**
+   * Cached global timeout from {@link McpConfig.timeout}, used as the
+   * fallback layer between per-server config and the `MCP_TOOL_TIMEOUT`
+   * environment variable. Populated on first `connectFromConfig` and can
+   * be overridden explicitly via {@link setGlobalTimeout} (for tests and
+   * callers that connect servers without going through the config file).
+   *
+   * `undefined` means "unset" (fall through to env / defaults);
+   * `null` means "explicitly no global override" (same effect, distinct
+   * marker so we can tell "never resolved" from "resolved to nothing").
+   */
+  private globalTimeout: number | { startup?: number; request?: number } | undefined | null =
+    undefined;
+
+  /**
+   * Explicitly set the global timeout override that will be used as the
+   * second-precedence layer (after per-server config, before
+   * `MCP_TOOL_TIMEOUT` env / built-in defaults). Passing `undefined`
+   * clears the override.
+   */
+  setGlobalTimeout(timeout: number | { startup?: number; request?: number } | undefined): void {
+    this.globalTimeout = timeout === undefined ? null : timeout;
+  }
 
   /**
    * Run an MCP request under a per-server `request` timeout budget.
@@ -892,6 +915,11 @@ export class McpClientManager {
   async connectFromConfig(options?: McpConnectOptions): Promise<void> {
     const config = loadMcpConfig();
 
+    // Cache the config-file-level global timeout so `getTimeoutsForServer`
+    // can use it as the fallback layer (per-server > global > env > default).
+    // A missing field clears any previously-set global override.
+    this.setGlobalTimeout(config.timeout);
+
     // Add graceful handling for server initialization failures
     const servers = config.servers.filter((s) => s.enabled && s.autoConnect);
     const results = await Promise.allSettled(
@@ -1012,40 +1040,67 @@ export class McpClientManager {
   }
 
   /**
+   * Normalize a raw `timeout` config value into a `{startup, request}`
+   * pair. Returns `undefined` if the value is absent so the caller can
+   * fall through to the next precedence layer. Zero and negative numbers
+   * are treated as unset (they would disable the timeout, which is never
+   * what an operator wants).
+   */
+  private normalizeTimeout(
+    raw: number | { startup?: number; request?: number } | undefined | null
+  ): { startup?: number; request?: number } | undefined {
+    if (typeof raw === 'number') {
+      if (!isFinite(raw) || raw <= 0) {
+        return undefined;
+      }
+      return { startup: raw, request: raw };
+    }
+    if (raw !== undefined && raw !== null && typeof raw === 'object') {
+      return { startup: raw.startup, request: raw.request };
+    }
+    return undefined;
+  }
+
+  /**
    * Get the startup and per-request timeouts for a specific server.
    *
-   * Resolution order:
-   * 1. If `connection.config.timeout` is a number, use it for BOTH phases
-   *    (legacy behaviour, preserves backwards-compat).
-   * 2. If it is an object, use `startup ?? DEFAULT_STARTUP_TIMEOUT_MS`
-   *    and `request ?? DEFAULT_TOOL_CALL_TIMEOUT_MS`.
-   * 3. Otherwise fall back to `MCP_TOOL_TIMEOUT` env (applied to BOTH
-   *    phases for backwards-compat) or the two defaults.
+   * Resolution order (per-phase, checked independently so a partial
+   * override at any layer falls through for the missing phase):
+   * 1. Per-server `McpServerConfig.timeout` (bare number applies to both
+   *    phases; object form contributes only the fields it sets).
+   * 2. Global `McpConfig.timeout` (this manager instance's cached global
+   *    timeout, set via {@link setGlobalTimeout} or auto-populated by
+   *    {@link connectFromConfig}).
+   * 3. `MCP_TOOL_TIMEOUT` environment variable (applied to both phases
+   *    for backwards-compat).
+   * 4. Built-in defaults (30000ms startup, 60000ms request).
    */
   private getTimeoutsForServer(serverName: string): { startup: number; request: number } {
     const connection = this.connections.get(serverName);
-    const configured = connection?.config.timeout;
+    const serverLayer = this.normalizeTimeout(connection?.config.timeout);
+    const globalLayer = this.normalizeTimeout(this.globalTimeout);
 
-    if (typeof configured === 'number') {
-      return { startup: configured, request: configured };
-    }
-
-    if (configured !== undefined && configured !== null && typeof configured === 'object') {
-      return {
-        startup: configured.startup ?? DEFAULT_STARTUP_TIMEOUT_MS,
-        request: configured.request ?? DEFAULT_TOOL_CALL_TIMEOUT_MS,
-      };
-    }
-
+    let envLayer: { startup?: number; request?: number } | undefined;
     const envTimeout = process.env.MCP_TOOL_TIMEOUT;
     if (envTimeout !== undefined) {
       const parsed = Number(envTimeout);
       if (!isNaN(parsed) && parsed > 0) {
-        return { startup: parsed, request: parsed };
+        envLayer = { startup: parsed, request: parsed };
       }
     }
 
-    return { startup: DEFAULT_STARTUP_TIMEOUT_MS, request: DEFAULT_TOOL_CALL_TIMEOUT_MS };
+    const startup =
+      serverLayer?.startup ??
+      globalLayer?.startup ??
+      envLayer?.startup ??
+      DEFAULT_STARTUP_TIMEOUT_MS;
+    const request =
+      serverLayer?.request ??
+      globalLayer?.request ??
+      envLayer?.request ??
+      DEFAULT_TOOL_CALL_TIMEOUT_MS;
+
+    return { startup, request };
   }
 
   /**

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -43,6 +43,11 @@ export interface McpServerConfig {
    * Defaults when unspecified:
    * - `startup`: 30000 ms (cold `npx -y` installs routinely take 5-15s)
    * - `request`: 60000 ms (per-tool call deadline)
+   *
+   * When this field is absent, the client falls back to the config-file
+   * global {@link McpConfig.timeout}, then to the `MCP_TOOL_TIMEOUT` env
+   * variable, and finally to the defaults above. See
+   * `McpClientManager.getTimeoutsForServer` for the full precedence chain.
    */
   timeout?: number | { startup?: number; request?: number };
   /**
@@ -84,6 +89,23 @@ export interface McpConfig {
   version: string;
   /** List of MCP servers */
   servers: McpServerConfig[];
+  /**
+   * Global default timeout budget(s) in milliseconds applied to every
+   * server that does NOT declare its own {@link McpServerConfig.timeout}.
+   *
+   * Accepts the same shapes as the per-server field:
+   * - A single number applied to BOTH startup and request phases.
+   * - An object `{ startup?: number; request?: number }` for independent
+   *   budgets; missing keys fall back to the built-in defaults
+   *   (30000ms startup, 60000ms request).
+   *
+   * Resolution order at call time (per server):
+   * 1. Per-server `McpServerConfig.timeout` (if set)
+   * 2. Global `McpConfig.timeout` (this field)
+   * 3. `MCP_TOOL_TIMEOUT` environment variable (applied to both phases)
+   * 4. Built-in defaults (30000ms startup, 60000ms request)
+   */
+  timeout?: number | { startup?: number; request?: number };
 }
 
 const CONFIG_DIR = path.join(os.homedir(), '.alexi');
@@ -95,6 +117,13 @@ const CONFIG_FILE = path.join(CONFIG_DIR, 'mcp-servers.json');
 function getDefaultConfig(): McpConfig {
   return {
     version: '1.0',
+    // Optional config-file global timeout. Applied to every server that
+    // does NOT declare its own `timeout` field. Accepts a bare number
+    // (both phases) or `{ startup?, request? }`. Omitted from the default
+    // config so built-in defaults (30s startup, 60s request) apply until
+    // an operator explicitly opts in.
+    // Example:
+    //   "timeout": { "startup": 45000, "request": 90000 }
     servers: [
       // Example: filesystem MCP server
       {
@@ -118,8 +147,12 @@ function getDefaultConfig(): McpConfig {
         },
         enabled: false,
         autoConnect: false,
+        // Per-server timeout overrides the global default. Bare number
+        // applies to both startup and request phases.
+        // timeout: 45000,
       },
-      // Example: Brave Search MCP server
+      // Example: Brave Search MCP server with an explicit per-server
+      // timeout that a slow-starting server may need.
       {
         name: 'brave-search',
         description: 'Web search via Brave Search API',
@@ -131,6 +164,9 @@ function getDefaultConfig(): McpConfig {
         },
         enabled: false,
         autoConnect: false,
+        // Object form lets startup and per-tool call have independent
+        // budgets. Omitted keys fall back through the precedence chain.
+        // timeout: { startup: 60000, request: 30000 },
       },
     ],
   };

--- a/tests/mcp-config.test.ts
+++ b/tests/mcp-config.test.ts
@@ -129,5 +129,79 @@ describe('MCP Config', () => {
       expect(config.servers).toHaveLength(1);
       expect(config.servers[0].name).toBe('test');
     });
+
+    it('should accept optional global timeout as a bare number', () => {
+      const config: McpConfig = {
+        version: '1.0',
+        timeout: 45000,
+        servers: [],
+      };
+      expect(config.timeout).toBe(45000);
+    });
+
+    it('should accept optional global timeout as an object', () => {
+      const config: McpConfig = {
+        version: '1.0',
+        timeout: { startup: 60000, request: 30000 },
+        servers: [],
+      };
+      expect(typeof config.timeout).toBe('object');
+      expect((config.timeout as { startup: number }).startup).toBe(60000);
+      expect((config.timeout as { request: number }).request).toBe(30000);
+    });
+
+    it('should accept per-server timeout as a bare number', () => {
+      const server: McpServerConfig = {
+        name: 'slow-server',
+        transport: 'stdio',
+        command: 'sleep',
+        enabled: true,
+        timeout: 90000,
+      };
+      expect(server.timeout).toBe(90000);
+    });
+
+    it('should accept per-server timeout as split startup / request object', () => {
+      const server: McpServerConfig = {
+        name: 'split-server',
+        transport: 'stdio',
+        command: 'sleep',
+        enabled: true,
+        timeout: { startup: 60000, request: 30000 },
+      };
+      expect(typeof server.timeout).toBe('object');
+      expect((server.timeout as { startup: number }).startup).toBe(60000);
+    });
+
+    it('preserves per-server timeout field after JSON round-trip', () => {
+      // The config file is JSON on disk — verify that both shapes of
+      // the per-server `timeout` field survive stringify/parse without
+      // schema stripping.
+      const original: McpConfig = {
+        version: '1.0',
+        timeout: { startup: 15000 },
+        servers: [
+          {
+            name: 'a',
+            transport: 'stdio',
+            command: 'a',
+            enabled: true,
+            timeout: 12345,
+          },
+          {
+            name: 'b',
+            transport: 'stdio',
+            command: 'b',
+            enabled: true,
+            timeout: { startup: 5000, request: 25000 },
+          },
+        ],
+      };
+
+      const roundTripped = JSON.parse(JSON.stringify(original)) as McpConfig;
+      expect(roundTripped.timeout).toEqual({ startup: 15000 });
+      expect(roundTripped.servers[0].timeout).toBe(12345);
+      expect(roundTripped.servers[1].timeout).toEqual({ startup: 5000, request: 25000 });
+    });
   });
 });

--- a/tests/mcp/client-global-timeout.test.ts
+++ b/tests/mcp/client-global-timeout.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock child_process.spawn
+const mockSpawn = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Mock @modelcontextprotocol/client
+const mockClientConnect = vi.fn().mockResolvedValue(undefined);
+const mockClientListTools = vi.fn().mockResolvedValue({ tools: [] });
+const mockClientCallTool = vi.fn();
+const mockClientClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@modelcontextprotocol/client', () => {
+  return {
+    Client: class MockClient {
+      connect = mockClientConnect;
+      listTools = mockClientListTools;
+      callTool = mockClientCallTool;
+      close = mockClientClose;
+    },
+  };
+});
+
+vi.mock('@modelcontextprotocol/client/stdio', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+// `loadMcpConfig` is what `connectFromConfig` reads for the global
+// timeout. Individual tests override the mock return value before
+// calling `connectFromConfig`.
+const mockLoadMcpConfig = vi.fn();
+vi.mock('../../src/mcp/config.js', () => ({
+  loadMcpConfig: (...args: unknown[]) => mockLoadMcpConfig(...args),
+  resolveEnvVars: vi.fn((env?: Record<string, string>) => env ?? {}),
+}));
+
+import { McpClientManager } from '../../src/mcp/client.js';
+import type { McpServerConfig } from '../../src/mcp/config.js';
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdin = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.pid = 12345;
+  return proc;
+}
+
+async function runTimingCall(
+  manager: McpClientManager,
+  serverName: string,
+  advanceMs: number
+): Promise<{ success: boolean; result?: unknown; error?: string }> {
+  mockClientCallTool.mockImplementation((_params: unknown, options?: { signal?: AbortSignal }) => {
+    return new Promise((_resolve, reject) => {
+      if (options?.signal) {
+        options.signal.addEventListener('abort', () => {
+          const error = new Error('The operation was aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      }
+    });
+  });
+
+  const promise = manager.callTool(serverName, 'some-tool', {});
+  await vi.advanceTimersByTimeAsync(advanceMs);
+  return promise;
+}
+
+describe('MCP global config timeout precedence', () => {
+  let manager: McpClientManager;
+  const originalEnv = process.env;
+
+  const baseServer: McpServerConfig = {
+    name: 'srv',
+    transport: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+    enabled: true,
+    autoConnect: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    manager = new McpClientManager();
+    mockSpawn.mockReturnValue(createMockProcess());
+    process.env = { ...originalEnv };
+    delete process.env.MCP_TOOL_TIMEOUT;
+    mockLoadMcpConfig.mockReturnValue({ version: '1.0', servers: [] });
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await manager.disconnectAll();
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  it('applies global config timeout when per-server timeout is absent', async () => {
+    // connectFromConfig reads loadMcpConfig(); return a global bare
+    // number that both phases should adopt.
+    mockLoadMcpConfig.mockReturnValue({
+      version: '1.0',
+      timeout: 4000,
+      servers: [{ ...baseServer, name: 'srv-global-num' }],
+    });
+
+    await manager.connectFromConfig();
+
+    // Startup: manager forwards the resolved startup budget to
+    // `client.connect({ timeout })`.
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 4000 })
+    );
+
+    // Request: callTool trips at the global request timeout.
+    const result = await runTimingCall(manager, 'srv-global-num', 4000);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^MCP callTool timed out after 4000ms /);
+    expect(result.error).toContain("(request timeout for server 'srv-global-num')");
+  });
+
+  it('applies global object-form timeout with independent startup / request', async () => {
+    mockLoadMcpConfig.mockReturnValue({
+      version: '1.0',
+      timeout: { startup: 8000, request: 2500 },
+      servers: [{ ...baseServer, name: 'srv-global-obj' }],
+    });
+
+    await manager.connectFromConfig();
+
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 8000 })
+    );
+
+    const result = await runTimingCall(manager, 'srv-global-obj', 2500);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^MCP callTool timed out after 2500ms /);
+  });
+
+  it('per-server timeout overrides global timeout', async () => {
+    mockLoadMcpConfig.mockReturnValue({
+      version: '1.0',
+      timeout: 20000,
+      servers: [{ ...baseServer, name: 'srv-override', timeout: 1500 }],
+    });
+
+    await manager.connectFromConfig();
+
+    // Per-server bare number wins for the startup handshake.
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 1500 })
+    );
+
+    const result = await runTimingCall(manager, 'srv-override', 1500);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^MCP callTool timed out after 1500ms /);
+  });
+
+  it('per-server object partially overrides global (fills missing phase from global)', async () => {
+    // Server sets only `request`; global provides `startup`. Result
+    // should be startup=global.startup, request=server.request.
+    mockLoadMcpConfig.mockReturnValue({
+      version: '1.0',
+      timeout: { startup: 12000, request: 40000 },
+      servers: [
+        {
+          ...baseServer,
+          name: 'srv-partial',
+          timeout: { request: 1200 },
+        },
+      ],
+    });
+
+    await manager.connectFromConfig();
+
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 12000 })
+    );
+
+    const result = await runTimingCall(manager, 'srv-partial', 1200);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^MCP callTool timed out after 1200ms /);
+  });
+
+  it('global timeout beats MCP_TOOL_TIMEOUT env var', async () => {
+    process.env.MCP_TOOL_TIMEOUT = '25000';
+    mockLoadMcpConfig.mockReturnValue({
+      version: '1.0',
+      timeout: 3500,
+      servers: [{ ...baseServer, name: 'srv-vs-env' }],
+    });
+
+    await manager.connectFromConfig();
+
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 3500 })
+    );
+
+    const result = await runTimingCall(manager, 'srv-vs-env', 3500);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^MCP callTool timed out after 3500ms /);
+  });
+
+  it('falls back to env / defaults when global timeout is absent', async () => {
+    process.env.MCP_TOOL_TIMEOUT = '9000';
+    mockLoadMcpConfig.mockReturnValue({
+      version: '1.0',
+      servers: [{ ...baseServer, name: 'srv-no-global' }],
+    });
+
+    await manager.connectFromConfig();
+
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 9000 })
+    );
+
+    const result = await runTimingCall(manager, 'srv-no-global', 9000);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^MCP callTool timed out after 9000ms /);
+  });
+
+  it('setGlobalTimeout works for callers connecting servers directly', async () => {
+    // Simulates a caller that bypasses connectFromConfig but still
+    // wants the global override to apply.
+    manager.setGlobalTimeout({ startup: 6000, request: 1800 });
+    await manager.connect({ ...baseServer, name: 'srv-direct' });
+
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 6000 })
+    );
+
+    const result = await runTimingCall(manager, 'srv-direct', 1800);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^MCP callTool timed out after 1800ms /);
+  });
+
+  it('setGlobalTimeout(undefined) clears the override so env / defaults apply', async () => {
+    manager.setGlobalTimeout({ startup: 6000, request: 1800 });
+    manager.setGlobalTimeout(undefined);
+
+    await manager.connect({ ...baseServer, name: 'srv-cleared' });
+
+    // Falls through to DEFAULT_STARTUP_TIMEOUT_MS (30000).
+    expect(mockClientConnect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 30000 })
+    );
+
+    // Falls through to DEFAULT_TOOL_CALL_TIMEOUT_MS (60000).
+    const result = await runTimingCall(manager, 'srv-cleared', 60000);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/^MCP callTool timed out after 60000ms /);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1218.

Adds an optional top-level `timeout` field to `McpConfig` and threads
it through `McpClientManager` as a second-precedence layer between the
existing per-server `timeout` and the `MCP_TOOL_TIMEOUT` environment
variable. Per-server timeouts now win with a proper fall-through when
they omit a phase.

## Resolution order

Per-phase, checked independently so a partial override at any layer
falls through for the missing phase:

1. Per-server `McpServerConfig.timeout` (bare number or object)
2. Global `McpConfig.timeout` (new)
3. `MCP_TOOL_TIMEOUT` env var (backwards-compat, applied to both phases)
4. Built-in defaults (30s startup, 60s request)

## Changes

- `src/mcp/config.ts`: add `McpConfig.timeout`, document precedence on
  the per-server field, and add commented-out examples of both fields in
  the default config so operators can discover them.
- `src/mcp/client.ts`:
  - Cache the global timeout on the manager (`setGlobalTimeout()`).
  - Auto-populate it in `connectFromConfig` from the loaded config.
  - Rewrite `getTimeoutsForServer` to fall through per-phase across the
    four layers using a shared `normalizeTimeout` helper.
- `tests/mcp-config.test.ts`: verify that both shapes of the per-server
  `timeout` field (and the new global one) survive JSON round-trip and
  type-check as expected.
- `tests/mcp/client-global-timeout.test.ts` (new): exercises the full
  precedence chain end-to-end (global bare number, global object form,
  per-server override, partial object fallthrough, env-var loses to
  global, absent global falls through to env/defaults, `setGlobalTimeout`
  direct API and clear-with-`undefined`).

## Verification

```
npm run typecheck        # clean
npm run lint             # 0 errors
npm run format:check     # clean
npm test                 # 3410 passed, 62 skipped
npm run build            # clean
```

Backwards compatibility: existing per-server tests
(`tests/mcp/timeout.test.ts`, `tests/mcp/client-timeout.test.ts`) and the
`MCP_TOOL_TIMEOUT` env var path continue to work unchanged.

[alexi-bot]