### PR TITLE
feat(core): add context-overflow recovery telemetry and status notices

### DIFF
--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -10,6 +10,7 @@ import {
 } from '../providers/index.js';
 import { formatProviderError, classifyProviderError } from '../providers/format.js';
 import { NothingToCompactError } from './compaction.js';
+import { logger } from '../utils/logger.js';
 import { routePrompt, recordRouteOutcome, classifyRouteError } from './router.js';
 import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
@@ -323,6 +324,10 @@ export function streamChat(
     // surface it inline. This is not persisted to session history.
     fullText += '\n\n[status] Context window exceeded, compacting conversation...\n\n';
 
+    // Also log an actionable info line so non-TUI callers (plain CLI,
+    // agent workflows, CI logs) see that recovery was triggered.
+    logger.info('Context window exceeded, compacting conversation history and retrying...');
+
     try {
       await sm.compact({
         overflowRecovery: true,
@@ -333,8 +338,8 @@ export function streamChat(
       if (compactErr instanceof NothingToCompactError) {
         // Terminal: no history to compact (overflow on first prompt).
         const term = new Error(
-          'Context window exceeded on first prompt (no history to compact). ' +
-            'Reduce the size of your input or switch to a model with a larger context window.'
+          'Context window exceeded on first prompt with no history to compact. ' +
+            'Please shorten your message or switch to a model with a larger context window.'
         );
         term.name = 'ContextOverflowError';
         throw term;
@@ -409,8 +414,8 @@ export function streamChat(
         // actionable terminal message instead of the raw provider error.
         if (overflowRetried && classifyProviderError(err) === 'context_overflow') {
           const term = new Error(
-            'Context window still exceeded after compaction. ' +
-              'Reduce input size or use a model with a larger context window.'
+            'Context window still exceeded after compacting history. ' +
+              'Please start a new session or switch to a model with a larger context window.'
           );
           term.name = 'ContextOverflowError';
           throw term;

--- a/tests/core/streamingOrchestrator.overflow.test.ts
+++ b/tests/core/streamingOrchestrator.overflow.test.ts
@@ -27,11 +27,23 @@ vi.mock('../../src/core/router.js', () => ({
   classifyRouteError: vi.fn(() => ({ kind: 'unknown' })),
 }));
 
+vi.mock('../../src/utils/logger.js', () => ({
+  logger: {
+    setLevel: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    print: vi.fn(),
+  },
+}));
+
 import { streamChat } from '../../src/core/streamingOrchestrator.js';
 import { getProviderForModelWithFallback, getDefaultModel } from '../../src/providers/index.js';
 import type { StreamChunk } from '../../src/providers/index.js';
 import type { SessionManager } from '../../src/core/sessionManager.js';
 import { NothingToCompactError } from '../../src/core/compaction.js';
+import { logger } from '../../src/utils/logger.js';
 
 interface FakeCall {
   index: number;
@@ -223,6 +235,7 @@ describe('streamChat context-overflow recovery (issue #1247)', () => {
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).name).toBe('ContextOverflowError');
     expect((caught as Error).message).toMatch(/no history to compact/i);
+    expect((caught as Error).message).toMatch(/shorten your message|larger context window/i);
   });
 
   it('surfaces "still exceeded after compaction" when retry also overflows', async () => {
@@ -268,7 +281,8 @@ describe('streamChat context-overflow recovery (issue #1247)', () => {
     expect(compactCalls).toHaveLength(1);
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).name).toBe('ContextOverflowError');
-    expect((caught as Error).message).toMatch(/still exceeded after compaction/i);
+    expect((caught as Error).message).toMatch(/still exceeded after compacting/i);
+    expect((caught as Error).message).toMatch(/start a new session|larger context window/i);
   });
 
   it('does NOT compact for non-overflow errors (e.g. rate limit)', async () => {
@@ -301,6 +315,75 @@ describe('streamChat context-overflow recovery (issue #1247)', () => {
     // No retry, no compaction — the rate-limit error is not overflow.
     expect(getCalls()).toHaveLength(1);
     expect(compactCalls).toHaveLength(0);
+  });
+
+  it('emits a logger.info status notice before compaction (issue #1258)', async () => {
+    const overflow = new Error("This model's maximum context length is 8192 tokens");
+    const { provider } = makeRecoverableProvider(overflow, 1, [
+      { text: 'ok', usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ]);
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: provider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: false,
+    });
+
+    const { sessionManager } = makeFakeSession({
+      history: [
+        { role: 'user', content: 'u1' },
+        { role: 'assistant', content: 'a1' },
+      ],
+    });
+
+    const iter = streamChat('hello', {
+      modelOverride: 'gpt-4o',
+      sessionManager,
+      streamIdleTimeoutMs: 0,
+    });
+
+    for (;;) {
+      const step = await iter.next();
+      if (step.done) {
+        break;
+      }
+    }
+
+    // logger.info must have been called BEFORE the compact() call with the
+    // actionable status notice. We assert on the argument text so a future
+    // wording tweak that drops the actionable substring is caught.
+    const infoCalls = vi.mocked(logger.info).mock.calls.map((c) => String(c[0]));
+    expect(infoCalls.some((msg) => /compacting conversation history and retrying/i.test(msg))).toBe(
+      true
+    );
+  });
+
+  it('does NOT emit the compaction notice for non-overflow errors', async () => {
+    const rate = new Error('rate limit exceeded');
+    (rate as Error & { statusCode?: number }).statusCode = 429;
+    const { provider } = makeRecoverableProvider(rate, 5, []);
+    vi.mocked(getProviderForModelWithFallback).mockReturnValue({
+      provider: provider as never,
+      effectiveModelId: 'gpt-4o',
+      usedFallback: false,
+    });
+
+    const { sessionManager } = makeFakeSession({
+      history: [
+        { role: 'user', content: 'u1' },
+        { role: 'assistant', content: 'a1' },
+      ],
+    });
+
+    const iter = streamChat('hi', {
+      modelOverride: 'gpt-4o',
+      sessionManager,
+      streamIdleTimeoutMs: 0,
+    });
+
+    await expect(iter.next()).rejects.toBeInstanceOf(Error);
+
+    const infoCalls = vi.mocked(logger.info).mock.calls.map((c) => String(c[0]));
+    expect(infoCalls.some((msg) => /compacting conversation history/i.test(msg))).toBe(false);
   });
 
   it('does NOT compact when no sessionManager is attached', async () => {


### PR DESCRIPTION
Closes #1258

## What

Adds a `logger.info` status notice emitted before `compactConversation({ overflowRecovery: true })` fires, and rewords the two terminal errors (first-prompt overflow, retry-after-compaction overflow) to match the actionable copy specified in the issue.

## Changes

- `src/core/streamingOrchestrator.ts`
  - Import `logger` from `../utils/logger.js`.
  - Call `logger.info('Context window exceeded, compacting conversation history and retrying...')` before invoking `sessionManager.compact()` so non-TUI callers (plain CLI, agent workflows, CI logs) see recovery kicked in — the inline `[status]` line into `fullText` is preserved for TUI consumers.
  - Reword `NothingToCompactError` terminal error to: `Context window exceeded on first prompt with no history to compact. Please shorten your message or switch to a model with a larger context window.`
  - Reword retry-overflow terminal error to: `Context window still exceeded after compacting history. Please start a new session or switch to a model with a larger context window.`
- `tests/core/streamingOrchestrator.overflow.test.ts`
  - Mock `../../src/utils/logger.js` so we can assert on `logger.info` calls.
  - New test: verifies `logger.info` is called with the compacting-and-retrying substring during successful recovery.
  - New test: verifies `logger.info` is NOT called with that substring for non-overflow errors (e.g. rate limit).
  - Extended existing terminal-error tests to also assert the new actionable substrings (`shorten your message` / `start a new session`).

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run format:check` — clean
- `npm test` — 3451 passed, 62 skipped (7/7 in overflow suite)
- `npm run build` — clean
- `npm run test:coverage` — lines 66.11% (well above the 40% CI floor)

## Done-when checklist (from issue)

- [x] Status notice emitted before compaction (logger.info)
- [x] `NothingToCompactError` surfaced with actionable message (first prompt, no history)
- [x] Retry overflow surfaced with actionable message (still exceeded after compaction)
- [x] Tests verify notice emitted and terminal errors transformed
- [x] typecheck / lint / test:coverage / build pass

[alexi-bot]