### PR TITLE
feat(providers): add empty-response retry to SAP AI Core provider

### DIFF
--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -19,6 +19,7 @@ import { buildAssembledSystemPromptAsync } from '../agent/system.js';
 import { stripInternalOptions } from '../agent/index.js';
 import { buildSessionHeaders } from '../providers/sessionHeaders.js';
 import type { CompletionOptions } from '../providers/sapOrchestration.js';
+import { retryEmptyResponse } from '../providers/sapOrchestration.js';
 import {
   createStreamWatchdog,
   DEFAULT_STREAM_TOOL_EXTENSION_MS,
@@ -52,6 +53,18 @@ export interface StreamingOptions {
    * Default: 600_000 ms (10 minutes).
    */
   streamToolExtensionMs?: number;
+  /**
+   * Maximum number of attempts the empty-response retry wrapper will make
+   * per turn. Default: 3. Set to 1 to disable retry.
+   *
+   * A turn is retried ONLY when it produces genuinely nothing — no text,
+   * no tool call. Tool-call-only turns are never retried. Errors are NOT
+   * retried here (higher layers own that policy).
+   *
+   * See `retryEmptyResponse` in `providers/sapOrchestration.ts` for the
+   * full contract (issue #1279, Kilo PR #12927).
+   */
+  emptyResponseMaxAttempts?: number;
 }
 
 export interface StreamingResult {
@@ -239,9 +252,18 @@ export function streamChat(
     };
     const providerOpts = stripInternalOptions(merged) as CompletionOptions;
 
+    // Wrap the provider stream with the empty-response retry wrapper so a
+    // transient empty turn (no text, no tool call — Kilo telemetry showed
+    // ~46 tasks / 120 events / 24h) can be recovered before it surfaces as
+    // a hard failure. See `retryEmptyResponse` in
+    // `providers/sapOrchestration.ts` (issue #1279, Kilo PR #12927).
+    const emptyRetryMax = options?.emptyResponseMaxAttempts ?? 3;
     watchdog = createStreamWatchdog(
       (effectiveSignal) =>
-        provider.streamComplete(messages, { ...providerOpts, signal: effectiveSignal }),
+        retryEmptyResponse(
+          () => provider.streamComplete(messages, { ...providerOpts, signal: effectiveSignal }),
+          { maxAttempts: emptyRetryMax }
+        ),
       {
         signal: options?.signal,
         // Resolve the idle timeout on every stream so a mid-session

--- a/src/providers/sapOrchestration.ts
+++ b/src/providers/sapOrchestration.ts
@@ -408,6 +408,232 @@ export function extractCacheTokens(usage: unknown): {
   return out;
 }
 
+// ============================================================================
+// Empty-Response Retry (issue #1279)
+// ============================================================================
+
+/**
+ * Classification of a single {@link StreamChunk} for the empty-response
+ * retry wrapper.
+ *
+ * - `output`   : chunk carries model-visible content (text, tool call, file,
+ *                reasoning) — the turn is NOT empty.
+ * - `structural`: metadata-only chunk (finish reason, usage, stream-start).
+ *                Not output on its own; used to detect end-of-turn.
+ * - `error`    : chunk represents an error signal from the provider.
+ *                Currently the SAP SDK throws for errors so this branch is
+ *                reserved for future providers that emit error frames.
+ */
+export type StreamPartKind = 'output' | 'structural' | 'error';
+
+/**
+ * Classify a {@link StreamChunk} for retry decisions.
+ *
+ * A chunk is considered `output` when it produced anything the user or a
+ * downstream tool loop can act on:
+ *   - non-empty `text`
+ *   - one or more `toolCalls`
+ *
+ * A chunk with only a `finishReason` or `usage` is `structural`. Purely
+ * empty chunks (no text, no tool calls, no finish reason, no usage) are
+ * treated as `structural` too — they cannot rescue an otherwise empty turn.
+ *
+ * The `output` category deliberately covers tool-call-only turns per the
+ * task contract ("tool-call-only turns are never retried"): a tool call is
+ * a valid, non-empty response even when the assistant produced no text.
+ */
+export function classifyStreamPart(chunk: StreamChunk): StreamPartKind {
+  const hasText = typeof chunk.text === 'string' && chunk.text.length > 0;
+  const hasToolCalls = Array.isArray(chunk.toolCalls) && chunk.toolCalls.length > 0;
+  if (hasText || hasToolCalls) {
+    return 'output';
+  }
+  return 'structural';
+}
+
+/**
+ * Configuration for {@link retryEmptyResponse}.
+ */
+export interface EmptyResponseRetryOptions {
+  /**
+   * Maximum number of attempts (including the initial one).
+   * Default: 3. Any value < 1 is treated as 1 (no retry).
+   */
+  maxAttempts?: number;
+  /**
+   * Optional callback invoked when an attempt is discarded as empty.
+   * Receives the 1-indexed attempt number that just failed and the
+   * (possibly undefined) aggregated usage-so-far. Errors thrown from the
+   * callback are swallowed to avoid masking retry progress.
+   */
+  onEmptyAttempt?: (attempt: number, usageSoFar: TokenUsage | undefined) => void;
+}
+
+/**
+ * Aggregate two {@link TokenUsage} records field-by-field.
+ *
+ * Undefined fields are treated as "unknown" and do NOT contribute to the
+ * sum (they are only kept if present on one side). When BOTH sides report
+ * a numeric value, they are summed. This matches the semantics needed for
+ * charging discarded-attempt cost against the eventual successful turn
+ * — the API billed us for the empty attempts, so the caller must see the
+ * total.
+ */
+export function mergeUsage(
+  a: TokenUsage | undefined,
+  b: TokenUsage | undefined
+): TokenUsage | undefined {
+  if (!a) {
+    return b;
+  }
+  if (!b) {
+    return a;
+  }
+  const addField = (x: number | undefined, y: number | undefined): number | undefined => {
+    if (x === undefined && y === undefined) {
+      return undefined;
+    }
+    return (x ?? 0) + (y ?? 0);
+  };
+  const out: TokenUsage = {};
+  const pt = addField(a.prompt_tokens, b.prompt_tokens);
+  if (pt !== undefined) {
+    out.prompt_tokens = pt;
+  }
+  const ct = addField(a.completion_tokens, b.completion_tokens);
+  if (ct !== undefined) {
+    out.completion_tokens = ct;
+  }
+  const tt = addField(a.total_tokens, b.total_tokens);
+  if (tt !== undefined) {
+    out.total_tokens = tt;
+  }
+  const cr = addField(a.cache_read_input_tokens, b.cache_read_input_tokens);
+  if (cr !== undefined) {
+    out.cache_read_input_tokens = cr;
+  }
+  const cc = addField(a.cache_creation_input_tokens, b.cache_creation_input_tokens);
+  if (cc !== undefined) {
+    out.cache_creation_input_tokens = cc;
+  }
+  return out;
+}
+
+/**
+ * Wrap a stream factory with empty-response retry.
+ *
+ * Semantics (see issue #1279 and Kilo PR #12927):
+ *  - Consume chunks from the factory-produced stream one at a time.
+ *  - As soon as we see an `output` chunk we "commit" the attempt: buffered
+ *    structural chunks (if any) are flushed, and everything from this
+ *    attempt is streamed through to the caller unchanged. No further
+ *    retries can happen for this turn.
+ *  - If the stream ends without producing any `output` chunk, the attempt
+ *    is discarded. Its usage is aggregated into a running total, and the
+ *    factory is called again to open a fresh stream.
+ *  - After {@link EmptyResponseRetryOptions.maxAttempts} attempts, the
+ *    accumulated structural chunks (with aggregated usage) are yielded to
+ *    the caller as a best-effort final metadata chunk. The turn ends
+ *    empty — the caller decides whether that is an error.
+ *  - Errors thrown by the underlying stream are propagated immediately.
+ *    They are NOT retried here; higher-level layers (`ErrorBackoff`, the
+ *    workflow `KILO_RETRIES` loop, or the route retry policy) handle
+ *    error retries with their own backoff and classification.
+ *
+ * The factory MUST be safe to invoke multiple times and MUST produce a
+ * fresh stream on each call (the previous stream is fully drained before
+ * a retry).
+ *
+ * Usage aggregation is field-by-field, using {@link mergeUsage}. When the
+ * committed attempt itself reports usage, that usage is summed with the
+ * aggregated total of the discarded attempts so downstream cost trackers
+ * bill the whole turn.
+ */
+export async function* retryEmptyResponse(
+  streamFactory: () => AsyncIterable<StreamChunk> | Promise<AsyncIterable<StreamChunk>>,
+  options: EmptyResponseRetryOptions = {}
+): AsyncGenerator<StreamChunk> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 3);
+  let aggregatedUsage: TokenUsage | undefined;
+  let lastStructural: StreamChunk | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const stream = await streamFactory();
+    const bufferedStructural: StreamChunk[] = [];
+    let committed = false;
+
+    for await (const chunk of stream) {
+      if (committed) {
+        // Post-commit passthrough: everything flows to the caller as-is.
+        // No further retry decisions and no aggregation are needed.
+        yield chunk;
+        continue;
+      }
+
+      const kind = classifyStreamPart(chunk);
+      if (kind === 'output') {
+        // Commit: flush buffered structural chunks first, then this one.
+        // Aggregate any usage seen so far into this chunk's usage so the
+        // caller sees the full billed cost of the turn.
+        committed = true;
+        for (const s of bufferedStructural) {
+          yield s;
+        }
+        if (aggregatedUsage) {
+          const merged = mergeUsage(aggregatedUsage, chunk.usage);
+          const rewritten: StreamChunk = { ...chunk };
+          if (merged) {
+            rewritten.usage = merged;
+          }
+          yield rewritten;
+          aggregatedUsage = undefined;
+        } else {
+          yield chunk;
+        }
+        continue;
+      }
+      // structural: buffer for potential replay of usage.
+      bufferedStructural.push(chunk);
+      if (chunk.usage) {
+        lastStructural = chunk;
+      }
+    }
+
+    if (committed) {
+      return;
+    }
+
+    // Attempt produced no output. Aggregate usage from the discarded
+    // stream's structural chunks into the running total.
+    for (const s of bufferedStructural) {
+      if (s.usage) {
+        aggregatedUsage = mergeUsage(aggregatedUsage, s.usage);
+      }
+    }
+    if (options.onEmptyAttempt) {
+      try {
+        options.onEmptyAttempt(attempt, aggregatedUsage);
+      } catch {
+        // Swallow to avoid masking retry progress.
+      }
+    }
+  }
+
+  // All attempts empty. Yield a final metadata chunk so the caller can
+  // still see the aggregated usage of the discarded attempts and the last
+  // finishReason. This keeps cost tracking honest.
+  const finalChunk: StreamChunk = {
+    text: '',
+  };
+  if (lastStructural?.finishReason) {
+    finalChunk.finishReason = lastStructural.finishReason;
+  }
+  if (aggregatedUsage) {
+    finalChunk.usage = aggregatedUsage;
+  }
+  yield finalChunk;
+}
+
 /**
  * Build input filters based on configuration
  */

--- a/tests/providers/sapOrchestration-emptyResponseRetry.test.ts
+++ b/tests/providers/sapOrchestration-emptyResponseRetry.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Tests for the empty-response retry wrapper added for issue #1279.
+ *
+ * Contract (mirrors Kilo PR #12927):
+ *  - Retry only when a turn produces genuinely nothing (no text, no tool
+ *    call). Tool-call-only turns are never retried. File/reasoning-only
+ *    turns (via any future StreamChunk shape) are never retried.
+ *  - Buffer structural chunks until an output chunk arrives, then commit.
+ *  - Aggregate usage across discarded attempts and surface it on the first
+ *    committed output chunk (or on a final structural chunk if all
+ *    attempts were empty).
+ *  - Errors thrown by the underlying stream are propagated immediately —
+ *    higher layers (ErrorBackoff, workflow retries) own error retry.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  classifyStreamPart,
+  mergeUsage,
+  retryEmptyResponse,
+  type StreamChunk,
+  type TokenUsage,
+} from '../../src/providers/sapOrchestration.js';
+
+async function collect(gen: AsyncIterable<StreamChunk>): Promise<StreamChunk[]> {
+  const out: StreamChunk[] = [];
+  for await (const c of gen) {
+    out.push(c);
+  }
+  return out;
+}
+
+function makeStream(chunks: StreamChunk[]): () => AsyncIterable<StreamChunk> {
+  return () => {
+    async function* gen(): AsyncGenerator<StreamChunk> {
+      for (const c of chunks) {
+        yield c;
+      }
+    }
+    return gen();
+  };
+}
+
+describe('classifyStreamPart', () => {
+  it('classifies non-empty text as output', () => {
+    expect(classifyStreamPart({ text: 'hello' })).toBe('output');
+  });
+
+  it('classifies tool-call-only chunks as output', () => {
+    expect(
+      classifyStreamPart({
+        text: '',
+        toolCalls: [{ index: 0, id: 'call_1', function: { name: 'x', arguments: '{}' } }],
+      })
+    ).toBe('output');
+  });
+
+  it('classifies empty text with no tool calls as structural', () => {
+    expect(classifyStreamPart({ text: '' })).toBe('structural');
+  });
+
+  it('classifies a metadata-only finish chunk as structural', () => {
+    expect(
+      classifyStreamPart({
+        text: '',
+        finishReason: 'stop',
+        usage: { prompt_tokens: 10, completion_tokens: 0, total_tokens: 10 },
+      })
+    ).toBe('structural');
+  });
+
+  it('classifies an empty tool-calls array as structural', () => {
+    expect(classifyStreamPart({ text: '', toolCalls: [] })).toBe('structural');
+  });
+});
+
+describe('mergeUsage', () => {
+  it('returns undefined when both sides are undefined', () => {
+    expect(mergeUsage(undefined, undefined)).toBeUndefined();
+  });
+
+  it('returns the defined side when one is undefined', () => {
+    const u: TokenUsage = { prompt_tokens: 5 };
+    expect(mergeUsage(u, undefined)).toBe(u);
+    expect(mergeUsage(undefined, u)).toBe(u);
+  });
+
+  it('sums numeric fields field-by-field', () => {
+    const a: TokenUsage = {
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+      cache_read_input_tokens: 3,
+      cache_creation_input_tokens: 2,
+    };
+    const b: TokenUsage = {
+      prompt_tokens: 20,
+      completion_tokens: 7,
+      total_tokens: 27,
+      cache_read_input_tokens: 1,
+      cache_creation_input_tokens: 4,
+    };
+    expect(mergeUsage(a, b)).toEqual({
+      prompt_tokens: 30,
+      completion_tokens: 12,
+      total_tokens: 42,
+      cache_read_input_tokens: 4,
+      cache_creation_input_tokens: 6,
+    });
+  });
+
+  it('omits fields undefined on both sides', () => {
+    const a: TokenUsage = { prompt_tokens: 10 };
+    const b: TokenUsage = { completion_tokens: 5 };
+    const merged = mergeUsage(a, b);
+    expect(merged).toEqual({ prompt_tokens: 10, completion_tokens: 5 });
+    expect(merged?.total_tokens).toBeUndefined();
+    expect(merged?.cache_read_input_tokens).toBeUndefined();
+  });
+
+  it('treats a missing field on one side as zero when the other is defined', () => {
+    const a: TokenUsage = { prompt_tokens: 10 };
+    const b: TokenUsage = { prompt_tokens: 5, completion_tokens: 3 };
+    expect(mergeUsage(a, b)).toEqual({ prompt_tokens: 15, completion_tokens: 3 });
+  });
+});
+
+describe('retryEmptyResponse', () => {
+  it('passes through a normal, non-empty turn without retry', async () => {
+    const chunks: StreamChunk[] = [
+      { text: 'Hello ' },
+      { text: 'world' },
+      {
+        text: '',
+        finishReason: 'stop',
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      },
+    ];
+    const factory = vi.fn(makeStream(chunks));
+    const result = await collect(retryEmptyResponse(factory, { maxAttempts: 3 }));
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(chunks);
+  });
+
+  it('does NOT retry a tool-call-only turn', async () => {
+    const chunks: StreamChunk[] = [
+      {
+        text: '',
+        toolCalls: [
+          { index: 0, id: 'call_1', function: { name: 'read_file', arguments: '{"path":"x"}' } },
+        ],
+      },
+      {
+        text: '',
+        finishReason: 'tool_calls',
+        usage: { prompt_tokens: 8, completion_tokens: 12, total_tokens: 20 },
+      },
+    ];
+    const factory = vi.fn(makeStream(chunks));
+    const result = await collect(retryEmptyResponse(factory, { maxAttempts: 3 }));
+    expect(factory).toHaveBeenCalledTimes(1);
+    // Tool-call chunk must arrive first and unchanged; finish chunk follows.
+    expect(result[0]?.toolCalls?.[0]?.id).toBe('call_1');
+    expect(result[1]?.finishReason).toBe('tool_calls');
+  });
+
+  it('retries an empty attempt until an output chunk arrives', async () => {
+    let callCount = 0;
+    const factory = (): AsyncIterable<StreamChunk> => {
+      callCount++;
+      async function* gen(): AsyncGenerator<StreamChunk> {
+        if (callCount < 3) {
+          // First two attempts: empty (only a finish chunk).
+          yield {
+            text: '',
+            finishReason: 'stop',
+            usage: { prompt_tokens: 5, completion_tokens: 0, total_tokens: 5 },
+          };
+          return;
+        }
+        // Third attempt succeeds.
+        yield { text: 'finally' };
+        yield {
+          text: '',
+          finishReason: 'stop',
+          usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+        };
+      }
+      return gen();
+    };
+    const onEmpty = vi.fn();
+    const result = await collect(
+      retryEmptyResponse(factory, { maxAttempts: 3, onEmptyAttempt: onEmpty })
+    );
+    expect(callCount).toBe(3);
+    expect(onEmpty).toHaveBeenCalledTimes(2);
+    // First yielded chunk is the committed output.
+    expect(result[0]).toEqual({
+      text: 'finally',
+      // Aggregated usage from 2 discarded attempts folded into the first
+      // output chunk, since the output chunk itself had no usage field.
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 0,
+        total_tokens: 10,
+      },
+    });
+    // Trailing finish chunk passes through unchanged.
+    expect(result[result.length - 1]?.finishReason).toBe('stop');
+  });
+
+  it('aggregates usage from discarded attempts into the first output chunk', async () => {
+    let callCount = 0;
+    const factory = (): AsyncIterable<StreamChunk> => {
+      callCount++;
+      async function* gen(): AsyncGenerator<StreamChunk> {
+        if (callCount === 1) {
+          yield {
+            text: '',
+            finishReason: 'stop',
+            usage: { prompt_tokens: 3, completion_tokens: 0, total_tokens: 3 },
+          };
+          return;
+        }
+        yield {
+          text: 'ok',
+          usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+        };
+      }
+      return gen();
+    };
+    const result = await collect(retryEmptyResponse(factory, { maxAttempts: 3 }));
+    expect(result[0]).toEqual({
+      text: 'ok',
+      usage: {
+        prompt_tokens: 8, // 3 discarded + 5 committed
+        completion_tokens: 1,
+        total_tokens: 9,
+      },
+    });
+  });
+
+  it('aggregates cache_read/creation tokens across discarded attempts', async () => {
+    let callCount = 0;
+    const factory = (): AsyncIterable<StreamChunk> => {
+      callCount++;
+      async function* gen(): AsyncGenerator<StreamChunk> {
+        if (callCount === 1) {
+          yield {
+            text: '',
+            finishReason: 'stop',
+            usage: {
+              prompt_tokens: 100,
+              completion_tokens: 0,
+              total_tokens: 100,
+              cache_read_input_tokens: 80,
+              cache_creation_input_tokens: 20,
+            },
+          };
+          return;
+        }
+        yield {
+          text: 'success',
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 3,
+            total_tokens: 103,
+            cache_read_input_tokens: 95,
+            cache_creation_input_tokens: 5,
+          },
+        };
+      }
+      return gen();
+    };
+    const result = await collect(retryEmptyResponse(factory, { maxAttempts: 3 }));
+    expect(result[0]?.usage).toEqual({
+      prompt_tokens: 200,
+      completion_tokens: 3,
+      total_tokens: 203,
+      cache_read_input_tokens: 175,
+      cache_creation_input_tokens: 25,
+    });
+  });
+
+  it('stops buffering (commits) on the first output chunk', async () => {
+    const seenAfterCommit: StreamChunk[] = [];
+    let callCount = 0;
+    const factory = (): AsyncIterable<StreamChunk> => {
+      callCount++;
+      async function* gen(): AsyncGenerator<StreamChunk> {
+        // First stream: an empty structural chunk, then output, then another
+        // structural finish. The wrapper should NOT retry after the output
+        // chunk even though the finish chunk carries no output.
+        yield { text: '' };
+        yield { text: 'hello' };
+        yield {
+          text: '',
+          finishReason: 'stop',
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        };
+      }
+      return gen();
+    };
+    for await (const c of retryEmptyResponse(factory, { maxAttempts: 3 })) {
+      seenAfterCommit.push(c);
+    }
+    expect(callCount).toBe(1);
+    // Buffered structural chunk arrives before the output.
+    expect(seenAfterCommit[0]).toEqual({ text: '' });
+    expect(seenAfterCommit[1]).toEqual({ text: 'hello' });
+    expect(seenAfterCommit[2]?.finishReason).toBe('stop');
+  });
+
+  it('yields a final aggregated metadata chunk when ALL attempts are empty', async () => {
+    let callCount = 0;
+    const factory = (): AsyncIterable<StreamChunk> => {
+      callCount++;
+      async function* gen(): AsyncGenerator<StreamChunk> {
+        yield {
+          text: '',
+          finishReason: 'stop',
+          usage: { prompt_tokens: 4, completion_tokens: 0, total_tokens: 4 },
+        };
+      }
+      return gen();
+    };
+    const result = await collect(retryEmptyResponse(factory, { maxAttempts: 3 }));
+    expect(callCount).toBe(3);
+    // Exactly one chunk: the aggregated final structural chunk.
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      text: '',
+      finishReason: 'stop',
+      usage: {
+        prompt_tokens: 12, // 4 * 3 attempts
+        completion_tokens: 0,
+        total_tokens: 12,
+      },
+    });
+  });
+
+  it('propagates errors thrown by the underlying stream without retrying', async () => {
+    let callCount = 0;
+    const factory = (): AsyncIterable<StreamChunk> => {
+      callCount++;
+      async function* gen(): AsyncGenerator<StreamChunk> {
+        yield { text: '' };
+        throw new Error('provider blew up');
+      }
+      return gen();
+    };
+    await expect(collect(retryEmptyResponse(factory, { maxAttempts: 3 }))).rejects.toThrow(
+      /provider blew up/
+    );
+    // Only one attempt: errors are NOT retried here.
+    expect(callCount).toBe(1);
+  });
+
+  it('treats maxAttempts < 1 as a single attempt (no retry)', async () => {
+    let callCount = 0;
+    const factory = (): AsyncIterable<StreamChunk> => {
+      callCount++;
+      async function* gen(): AsyncGenerator<StreamChunk> {
+        yield { text: '' };
+      }
+      return gen();
+    };
+    await collect(retryEmptyResponse(factory, { maxAttempts: 0 }));
+    expect(callCount).toBe(1);
+  });
+
+  it('does not retry a file-like output turn (future-proofing)', async () => {
+    // The current StreamChunk shape has {text, toolCalls, finishReason,
+    // usage}. If a future refactor adds a `file` field, classifyStreamPart
+    // stays conservative and any chunk carrying non-empty text or tool
+    // calls is treated as output. This test pins the "non-empty text is
+    // output" branch even when the text is a file descriptor payload.
+    const chunks: StreamChunk[] = [
+      { text: '<file id="abc">contents</file>' },
+      {
+        text: '',
+        finishReason: 'stop',
+        usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+      },
+    ];
+    let callCount = 0;
+    const factory = (): AsyncIterable<StreamChunk> => {
+      callCount++;
+      return makeStream(chunks)();
+    };
+    await collect(retryEmptyResponse(factory, { maxAttempts: 3 }));
+    expect(callCount).toBe(1);
+  });
+
+  it('surfaces onEmptyAttempt callback errors without breaking retry', async () => {
+    let callCount = 0;
+    const factory = (): AsyncIterable<StreamChunk> => {
+      callCount++;
+      async function* gen(): AsyncGenerator<StreamChunk> {
+        if (callCount === 1) {
+          yield { text: '' };
+          return;
+        }
+        yield { text: 'ok' };
+      }
+      return gen();
+    };
+    const onEmpty = vi.fn(() => {
+      throw new Error('callback exploded');
+    });
+    const result = await collect(
+      retryEmptyResponse(factory, { maxAttempts: 3, onEmptyAttempt: onEmpty })
+    );
+    expect(onEmpty).toHaveBeenCalledTimes(1);
+    expect(result[0]?.text).toBe('ok');
+  });
+});


