### PR TITLE
feat(cli): debounce InputBox mount to prevent duplicate submits

### DIFF
--- a/src/cli/tui/components/InputBox.tsx
+++ b/src/cli/tui/components/InputBox.tsx
@@ -25,6 +25,21 @@ export type { InputBoxProps };
  */
 const MAX_SUGGESTIONS = 6;
 
+/**
+ * Mount-time debounce window (ms).
+ *
+ * When the InputBox mounts, submissions that fire within this window are
+ * suppressed. This guards against duplicate submissions that can occur when
+ * the component unmounts and remounts rapidly — for example when a dialog
+ * opens, closes, then reopens during a state transition. Without this guard,
+ * a stale keypress event delivered to the freshly mounted TextInput can
+ * re-fire `onSubmit` with the previous value.
+ *
+ * 500ms is short enough to be imperceptible to a human typing and long enough
+ * to absorb the typical React commit + Ink render cycle on modern terminals.
+ */
+export const MOUNT_DEBOUNCE_MS = 500;
+
 export function InputBox({
   agent,
   agentColor,
@@ -45,6 +60,11 @@ export function InputBox({
   const savedInputRef = useRef('');
   // Autocomplete selection index (-1 = none selected)
   const [selectedSuggestion, setSelectedSuggestion] = useState(-1);
+
+  // Mount-time debounce: track when this instance mounted so we can suppress
+  // submissions that fire within MOUNT_DEBOUNCE_MS of mount (e.g. stray keys
+  // delivered to a freshly remounted TextInput after a dialog transition).
+  const mountTimeRef = useRef<number>(Date.now());
 
   // Clipboard image paste (Ctrl+V interception)
   useClipboardImage({ enabled: isFocused && !disabled });
@@ -217,6 +237,18 @@ export function InputBox({
 
       const trimmed = text.trim();
       if (!trimmed || disabled) {
+        return;
+      }
+      // Mount-time debounce: swallow submits that arrive within
+      // MOUNT_DEBOUNCE_MS of mount. These are almost always duplicate
+      // events surviving a rapid unmount/remount cycle (dialog transitions,
+      // tab switches, focus flips) rather than legitimate user input, since
+      // a real user cannot both mount the component and hit Enter with
+      // non-empty content in less than half a second.
+      if (Date.now() - mountTimeRef.current < MOUNT_DEBOUNCE_MS) {
+        // Clear the stray value so the next real submit starts clean.
+        setValue('');
+        setSelectedSuggestion(-1);
         return;
       }
       // Push to history (skip consecutive identical entries)

--- a/tests/cli/tui/InputBox.test.tsx
+++ b/tests/cli/tui/InputBox.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from 'ink-testing-library';
 
 // Mock useClipboardImage so InputBox doesn't need a real AttachmentProvider
@@ -21,7 +21,7 @@ vi.mock('../../../src/cli/tui/context/AttachmentContext.js', () => ({
   }),
 }));
 
-import { InputBox } from '../../../src/cli/tui/components/InputBox.js';
+import { InputBox, MOUNT_DEBOUNCE_MS } from '../../../src/cli/tui/components/InputBox.js';
 import type { SlashCommand } from '../../../src/cli/tui/hooks/useCommands.js';
 import { ThemeProvider } from '../../../src/cli/tui/context/ThemeContext.js';
 
@@ -175,6 +175,121 @@ describe('InputBox', () => {
           </Wrapper>
         );
       }).not.toThrow();
+    });
+  });
+
+  describe('mount-time debounce', () => {
+    let nowSpy: ReturnType<typeof vi.spyOn> | undefined;
+    let currentTime = 0;
+
+    beforeEach(() => {
+      currentTime = 1_000_000;
+      nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
+    });
+
+    afterEach(() => {
+      nowSpy?.mockRestore();
+    });
+
+    it('exposes MOUNT_DEBOUNCE_MS as 500', () => {
+      expect(MOUNT_DEBOUNCE_MS).toBe(500);
+    });
+
+    it('suppresses submissions that fire immediately after mount', () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <Wrapper>
+          <InputBox {...defaultProps} onSubmit={onSubmit} />
+        </Wrapper>
+      );
+      // Type and submit within 0ms of mount — this simulates a stale
+      // Enter keypress delivered to a freshly mounted TextInput.
+      stdin.write('hello');
+      stdin.write('\r');
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('suppresses submissions inside the debounce window', () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <Wrapper>
+          <InputBox {...defaultProps} onSubmit={onSubmit} />
+        </Wrapper>
+      );
+      // Advance the clock but stay inside the 500ms window.
+      currentTime += MOUNT_DEBOUNCE_MS - 1;
+      stdin.write('hi');
+      stdin.write('\r');
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('allows submissions after the debounce window elapses', async () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <Wrapper>
+          <InputBox {...defaultProps} onSubmit={onSubmit} />
+        </Wrapper>
+      );
+      // Advance past the debounce window before submitting.
+      currentTime += MOUNT_DEBOUNCE_MS + 1;
+      stdin.write('hello');
+      // Allow React to flush the onChange update before Enter is processed.
+      await new Promise((r) => setImmediate(r));
+      stdin.write('\r');
+      await new Promise((r) => setImmediate(r));
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith('hello');
+    });
+
+    it('debounce window is scoped to each mount instance', async () => {
+      const onSubmit = vi.fn();
+      // First instance: unmount before the window elapses (rapid remount).
+      const first = render(
+        <Wrapper>
+          <InputBox {...defaultProps} onSubmit={onSubmit} />
+        </Wrapper>
+      );
+      currentTime += 100;
+      first.unmount();
+
+      // Second instance mounts "now" — its own mountTime becomes the new
+      // reference, so a submit shortly after this remount is still inside
+      // the fresh window and gets suppressed.
+      const second = render(
+        <Wrapper>
+          <InputBox {...defaultProps} onSubmit={onSubmit} />
+        </Wrapper>
+      );
+      currentTime += 100;
+      second.stdin.write('x');
+      await new Promise((r) => setImmediate(r));
+      second.stdin.write('\r');
+      await new Promise((r) => setImmediate(r));
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      // After the window fully elapses on the second instance, submits work.
+      currentTime += MOUNT_DEBOUNCE_MS;
+      second.stdin.write('y');
+      await new Promise((r) => setImmediate(r));
+      second.stdin.write('\r');
+      await new Promise((r) => setImmediate(r));
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith('y');
+    });
+
+    it('does not submit empty or whitespace after debounce window', async () => {
+      const onSubmit = vi.fn();
+      const { stdin } = render(
+        <Wrapper>
+          <InputBox {...defaultProps} onSubmit={onSubmit} />
+        </Wrapper>
+      );
+      currentTime += MOUNT_DEBOUNCE_MS + 1;
+      stdin.write('   ');
+      await new Promise((r) => setImmediate(r));
+      stdin.write('\r');
+      await new Promise((r) => setImmediate(r));
+      expect(onSubmit).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes #1227

## What

Add a 500 ms mount-time debounce window in the TUI `InputBox` to swallow submissions that fire immediately after the component mounts. Guards against duplicate `onSubmit` calls caused by stale keypress events delivered to a freshly remounted `TextInput` after rapid unmount/remount cycles.

## Why

Users reported duplicate chat messages and tool invocations when the TUI input component mounted/unmounted/remounted rapidly (dialog open -> close -> reopen, tab switch and return, component state change triggering re-render). The debounce is a bounded, per-instance guard that matches the pattern suggested in the issue.

## How

- `src/cli/tui/components/InputBox.tsx`
  - Added \`mountTimeRef = useRef<number>(Date.now())\` initialised at first render (per-instance).
  - Exported \`MOUNT_DEBOUNCE_MS = 500\`.
  - In \`handleSubmit\`, if \`Date.now() - mountTimeRef.current < MOUNT_DEBOUNCE_MS\`, clear the pending value and skip \`onSubmit\`.
- \`tests/cli/tui/InputBox.test.tsx\`
  - New \`mount-time debounce\` describe block with 5 test cases:
    - Constant \`MOUNT_DEBOUNCE_MS === 500\`.
    - Submits at 0 ms after mount are suppressed.
    - Submits inside the window (< 500 ms) are suppressed.
    - Submits after the window (> 500 ms) are delivered normally.
    - The window is scoped per mount: unmount + remount resets the reference.
    - Empty/whitespace input still does not submit after the window.
  - Uses \`vi.spyOn(Date, 'now')\` to drive the virtual clock and \`ink-testing-library\` \`stdin.write\` + \`setImmediate\` flushes to simulate typing + Enter.

## Gate verification

- \`npm run lint\`: 0 errors.
- \`npm run typecheck\`: clean.
- \`npm run format:check\`: clean.
- \`npm run test:coverage\`: 3416 passed, 62 skipped, coverage well above 40 % (Lines 65.96 %).
- \`npm run build\`: clean.

## Scope

Touched only \`src/cli/tui/components/InputBox.tsx\` and its matching test file. No changes to \`.github/\`, \`package.json\` version, or unrelated code.