### PR TITLE
feat(providers): actionable error when model id is not in SAP catalog

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -55,6 +55,7 @@ export {
   createTool,
   createToolResponse,
   isOrchestrationModel,
+  InvalidModelError,
   ORCHESTRATION_MODELS,
   type OrchestrationModel,
   type OrchestrationConfig,

--- a/src/providers/sapOrchestration.ts
+++ b/src/providers/sapOrchestration.ts
@@ -613,6 +613,15 @@ export class SapOrchestrationProvider {
   private _connectivityChecked = false;
 
   constructor(config: OrchestrationConfig) {
+    // Validate model id against the SAP AI Core orchestration catalog so an
+    // unknown id fails fast with an actionable message instead of leaking
+    // through to the SAP API as a generic 400/404. `deploymentId` is an
+    // escape hatch for callers that have pinned a concrete deployment
+    // out-of-band — the deployment binds the model, so the catalog check is
+    // not authoritative there. See `InvalidModelError` for rationale.
+    if (!config.deploymentId && !isOrchestrationModel(config.modelName)) {
+      throw new InvalidModelError(config.modelName);
+    }
     this.config = config;
   }
 
@@ -1200,12 +1209,16 @@ export function createToolResponse(toolCallId: string, content: string | object)
 export const ORCHESTRATION_MODELS = [
   // OpenAI models
   'gpt-4o',
+  'gpt-4o-mini',
   'gpt-4.1',
   'gpt-5',
   'gpt-5-mini',
   // Anthropic models
   'anthropic--claude-3.7-sonnet',
+  'anthropic--claude-4.5-haiku',
   'anthropic--claude-4.5-sonnet',
+  'anthropic--claude-4.5-opus',
+  'anthropic--claude-4.7-opus',
   // Google models
   'gemini-2.5-flash',
   'gemini-2.5-pro',
@@ -1230,6 +1243,44 @@ export type OrchestrationModel = (typeof ORCHESTRATION_MODELS)[number];
  */
 export function isOrchestrationModel(modelId: string): boolean {
   return ORCHESTRATION_MODELS.includes(modelId as OrchestrationModel);
+}
+
+/**
+ * Error thrown when `SapOrchestrationProvider` is constructed with a model id
+ * that is not in the `ORCHESTRATION_MODELS` catalog and no `deploymentId`
+ * escape hatch is provided.
+ *
+ * The message is actionable: it echoes the invalid id, lists the first five
+ * catalog entries as concrete examples, and points the user at the three
+ * places a bad id typically originates (env var, routing-config.json, CLI
+ * flag). This is a *permanent* failure per the error-classification contract
+ * in `AGENTS.md` — the SAP AI Core API would eventually return
+ * `model_not_found`/`deployment_not_found`, but by then the caller has
+ * already spent budget on retries. Catching it at construction time lets the
+ * router / TUI show one crisp diagnostic instead.
+ *
+ * `deploymentId` acts as an escape hatch because a caller who has pinned a
+ * concrete SAP deployment id has bound the model out-of-band and does not
+ * need the catalog check — the deployment itself is the authoritative
+ * binding.
+ */
+export class InvalidModelError extends Error {
+  readonly modelName: string;
+  readonly validExamples: readonly string[];
+
+  constructor(modelName: string) {
+    const validExamples = ORCHESTRATION_MODELS.slice(0, 5);
+    const message =
+      `Model '${modelName}' not found in SAP AI Core catalog. Check:\n` +
+      `  1. AICORE_MODEL environment variable\n` +
+      `  2. routing-config.json model ids\n` +
+      `  3. CLI --model flag spelling\n` +
+      `Valid models: ${validExamples.join(', ')}`;
+    super(message);
+    this.name = 'InvalidModelError';
+    this.modelName = modelName;
+    this.validExamples = validExamples;
+  }
 }
 
 // ============================================================================

--- a/tests/providers/error-handling.test.ts
+++ b/tests/providers/error-handling.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Provider error handling tests.
+ *
+ * Verifies that `SapOrchestrationProvider` fails fast with an actionable
+ * `InvalidModelError` when constructed with a model id that is not in the
+ * `ORCHESTRATION_MODELS` catalog, and that the `deploymentId` escape hatch
+ * bypasses the check for callers that have pinned a concrete SAP deployment
+ * out-of-band. See `AGENTS.md` "Error classification" — a bad model id is a
+ * *permanent* failure that should NOT be retried, and the message must guide
+ * the operator to the fix (AICORE_MODEL, routing-config.json, --model flag).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  InvalidModelError,
+  ORCHESTRATION_MODELS,
+  SapOrchestrationProvider,
+  createSapOrchestrationProvider,
+  isOrchestrationModel,
+} from '../../src/providers/index.js';
+
+describe('SapOrchestrationProvider invalid model handling', () => {
+  it('throws InvalidModelError for an unknown model id', () => {
+    expect(() => new SapOrchestrationProvider({ modelName: 'totally-fake-model' })).toThrow(
+      InvalidModelError
+    );
+  });
+
+  it('the error message echoes the invalid model id verbatim', () => {
+    try {
+      new SapOrchestrationProvider({ modelName: 'gpt-99-turbo' });
+      expect.fail('constructor should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidModelError);
+      const e = err as InvalidModelError;
+      expect(e.modelName).toBe('gpt-99-turbo');
+      expect(e.message).toContain("'gpt-99-turbo'");
+      expect(e.message).toContain('not found in SAP AI Core catalog');
+    }
+  });
+
+  it('the error message lists the three fix locations', () => {
+    try {
+      new SapOrchestrationProvider({ modelName: 'nope' });
+      expect.fail('constructor should have thrown');
+    } catch (err) {
+      const e = err as InvalidModelError;
+      expect(e.message).toContain('AICORE_MODEL');
+      expect(e.message).toContain('routing-config.json');
+      expect(e.message).toContain('--model');
+    }
+  });
+
+  it('the error exposes the first 5 catalog entries as valid examples', () => {
+    try {
+      new SapOrchestrationProvider({ modelName: 'nope' });
+      expect.fail('constructor should have thrown');
+    } catch (err) {
+      const e = err as InvalidModelError;
+      const expected = ORCHESTRATION_MODELS.slice(0, 5);
+      expect(e.validExamples).toEqual(expected);
+      for (const model of expected) {
+        expect(e.message).toContain(model);
+      }
+    }
+  });
+
+  it('accepts a valid model id from the catalog without throwing', () => {
+    expect(isOrchestrationModel('gpt-4o')).toBe(true);
+    expect(() => new SapOrchestrationProvider({ modelName: 'gpt-4o' })).not.toThrow();
+  });
+
+  it('accepts every entry in ORCHESTRATION_MODELS', () => {
+    for (const model of ORCHESTRATION_MODELS) {
+      expect(() => new SapOrchestrationProvider({ modelName: model })).not.toThrow();
+    }
+  });
+
+  it('bypasses catalog validation when deploymentId is provided (escape hatch)', () => {
+    // A concrete SAP deployment id binds the model out-of-band, so the
+    // catalog check is not authoritative.
+    expect(
+      () =>
+        new SapOrchestrationProvider({
+          modelName: 'some-custom-deployment-model',
+          deploymentId: 'd-1234abcd',
+        })
+    ).not.toThrow();
+  });
+
+  it('still throws when modelName is invalid and deploymentId is undefined', () => {
+    expect(
+      () =>
+        new SapOrchestrationProvider({
+          modelName: 'unknown-model',
+          resourceGroup: 'default',
+        })
+    ).toThrow(InvalidModelError);
+  });
+
+  it('factory helper createSapOrchestrationProvider also throws on invalid id', () => {
+    expect(() => createSapOrchestrationProvider({ modelName: 'not-a-real-model' })).toThrow(
+      InvalidModelError
+    );
+  });
+
+  it('InvalidModelError is an Error subclass with a stable name', () => {
+    const err = new InvalidModelError('x');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('InvalidModelError');
+  });
+});


### PR DESCRIPTION
Closes #1241

## Summary

Fail fast in `SapOrchestrationProvider` constructor with a new
`InvalidModelError` when `config.modelName` is not in
`ORCHESTRATION_MODELS`. A typo in \`AICORE_MODEL\`, \`routing-config.json\`,
or the \`--model\` flag now surfaces at the first turn with an actionable
diagnostic instead of leaking through as a generic SAP AI Core API 400.

## Changes

- **\`src/providers/sapOrchestration.ts\`**
  - New \`InvalidModelError\` class extending \`Error\` with:
    - \`modelName\` — the invalid id (echoed verbatim in the message)
    - \`validExamples\` — first 5 catalog entries (also inlined in message)
    - Message body pointing at the three canonical fix locations
      (\`AICORE_MODEL\`, \`routing-config.json\`, \`--model\`).
  - Constructor now calls \`isOrchestrationModel(config.modelName)\` and
    throws \`InvalidModelError\` when unknown, unless \`config.deploymentId\`
    is set (escape hatch — a concrete deployment id binds the model
    out-of-band and the catalog is not authoritative there).
  - Extended \`ORCHESTRATION_MODELS\` with SAP-reachable ids already in
    active use across the repo (\`gpt-4o-mini\`,
    \`anthropic--claude-4.5-haiku\`, \`anthropic--claude-4.5-opus\`,
    \`anthropic--claude-4.7-opus\` — the agent-fleet pin). Prevents
    false-positive rejections of valid models the routing config and
    workflows already rely on.

- **\`src/providers/index.ts\`** — re-export \`InvalidModelError\`.

- **\`tests/providers/error-handling.test.ts\`** (new) — 10 cases:
  throws on unknown id, echoes bad id, includes the three fix locations,
  exposes first-5 valid examples, accepts every catalog entry, honors
  the \`deploymentId\` escape hatch, factory helper parity, and
  \`InvalidModelError\` is an \`Error\` subclass with a stable \`name\`.

## Verification

All local gates green:

- \`npm run lint\` — 0 errors (existing warnings unchanged)
- \`npm run typecheck\` — clean
- \`npm run format:check\` — clean
- \`npm run test:coverage\` — 3426 pass / 62 skipped; global lines 66.07%
  (well above the 40% CI floor)
- \`npm run build\` — clean

## Rationale for the \`deploymentId\` escape hatch

Per \`AGENTS.md\` "Error classification", \`model_not_found\` is a
**permanent** failure that must not be retried. Catching it at
construction time turns a 400/404 from SAP into one crisp local error.
However, callers who have pinned a concrete SAP deployment id (rare in
the current runtime, common in tests and advanced setups) already have
the model bound out-of-band — the deployment id is the authoritative
binding. Requiring the catalog to know every deployment-scoped id would
force churn every time a new deployment is registered. The
\`!config.deploymentId\` guard resolves this cleanly.