### PR DESCRIPTION
Closes #1279

## What

Adds a `retryEmptyResponse` wrapper around `SapOrchestrationProvider.streamComplete()` so a transient empty turn (no text, no tool call) can be recovered before it surfaces as a hard `Model returned empty response` failure. Kilo production telemetry showed 46 tasks / 120 events / 24h on hosted backends.

Mirrors Kilo PR [#12927](https://github.com/Kilo-Org/kilocode/pull/12927).

## How

### `src/providers/sapOrchestration.ts`

- **`classifyStreamPart(chunk)`** — classifies a `StreamChunk` as `output` (non-empty text OR one or more tool calls) or `structural` (finish reason / usage / empty). Tool-call-only turns are `output` and are never retried, per the issue contract.
- **`mergeUsage(a, b)`** — sums `prompt_tokens`, `completion_tokens`, `total_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` field-by-field, preserving `undefined` as "unknown".
- **`retryEmptyResponse(factory, { maxAttempts })`** — async generator wrapper. Buffers structural chunks per attempt, commits on first `output` chunk, aggregates usage across discarded attempts and folds it into the committed chunk. All attempts empty ⇒ yields a final structural chunk carrying the aggregated usage. Errors propagate immediately (higher layers own error retry).

### `src/core/streamingOrchestrator.ts`

- New `StreamingOptions.emptyResponseMaxAttempts` (default 3, set to 1 to disable).
- Wraps `provider.streamComplete(...)` inside the watchdog's `sourceFactory` so idle-timeout and caller-signal cancellation still cascade to the retry loop.

### Tests

`tests/providers/sapOrchestration-emptyResponseRetry.test.ts` — 21 tests covering:

- `classifyStreamPart` — text-only, tool-call-only, empty-tool-calls, finish-only, empty-text-only
- `mergeUsage` — both-undefined, one-defined, full sum, cache fields, missing-field handling
- `retryEmptyResponse` — passthrough, tool-only never retried, retry until output, usage aggregation, cache-field aggregation, commit on first output, all-attempts-empty final chunk, error passthrough, `maxAttempts < 1` clamp, file-like output never retried, resilient `onEmptyAttempt` callback

## Verification

```
npm run typecheck    # ✔
npm run lint         # ✔ (0 errors, unrelated warnings only)
npm run format:check # ✔
npm test             # ✔ 3518 passed / 62 skipped
npm run test:coverage # ✔ 66.55% lines (CI threshold 40%)
npm run build        # ✔
```

[alexi-bot]