### PR TITLE
feat(tools): add read-only bash command allowlist for plan mode

### DIFF
--- a/src/plan/index.ts
+++ b/src/plan/index.ts
@@ -6,6 +6,7 @@
 
 import { z } from 'zod';
 import { defineEvent } from '../bus/index.js';
+import { isCommandReadOnly } from '../tool/tools/bash-command-parser.js';
 
 // ============ Types ============
 
@@ -231,13 +232,36 @@ export class PlanModeManager {
   }
 
   /**
-   * Attempt to execute a tool and emit blocked event if not allowed
+   * Attempt to execute a tool and emit blocked event if not allowed.
+   *
+   * When plan mode is active and `allowReadOnlyBash` is enabled in
+   * config, a `bash` invocation is inspected via
+   * `isCommandReadOnly` — read-only investigation commands (ls, cat,
+   * grep, git status, ...) are permitted while any command that
+   * modifies the filesystem, VCS state, or installs packages is
+   * blocked.
+   *
    * @param toolName - Name of the tool being executed
+   * @param command  - For `bash`, the raw shell command string. Ignored
+   *                   for other tools.
    * @returns true if tool execution should proceed, false if blocked
    */
-  checkToolExecution(toolName: string): boolean {
+  checkToolExecution(toolName: string, command?: string): boolean {
     if (this.isToolAllowed(toolName)) {
       return true;
+    }
+
+    // Special case: bash in plan mode with read-only allowlist enabled.
+    if (
+      this.mode === 'plan' &&
+      toolName === 'bash' &&
+      currentConfig.allowReadOnlyBash &&
+      typeof command === 'string' &&
+      command.length > 0
+    ) {
+      if (isCommandReadOnly(command)) {
+        return true;
+      }
     }
 
     // Determine operation type from tool name
@@ -383,11 +407,12 @@ export function withPlanModeCheckSync<T>(
  */
 export async function withToolCheck<T>(
   toolName: string,
-  handler: () => Promise<T>
+  handler: () => Promise<T>,
+  command?: string
 ): Promise<T | { success: false; error: string }> {
   const manager = getPlanModeManager();
 
-  if (!manager.checkToolExecution(toolName)) {
+  if (!manager.checkToolExecution(toolName, command)) {
     return {
       success: false,
       error: `Tool '${toolName}' is blocked in plan mode. Use /mode build to switch to build mode.`,

--- a/src/tool/tools/bash-command-parser.ts
+++ b/src/tool/tools/bash-command-parser.ts
@@ -1,0 +1,744 @@
+/**
+ * Bash command parser for plan-mode read-only allowlist.
+ *
+ * Given a shell command string, determines whether the command is safe to
+ * run in a read-only investigation context (i.e. it will not modify the
+ * filesystem, network state, or version control history).
+ *
+ * Design (ported from kilocode #12906):
+ *
+ * 1. Mask out quoted strings, heredoc bodies, escaped characters and
+ *    shell comments so that the tokens inside them cannot false-positive
+ *    against the read-only allowlist or the block-list. The masking
+ *    replaces the payload with same-length runs of a filler character so
+ *    that index positions remain stable for the rest of the pipeline.
+ * 2. Split the masked command on shell control operators (`;`, `|`, `||`,
+ *    `&&`, `&`, newline) into simple segments.
+ * 3. Inspect each segment independently. A segment is read-only if:
+ *      - The leading command token is in `READ_ONLY_COMMANDS`, and
+ *      - When the command is `git`, its subcommand is in
+ *        `READ_ONLY_GIT_SUBCOMMANDS` and not in
+ *        `MUTATING_GIT_SUBCOMMANDS`, and
+ *      - No `>`, `>>`, `<>` redirect targets a real filesystem path
+ *        (writes to `/dev/*` and `/tmp/*` are tolerated, but `..`
+ *        traversal is always rejected), and
+ *      - The command is not a known mutating helper for otherwise
+ *        read-looking commands (e.g. `sed -i`, `perl -i`, `sort -o`,
+ *        `find -delete`, `xargs rm`, `npm install`).
+ * 4. If any segment is not read-only, the entire command is treated as
+ *    mutating. This is deliberately conservative — a pipeline that
+ *    starts with `ls` but pipes into `xargs rm` MUST be blocked.
+ *
+ * All matchers operate on the masked command so a `rm` sitting inside a
+ * quoted echo (`echo "rm foo.txt"`) does not trigger a false positive.
+ */
+
+// ============ Allowlists / blocklists ============
+
+/**
+ * Command names whose default behaviour is read-only (writes stdout/stderr,
+ * inspects the filesystem, or prints VCS metadata). Individual entries may
+ * still be rejected below if used with mutating flags — e.g. `sed -i`.
+ */
+const READ_ONLY_COMMANDS = new Set<string>([
+  'ls',
+  'cat',
+  'head',
+  'tail',
+  'less',
+  'more',
+  'grep',
+  'egrep',
+  'fgrep',
+  'rg',
+  'ag',
+  'ack',
+  'find',
+  'pwd',
+  'echo',
+  'printf',
+  'git',
+  'diff',
+  'wc',
+  'sort',
+  'uniq',
+  'cut',
+  'awk',
+  'gawk',
+  'sed',
+  'du',
+  'df',
+  'stat',
+  'file',
+  'which',
+  'type',
+  'whoami',
+  'id',
+  'date',
+  'uname',
+  'hostname',
+  'env',
+  'printenv',
+  'true',
+  'false',
+  'test',
+  'tree',
+  'basename',
+  'dirname',
+  'realpath',
+  'readlink',
+  'tr',
+  'jq',
+  'yq',
+  'column',
+  'nl',
+  'tac',
+  'rev',
+  'ps',
+  'top',
+  'htop',
+  'xargs',
+  'perl',
+  'python',
+  'python3',
+  'node',
+  'ruby',
+]);
+
+/**
+ * Command names whose default behaviour writes to the filesystem, mutates
+ * VCS state, or performs a network install/upload. Always blocked.
+ */
+const BLOCKED_COMMANDS = new Set<string>([
+  'rm',
+  'mv',
+  'cp',
+  'tee',
+  'touch',
+  'truncate',
+  'dd',
+  'install',
+  'unlink',
+  'shred',
+  'chmod',
+  'chown',
+  'mkdir',
+  'rmdir',
+  'ln',
+  'sudo',
+  'su',
+  'doas',
+  'eval',
+  'exec',
+  'source',
+  '.',
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  'dash',
+  'ksh',
+  'csh',
+  'tcsh',
+  'pwsh',
+  'powershell',
+  'cmd',
+]);
+
+/**
+ * `git <subcmd>` phrases that are read-only. A phrase may be one token
+ * (`git log`) or two (`git stash list`).
+ */
+const READ_ONLY_GIT_SUBCOMMANDS = new Set<string>([
+  'status',
+  'log',
+  'diff',
+  'show',
+  'branch',
+  'tag',
+  'remote',
+  'ls-files',
+  'ls-tree',
+  'rev-parse',
+  'rev-list',
+  'reflog',
+  'blame',
+  'shortlog',
+  'describe',
+  'config',
+  'stash list',
+  'stash show',
+  'worktree list',
+  'submodule status',
+  'help',
+  'grep',
+]);
+
+/**
+ * `git <subcmd>` phrases that mutate the repository, working tree, or
+ * remote. Always blocked, even if `git` itself is otherwise read-only.
+ */
+const MUTATING_GIT_SUBCOMMANDS = new Set<string>([
+  'add',
+  'commit',
+  'push',
+  'pull',
+  'fetch',
+  'merge',
+  'rebase',
+  'cherry-pick',
+  'revert',
+  'reset',
+  'checkout',
+  'switch',
+  'restore',
+  'clean',
+  'rm',
+  'mv',
+  'apply',
+  'am',
+  'stash save',
+  'stash push',
+  'stash apply',
+  'stash pop',
+  'stash drop',
+  'stash clear',
+  'stash create',
+  'stash store',
+  'tag -d',
+  'branch -d',
+  'branch -D',
+  'remote add',
+  'remote remove',
+  'remote rename',
+  'remote set-url',
+  'worktree add',
+  'worktree remove',
+  'submodule add',
+  'submodule update',
+]);
+
+/**
+ * Package managers whose `install`, `add`, `remove`, `update`, `upgrade`,
+ * `publish` subcommands must be blocked. Their read-only subcommands
+ * (`npm ls`, `pip show`, `cargo tree`, ...) are also blocked here — the
+ * simpler rule is to require the user to leave plan mode for any
+ * package-manager invocation.
+ */
+const BLOCKED_PACKAGE_MANAGERS = new Set<string>([
+  'npm',
+  'pnpm',
+  'yarn',
+  'bun',
+  'pip',
+  'pip3',
+  'pipx',
+  'poetry',
+  'cargo',
+  'gem',
+  'bundle',
+  'go',
+  'apt',
+  'apt-get',
+  'yum',
+  'dnf',
+  'brew',
+  'apk',
+  'pacman',
+  'snap',
+  'nix',
+  'docker',
+  'podman',
+  'kubectl',
+  'helm',
+  'terraform',
+  'ansible',
+  'ansible-playbook',
+]);
+
+/**
+ * Sentinel character used to mask masked-out ranges (quoted strings,
+ * heredoc bodies, escapes, comments). Chosen because `\u0001` is not a
+ * valid character in a shell command line under any normal condition.
+ * Constructed via `String.fromCharCode` and compared with `RegExp`
+ * built from that same string so ESLint's `no-control-regex` rule
+ * does not fire on inline `\u0001` literals.
+ */
+const FILLER_CHAR = String.fromCharCode(1);
+const FILLER_ONLY_RE = new RegExp(`${FILLER_CHAR}+`, 'g');
+
+// ============ Masking helpers ============
+
+/**
+ * Mask ranges of the command string that must NOT participate in token
+ * matching: single/double/backtick quotes, heredoc bodies, escape
+ * sequences, and shell comments.
+ *
+ * Replaces each masked character with a fixed filler that is guaranteed
+ * not to appear in a real command (`\u0001`). Length is preserved so
+ * downstream splitters and matchers keep their indices.
+ */
+function maskLiterals(input: string): string {
+  const chars = input.split('');
+  const out: string[] = new Array(chars.length);
+  const FILLER = FILLER_CHAR;
+  let i = 0;
+
+  // Preserve newlines and shell operators; mask everything else inside
+  // a quoted range.
+  const preserve = (ch: string): boolean => ch === '\n';
+
+  while (i < chars.length) {
+    const c = chars[i];
+
+    // Backslash escape — consume the next character verbatim (masked).
+    if (c === '\\' && i + 1 < chars.length) {
+      out[i] = FILLER;
+      out[i + 1] = FILLER;
+      i += 2;
+      continue;
+    }
+
+    // Line comment `#...` up to newline. Only recognised as a comment
+    // when at start of segment or preceded by whitespace, to avoid
+    // false-positives like `foo#bar` (a valid unquoted token).
+    if (c === '#' && (i === 0 || /\s/.test(chars[i - 1]))) {
+      while (i < chars.length && chars[i] !== '\n') {
+        out[i] = FILLER;
+        i += 1;
+      }
+      continue;
+    }
+
+    // Heredoc: `<<[-]?WORD` opens; body ends at a line containing WORD.
+    // We detect the opener conservatively by scanning back for `<<`.
+    if (c === '<' && chars[i + 1] === '<') {
+      // Parse `<<[-]?TAG`
+      let j = i + 2;
+      out[i] = '<';
+      out[i + 1] = '<';
+      let stripTabs = false;
+      if (chars[j] === '-') {
+        out[j] = '-';
+        stripTabs = true;
+        j += 1;
+      }
+      // Skip whitespace between `<<` and the tag.
+      while (j < chars.length && chars[j] === ' ') {
+        out[j] = ' ';
+        j += 1;
+      }
+      // Read the tag (may be quoted).
+      let tag = '';
+      const tagStart = j;
+      if (chars[j] === '"' || chars[j] === "'") {
+        const q = chars[j];
+        out[j] = q;
+        j += 1;
+        while (j < chars.length && chars[j] !== q) {
+          tag += chars[j];
+          out[j] = chars[j];
+          j += 1;
+        }
+        if (j < chars.length) {
+          out[j] = q;
+          j += 1;
+        }
+      } else {
+        while (j < chars.length && /[A-Za-z0-9_]/.test(chars[j])) {
+          tag += chars[j];
+          out[j] = chars[j];
+          j += 1;
+        }
+      }
+      if (tag.length === 0) {
+        // Not actually a heredoc — leave as-is.
+        i = tagStart;
+        out[i] = chars[i];
+        i += 1;
+        continue;
+      }
+      // Advance to end of line, then mask body up to the line containing
+      // exactly the tag (optionally indented if stripTabs).
+      while (j < chars.length && chars[j] !== '\n') {
+        out[j] = chars[j];
+        j += 1;
+      }
+      if (j < chars.length) {
+        out[j] = '\n';
+        j += 1;
+      }
+      // Mask body line-by-line until a line matches the tag exactly.
+      // Newlines inside the body are ALSO masked so `splitSegments`
+      // does not treat the body as extra segments.
+      while (j < chars.length) {
+        const lineStart = j;
+        let lineEnd = j;
+        while (lineEnd < chars.length && chars[lineEnd] !== '\n') {
+          lineEnd += 1;
+        }
+        let line = input.slice(lineStart, lineEnd);
+        if (stripTabs) {
+          line = line.replace(/^\t+/, '');
+        }
+        if (line === tag) {
+          // Terminator — mask the tag line and its terminating newline
+          // so the entire heredoc contributes zero extra tokens.
+          for (let k = lineStart; k < lineEnd; k += 1) {
+            out[k] = FILLER;
+          }
+          if (lineEnd < chars.length) {
+            out[lineEnd] = FILLER;
+          }
+          j = lineEnd + 1;
+          break;
+        }
+        // Mask the body line (including its terminating newline).
+        for (let k = lineStart; k < lineEnd; k += 1) {
+          out[k] = FILLER;
+        }
+        if (lineEnd < chars.length) {
+          out[lineEnd] = FILLER;
+        }
+        j = lineEnd + 1;
+      }
+      i = j;
+      continue;
+    }
+
+    // Quoted ranges: '...', "...", `...`.
+    if (c === "'" || c === '"' || c === '`') {
+      out[i] = c;
+      let j = i + 1;
+      while (j < chars.length && chars[j] !== c) {
+        if (c === '"' && chars[j] === '\\' && j + 1 < chars.length) {
+          out[j] = FILLER;
+          out[j + 1] = FILLER;
+          j += 2;
+          continue;
+        }
+        out[j] = preserve(chars[j]) ? chars[j] : FILLER;
+        j += 1;
+      }
+      if (j < chars.length) {
+        out[j] = c;
+        j += 1;
+      }
+      i = j;
+      continue;
+    }
+
+    out[i] = c;
+    i += 1;
+  }
+
+  return out.join('');
+}
+
+// ============ Splitting ============
+
+const SEGMENT_SEPARATORS = /(?:\|\||&&|;|\||&|\n)/g;
+
+/**
+ * Split the masked command into segments on shell control operators.
+ * Empty segments are dropped. Whitespace is trimmed.
+ */
+function splitSegments(masked: string): string[] {
+  return masked
+    .split(SEGMENT_SEPARATORS)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .filter((s) => s.replace(FILLER_ONLY_RE, '').trim().length > 0);
+}
+
+// ============ Redirect analysis ============
+
+/**
+ * A redirect target is safe if it targets `/dev/*` or `/tmp/*` AND does
+ * not contain `..` path traversal. Everything else is considered a real
+ * filesystem write and blocked.
+ */
+function isRedirectTargetSafe(target: string): boolean {
+  const trimmed = target.trim().replace(/^["']|["']$/g, '');
+  if (trimmed.length === 0) {
+    return false;
+  }
+  if (trimmed.includes('..')) {
+    return false;
+  }
+  if (trimmed.startsWith('/dev/') || trimmed === '/dev/null') {
+    return true;
+  }
+  if (trimmed.startsWith('/tmp/') || trimmed === '/tmp') {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Reject segments containing an output redirect to a real filesystem
+ * path. `<` (input redirect) is fine; `>`, `>>`, `<>` are output-mutating.
+ *
+ * Matches numeric fd prefixes (`2>`, `&>`) too.
+ */
+function hasUnsafeRedirect(segment: string): boolean {
+  const re = /(?:\d*&?>{1,2}|<>)\s*(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(segment)) !== null) {
+    const target = match[1];
+    if (!isRedirectTargetSafe(target)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ============ Segment-level analysis ============
+
+/** Tokenise a segment by whitespace, dropping tokens that are only FILLER. */
+function tokenise(segment: string): string[] {
+  return segment
+    .split(/\s+/)
+    .map((t) => t.replace(FILLER_ONLY_RE, ''))
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Some commands are otherwise read-only but have flag combinations that
+ * mutate the filesystem. Return `true` if the mutating variant is
+ * detected on the given argv.
+ */
+function hasMutatingFlags(cmd: string, args: string[]): boolean {
+  switch (cmd) {
+    case 'sed':
+    case 'gsed':
+      // -i / --in-place
+      return args.some((a) => a === '-i' || a === '--in-place' || /^-i[^\s]*/.test(a));
+    case 'perl':
+      // -i / -i.bak
+      return args.some((a) => a === '-i' || /^-i\..+/.test(a));
+    case 'gawk':
+    case 'awk':
+      // -i inplace (gawk) or -i /path/to/inplace
+      return args.some((a, idx) => a === '-i' && (args[idx + 1] ?? '').includes('inplace'));
+    case 'sort':
+      // -o FILE writes result to FILE. Any `-o` presence is treated as
+      // mutating unless the target is a safe path (/dev/*, /tmp/*).
+      return args.some((a, idx) => {
+        if (a === '-o' || a === '--output') {
+          return !isRedirectTargetSafe(args[idx + 1] ?? '');
+        }
+        if (a.startsWith('--output=')) {
+          return !isRedirectTargetSafe(a.slice('--output='.length));
+        }
+        if (/^-o./.test(a)) {
+          return true;
+        }
+        return false;
+      });
+    case 'find':
+      // -delete, -exec ... {} (dangerous), -execdir
+      return args.some((a) => a === '-delete' || a === '-exec' || a === '-execdir' || a === '-ok');
+    case 'xargs': {
+      // xargs <cmd>: the tail after xargs flags is the command being fed.
+      // Find the first non-flag argument — that's the sub-command.
+      let sub: string | undefined;
+      for (let i = 0; i < args.length; i += 1) {
+        const a = args[i];
+        if (a.startsWith('-')) {
+          // -I {} / -n 1 / -0 etc. Skip the arg after -I, -n, -P, -L, -s if any.
+          if (['-I', '-i', '-n', '-P', '-L', '-s', '-a', '-E', '-d'].includes(a)) {
+            i += 1;
+          }
+          continue;
+        }
+        sub = a;
+        break;
+      }
+      if (!sub) {
+        return false;
+      }
+      // The inner command must itself be read-only.
+      return !isSingleCommandReadOnly(sub, args.slice(args.indexOf(sub) + 1));
+    }
+    case 'tar':
+      // Extract / create writes files; only `-t` / `--list` is read-only.
+      return !args.some((a) => a === '-t' || a === '--list' || /^-[^-]*t/.test(a));
+    case 'zip':
+    case 'gzip':
+    case 'bzip2':
+    case 'xz':
+    case 'zstd':
+      // Compression writes files.
+      return !args.some((a) => a === '-l' || a === '--list' || a === '-t' || a === '--test');
+    case 'unzip':
+      // Only `-l` (list) is read-only.
+      return !args.some((a) => a === '-l' || a === '-t');
+    case 'python':
+    case 'python3':
+    case 'node':
+    case 'ruby': {
+      // Running arbitrary scripts can do anything. Only allow `-V` /
+      // `--version` / `--help`. Also treat `-i` / `-i.bak` as an
+      // in-place mutation for `ruby` / `perl`-style invocations.
+      if (args.some((a) => a === '-i' || /^-i\..+/.test(a))) {
+        return true;
+      }
+      return !args.every((a) => /^--?v(ersion)?$/.test(a) || /^--help$/.test(a) || a === '-h');
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Return true when the given command + args is a read-only invocation.
+ *
+ * Called for the top-level segment token and, recursively, for the inner
+ * command of `xargs`.
+ */
+function isSingleCommandReadOnly(cmd: string, args: string[]): boolean {
+  // Strip any FILLER prefix (shouldn't happen, but be defensive).
+  const bare = cmd.replace(FILLER_ONLY_RE, '').trim();
+  if (bare.length === 0) {
+    return false;
+  }
+
+  // Package managers are always blocked in plan mode.
+  if (BLOCKED_PACKAGE_MANAGERS.has(bare)) {
+    return false;
+  }
+
+  // Hard blocks (rm, sudo, sh -c, ...).
+  if (BLOCKED_COMMANDS.has(bare)) {
+    return false;
+  }
+
+  // Must be on the read-only allowlist.
+  if (!READ_ONLY_COMMANDS.has(bare)) {
+    return false;
+  }
+
+  // Special handling for `git <subcmd>`.
+  if (bare === 'git') {
+    // Ignore leading global flags like `git -C /path` and `git --no-pager`.
+    let idx = 0;
+    while (idx < args.length) {
+      const a = args[idx];
+      if (a === '-C' || a === '--git-dir' || a === '--work-tree') {
+        idx += 2;
+        continue;
+      }
+      if (a.startsWith('-')) {
+        idx += 1;
+        continue;
+      }
+      break;
+    }
+    const sub1 = args[idx];
+    const sub2 = args[idx + 1];
+    if (!sub1) {
+      // `git` alone prints help, treat as read-only.
+      return true;
+    }
+    const twoWord = sub2 ? `${sub1} ${sub2}` : '';
+    // Explicit mutating phrase wins.
+    if (MUTATING_GIT_SUBCOMMANDS.has(sub1) || (twoWord && MUTATING_GIT_SUBCOMMANDS.has(twoWord))) {
+      return false;
+    }
+    // Composite phrases like `stash list` must match on the two-word form.
+    if (twoWord && READ_ONLY_GIT_SUBCOMMANDS.has(twoWord)) {
+      return true;
+    }
+    if (READ_ONLY_GIT_SUBCOMMANDS.has(sub1)) {
+      return true;
+    }
+    // Unknown git subcommand — be conservative.
+    return false;
+  }
+
+  // Check per-command mutating flag combinations.
+  if (hasMutatingFlags(bare, args)) {
+    return false;
+  }
+
+  return true;
+}
+
+/** Analyse a single segment. */
+function isSegmentReadOnly(rawSegment: string, maskedSegment: string): boolean {
+  if (hasUnsafeRedirect(rawSegment)) {
+    return false;
+  }
+  const tokens = tokenise(maskedSegment);
+  if (tokens.length === 0) {
+    return false;
+  }
+  // Strip leading env var assignments like `FOO=bar cmd ...`.
+  let i = 0;
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) {
+    i += 1;
+  }
+  const cmdTok = tokens[i];
+  if (!cmdTok) {
+    return false;
+  }
+  const rest = tokens.slice(i + 1);
+  return isSingleCommandReadOnly(cmdTok, rest);
+}
+
+// ============ Public API ============
+
+/**
+ * Return `true` if the given shell command is safe to execute in a
+ * read-only plan-mode context (does not modify files, VCS state, or
+ * network state).
+ *
+ * The command may contain multiple segments joined by `;`, `|`, `&&`,
+ * `||`, `&`, or newlines. Every segment must be individually read-only
+ * for the whole command to be considered read-only.
+ */
+export function isCommandReadOnly(command: string): boolean {
+  if (typeof command !== 'string') {
+    return false;
+  }
+  const trimmed = command.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+
+  const masked = maskLiterals(trimmed);
+  // Reject command-substitution which could hide anything: `$(...)`, `<(...)`.
+  if (/\$\(/.test(masked) || /<\(/.test(masked) || />\(/.test(masked)) {
+    return false;
+  }
+
+  const segments = splitSegments(masked);
+  if (segments.length === 0) {
+    return false;
+  }
+
+  // Also split the raw command in parallel so redirect analysis can see
+  // the actual path text (masking wipes it).
+  const rawSegments = splitSegments(trimmed);
+  for (let i = 0; i < segments.length; i += 1) {
+    const raw = rawSegments[i] ?? segments[i];
+    if (!isSegmentReadOnly(raw, segments[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// ============ Test hooks ============
+
+/**
+ * @internal Exposed for unit tests only. Not part of the public API.
+ */
+export const _testing = {
+  maskLiterals,
+  splitSegments,
+  isRedirectTargetSafe,
+  hasUnsafeRedirect,
+};

--- a/src/tool/tools/bash.ts
+++ b/src/tool/tools/bash.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import { defineTool, truncateOutput, persistLargeOutput, type ToolResult } from '../index.js';
 import { normalizeUrls } from '../../utils/url.js';
 import { auditCommand } from '../../permission/next.js';
+import { getPlanModeManager } from '../../plan/index.js';
 import { detectShell, shellSpawnArgs, type ShellInfo } from './shell/id.js';
 import { detectShellEnv, formatShellEnvSummary } from './shell/env.js';
 import {
@@ -167,6 +168,19 @@ const bashToolBase = defineTool<typeof BashParamsSchema, BashResult>({
         ? params.workdir
         : path.join(context.workdir, params.workdir)
       : context.workdir;
+
+    // Pre-flight plan-mode check: in plan mode, bash is only permitted
+    // when the command is a read-only investigation command (ls, cat,
+    // grep, git status, ...) and `allowReadOnlyBash` is enabled. See
+    // `src/plan/index.ts` and `src/tool/tools/bash-command-parser.ts`.
+    const planManager = getPlanModeManager();
+    if (!planManager.checkToolExecution('bash', params.command)) {
+      return {
+        success: false,
+        error: `Tool 'bash' is blocked in plan mode. Use /mode build to switch to build mode.`,
+        data: { stdout: '', stderr: '', exitCode: -1, timedOut: false },
+      };
+    }
 
     // Pre-flight audit: detect directory-mutating builtins (`cd`, `pushd`,
     // `popd`, `chdir`, parenthesised subshells, `OLDPWD=…; cd -`) that

--- a/tests/tool/tools/bash-command-parser.test.ts
+++ b/tests/tool/tools/bash-command-parser.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Unit tests for the read-only bash command parser used by plan mode.
+ *
+ * Verifies that `isCommandReadOnly` correctly distinguishes
+ * investigation commands (allowed in plan mode) from any command that
+ * modifies files, VCS state, package manager state, or the network.
+ *
+ * Ported concepts from kilocode #12906.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isCommandReadOnly, _testing } from '../../../src/tool/tools/bash-command-parser.js';
+
+describe('isCommandReadOnly - read-only commands allowed', () => {
+  it.each([
+    'ls',
+    'ls -la',
+    'ls /tmp',
+    'cat README.md',
+    'head -n 20 file.txt',
+    'tail -f logs.txt',
+    'grep -r foo src',
+    'rg foo src',
+    'pwd',
+    'echo hello world',
+    'find src -name "*.ts"',
+    'wc -l file.txt',
+    'diff a.txt b.txt',
+    'du -sh .',
+    'df -h',
+    'stat file.txt',
+    'which node',
+    'date',
+    'uname -a',
+  ])('allows: %s', (cmd) => {
+    expect(isCommandReadOnly(cmd)).toBe(true);
+  });
+});
+
+describe('isCommandReadOnly - git subcommands', () => {
+  it.each([
+    'git status',
+    'git log',
+    'git log --oneline -20',
+    'git diff',
+    'git diff HEAD~1',
+    'git show HEAD',
+    'git branch',
+    'git tag',
+    'git remote',
+    'git ls-files',
+    'git stash list',
+    'git worktree list',
+    'git submodule status',
+    'git help',
+    'git -C /tmp/repo status',
+    'git --no-pager log',
+  ])('allows read-only git: %s', (cmd) => {
+    expect(isCommandReadOnly(cmd)).toBe(true);
+  });
+
+  it.each([
+    'git add .',
+    'git commit -m "wip"',
+    'git push origin master',
+    'git pull',
+    'git fetch',
+    'git merge feature',
+    'git rebase master',
+    'git cherry-pick abc123',
+    'git revert HEAD',
+    'git reset --hard',
+    'git checkout master',
+    'git switch feature',
+    'git restore file.txt',
+    'git clean -fdx',
+    'git stash save "wip"',
+    'git stash push',
+    'git stash apply',
+    'git stash pop',
+    'git stash drop',
+    'git stash clear',
+  ])('blocks mutating git: %s', (cmd) => {
+    expect(isCommandReadOnly(cmd)).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - write commands blocked', () => {
+  it.each([
+    'rm file.txt',
+    'rm -rf /tmp/foo',
+    'mv a.txt b.txt',
+    'cp a.txt b.txt',
+    'tee output.txt',
+    'touch newfile.txt',
+    'truncate -s 0 file.txt',
+    'chmod +x script.sh',
+    'chown user:user file',
+    'mkdir newdir',
+    'rmdir olddir',
+    'ln -s source target',
+    'dd if=/dev/zero of=file bs=1M',
+  ])('blocks: %s', (cmd) => {
+    expect(isCommandReadOnly(cmd)).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - in-place editors blocked', () => {
+  it('blocks sed -i', () => {
+    expect(isCommandReadOnly('sed -i s/foo/bar/g file.txt')).toBe(false);
+  });
+
+  it('blocks sed --in-place', () => {
+    expect(isCommandReadOnly('sed --in-place s/foo/bar/g file.txt')).toBe(false);
+  });
+
+  it('allows sed without -i', () => {
+    expect(isCommandReadOnly('sed s/foo/bar/g file.txt')).toBe(true);
+  });
+
+  it('blocks perl -i', () => {
+    expect(isCommandReadOnly('perl -i -pe s/foo/bar/g file.txt')).toBe(false);
+  });
+
+  it('blocks perl -i.bak', () => {
+    expect(isCommandReadOnly('perl -i.bak -pe s/foo/bar/g file.txt')).toBe(false);
+  });
+
+  it('blocks gawk -i inplace', () => {
+    expect(isCommandReadOnly('gawk -i inplace {print} file.txt')).toBe(false);
+  });
+
+  it('blocks sort -o', () => {
+    expect(isCommandReadOnly('sort -o out.txt in.txt')).toBe(false);
+  });
+
+  it('allows sort without -o', () => {
+    expect(isCommandReadOnly('sort in.txt')).toBe(true);
+  });
+});
+
+describe('isCommandReadOnly - output redirects', () => {
+  it('blocks > to file path', () => {
+    expect(isCommandReadOnly('echo hello > out.txt')).toBe(false);
+  });
+
+  it('blocks >> to file path', () => {
+    expect(isCommandReadOnly('echo hello >> out.txt')).toBe(false);
+  });
+
+  it('blocks stderr redirect 2> to file', () => {
+    expect(isCommandReadOnly('ls foo 2> err.txt')).toBe(false);
+  });
+
+  it('allows > /dev/null', () => {
+    expect(isCommandReadOnly('echo hi > /dev/null')).toBe(true);
+  });
+
+  it('allows 2> /dev/null', () => {
+    expect(isCommandReadOnly('ls /nonexistent 2> /dev/null')).toBe(true);
+  });
+
+  it('allows > /tmp/foo', () => {
+    expect(isCommandReadOnly('echo hi > /tmp/foo')).toBe(true);
+  });
+
+  it('rejects .. traversal in /tmp redirect', () => {
+    expect(isCommandReadOnly('echo hi > /tmp/../etc/passwd')).toBe(false);
+  });
+
+  it('rejects .. traversal in /dev redirect', () => {
+    expect(isCommandReadOnly('echo hi > /dev/../etc/passwd')).toBe(false);
+  });
+
+  it('blocks <> read-write redirect', () => {
+    expect(isCommandReadOnly('cat <> file.txt')).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - package managers blocked', () => {
+  it.each([
+    'npm install',
+    'npm i lodash',
+    'npm ls',
+    'pnpm install',
+    'yarn add react',
+    'pip install requests',
+    'pip3 install pytest',
+    'cargo install ripgrep',
+    'cargo build',
+    'gem install bundler',
+    'apt install curl',
+    'brew install jq',
+    'docker run -it alpine',
+    'kubectl apply -f pod.yaml',
+    'terraform apply',
+  ])('blocks package manager: %s', (cmd) => {
+    expect(isCommandReadOnly(cmd)).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - find flags', () => {
+  it('allows find with -name', () => {
+    expect(isCommandReadOnly('find . -name "*.ts"')).toBe(true);
+  });
+
+  it('blocks find -delete', () => {
+    expect(isCommandReadOnly('find . -name "*.tmp" -delete')).toBe(false);
+  });
+
+  it('blocks find -exec', () => {
+    expect(isCommandReadOnly('find . -name "*.tmp" -exec rm {} \\;')).toBe(false);
+  });
+
+  it('blocks find -execdir', () => {
+    expect(isCommandReadOnly('find . -name x -execdir rm {} \\;')).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - xargs', () => {
+  it('allows xargs with read-only inner command', () => {
+    expect(isCommandReadOnly('ls | xargs echo')).toBe(true);
+  });
+
+  it('allows xargs cat', () => {
+    expect(isCommandReadOnly('ls *.md | xargs cat')).toBe(true);
+  });
+
+  it('blocks xargs rm', () => {
+    expect(isCommandReadOnly('ls | xargs rm')).toBe(false);
+  });
+
+  it('blocks xargs mv', () => {
+    expect(isCommandReadOnly('ls | xargs -I {} mv {} /tmp')).toBe(false);
+  });
+
+  it('blocks xargs sh -c', () => {
+    expect(isCommandReadOnly('echo foo | xargs sh -c "rm $1"')).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - nested shells and eval', () => {
+  it.each([
+    'sh -c "ls"',
+    'bash -c "cat file"',
+    'zsh -c pwd',
+    'eval "ls"',
+    'sudo ls',
+    'sudo -u root ls',
+    'source setup.sh',
+    '. setup.sh',
+  ])('blocks nested shell / eval / sudo: %s', (cmd) => {
+    expect(isCommandReadOnly(cmd)).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - quoting and masking', () => {
+  it('does NOT trip on "rm" inside a double-quoted echo argument', () => {
+    expect(isCommandReadOnly('echo "rm foo.txt"')).toBe(true);
+  });
+
+  it('does NOT trip on rm inside a single-quoted echo argument', () => {
+    expect(isCommandReadOnly("echo 'rm foo.txt'")).toBe(true);
+  });
+
+  it('does NOT trip on rm inside a heredoc body', () => {
+    const cmd = 'cat <<EOF\nrm foo.txt\nEOF';
+    expect(isCommandReadOnly(cmd)).toBe(true);
+  });
+
+  it('does NOT trip on rm inside an indented heredoc body with <<-', () => {
+    const cmd = 'cat <<-EOF\n\trm foo.txt\n\tEOF';
+    expect(isCommandReadOnly(cmd)).toBe(true);
+  });
+
+  it('does NOT trip on rm inside a comment', () => {
+    expect(isCommandReadOnly('ls # rm foo.txt')).toBe(true);
+  });
+
+  it('blocks command substitution $(...)', () => {
+    expect(isCommandReadOnly('echo $(rm foo)')).toBe(false);
+  });
+
+  it('blocks process substitution <(...)', () => {
+    expect(isCommandReadOnly('diff <(ls) <(ls -a)')).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - pipelines and separators', () => {
+  it('allows a fully read-only pipeline', () => {
+    expect(isCommandReadOnly('ls | grep foo | wc -l')).toBe(true);
+  });
+
+  it('blocks a pipeline where any stage mutates', () => {
+    expect(isCommandReadOnly('ls | tee out.txt')).toBe(false);
+  });
+
+  it('allows chained read-only commands with ;', () => {
+    expect(isCommandReadOnly('pwd; ls; date')).toBe(true);
+  });
+
+  it('blocks chained commands when any is mutating', () => {
+    expect(isCommandReadOnly('pwd; rm file.txt')).toBe(false);
+  });
+
+  it('blocks && when second command mutates', () => {
+    expect(isCommandReadOnly('ls && rm foo')).toBe(false);
+  });
+
+  it('allows && when both sides are read-only', () => {
+    expect(isCommandReadOnly('ls && pwd')).toBe(true);
+  });
+
+  it('blocks background & when command mutates', () => {
+    expect(isCommandReadOnly('rm foo &')).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - env var assignments', () => {
+  it('allows env-prefixed read-only command', () => {
+    expect(isCommandReadOnly('FOO=bar ls')).toBe(true);
+  });
+
+  it('blocks env-prefixed mutating command', () => {
+    expect(isCommandReadOnly('FOO=bar rm x')).toBe(false);
+  });
+});
+
+describe('isCommandReadOnly - edge cases', () => {
+  it('rejects empty string', () => {
+    expect(isCommandReadOnly('')).toBe(false);
+  });
+
+  it('rejects whitespace-only string', () => {
+    expect(isCommandReadOnly('   ')).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    // deliberately violating types
+    expect(isCommandReadOnly(undefined as unknown as string)).toBe(false);
+    expect(isCommandReadOnly(null as unknown as string)).toBe(false);
+    expect(isCommandReadOnly(42 as unknown as string)).toBe(false);
+  });
+
+  it('rejects unknown commands (conservative default)', () => {
+    expect(isCommandReadOnly('my-random-tool --do-something')).toBe(false);
+  });
+
+  it('allows git alone', () => {
+    expect(isCommandReadOnly('git')).toBe(true);
+  });
+
+  it('blocks node with arbitrary script', () => {
+    expect(isCommandReadOnly('node script.js')).toBe(false);
+  });
+
+  it('allows node --version', () => {
+    expect(isCommandReadOnly('node --version')).toBe(true);
+  });
+});
+
+describe('isCommandReadOnly - internal helpers', () => {
+  it('maskLiterals preserves length', () => {
+    const input = 'echo "hi there" # comment';
+    const masked = _testing.maskLiterals(input);
+    expect(masked.length).toBe(input.length);
+  });
+
+  it('isRedirectTargetSafe accepts /dev/null', () => {
+    expect(_testing.isRedirectTargetSafe('/dev/null')).toBe(true);
+  });
+
+  it('isRedirectTargetSafe rejects relative paths', () => {
+    expect(_testing.isRedirectTargetSafe('foo.txt')).toBe(false);
+  });
+
+  it('isRedirectTargetSafe rejects .. traversal', () => {
+    expect(_testing.isRedirectTargetSafe('/tmp/../etc/passwd')).toBe(false);
+  });
+
+  it('splitSegments splits on ; | && || & and newlines', () => {
+    const segs = _testing.splitSegments('a ; b | c && d || e & f\ng');
+    expect(segs).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+  });
+});

--- a/tests/tool/tools/bash-planmode-allowlist.test.ts
+++ b/tests/tool/tools/bash-planmode-allowlist.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Integration tests for the plan-mode read-only bash allowlist.
+ *
+ * Exercises `PlanModeManager.checkToolExecution` with real command
+ * strings under the three interesting configurations:
+ *
+ * 1. Plan mode + `allowReadOnlyBash: true`  — read-only bash allowed,
+ *    mutating bash still blocked.
+ * 2. Plan mode + `allowReadOnlyBash: false` — all bash blocked (default).
+ * 3. Build mode                              — all bash allowed
+ *    regardless of the config.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getPlanModeManager,
+  configurePlanMode,
+  resetPlanModeConfig,
+} from '../../../src/plan/index.js';
+
+describe('plan-mode read-only bash allowlist', () => {
+  beforeEach(() => {
+    // Fresh manager state each test.
+    getPlanModeManager().setMode('build');
+    resetPlanModeConfig();
+  });
+
+  afterEach(() => {
+    getPlanModeManager().setMode('build');
+    resetPlanModeConfig();
+  });
+
+  describe('plan mode + allowReadOnlyBash=true', () => {
+    beforeEach(() => {
+      configurePlanMode({ allowReadOnlyBash: true });
+      getPlanModeManager().setMode('plan');
+    });
+
+    it('allows read-only bash commands', () => {
+      const mgr = getPlanModeManager();
+      expect(mgr.checkToolExecution('bash', 'ls -la')).toBe(true);
+      expect(mgr.checkToolExecution('bash', 'cat README.md')).toBe(true);
+      expect(mgr.checkToolExecution('bash', 'grep -r foo src')).toBe(true);
+      expect(mgr.checkToolExecution('bash', 'git status')).toBe(true);
+      expect(mgr.checkToolExecution('bash', 'git log --oneline -20')).toBe(true);
+    });
+
+    it('blocks mutating bash commands', () => {
+      const mgr = getPlanModeManager();
+      expect(mgr.checkToolExecution('bash', 'rm file.txt')).toBe(false);
+      expect(mgr.checkToolExecution('bash', 'git commit -m wip')).toBe(false);
+      expect(mgr.checkToolExecution('bash', 'sed -i s/x/y/ file')).toBe(false);
+      expect(mgr.checkToolExecution('bash', 'echo hi > out.txt')).toBe(false);
+      expect(mgr.checkToolExecution('bash', 'npm install lodash')).toBe(false);
+    });
+
+    it('blocks bash entirely if no command string is supplied', () => {
+      const mgr = getPlanModeManager();
+      expect(mgr.checkToolExecution('bash')).toBe(false);
+    });
+
+    it('still blocks non-bash write tools', () => {
+      const mgr = getPlanModeManager();
+      expect(mgr.checkToolExecution('write')).toBe(false);
+      expect(mgr.checkToolExecution('edit')).toBe(false);
+    });
+  });
+
+  describe('plan mode + allowReadOnlyBash=false (default)', () => {
+    beforeEach(() => {
+      getPlanModeManager().setMode('plan');
+    });
+
+    it('blocks ALL bash commands, including read-only ones', () => {
+      const mgr = getPlanModeManager();
+      expect(mgr.checkToolExecution('bash', 'ls -la')).toBe(false);
+      expect(mgr.checkToolExecution('bash', 'cat README.md')).toBe(false);
+      expect(mgr.checkToolExecution('bash', 'git status')).toBe(false);
+      expect(mgr.checkToolExecution('bash', 'rm file.txt')).toBe(false);
+    });
+  });
+
+  describe('build mode', () => {
+    beforeEach(() => {
+      configurePlanMode({ allowReadOnlyBash: true });
+      getPlanModeManager().setMode('build');
+    });
+
+    it('allows all bash commands regardless of allowReadOnlyBash', () => {
+      const mgr = getPlanModeManager();
+      expect(mgr.checkToolExecution('bash', 'ls')).toBe(true);
+      expect(mgr.checkToolExecution('bash', 'rm file.txt')).toBe(true);
+      expect(mgr.checkToolExecution('bash', 'git commit -m wip')).toBe(true);
+      expect(mgr.checkToolExecution('bash')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1283

## Summary

Adds a bash command parser (`src/tool/tools/bash-command-parser.ts`) that classifies shell commands as read-only investigation vs mutating. When plan mode is active AND `allowReadOnlyBash` config is enabled, read-only commands (ls, cat, grep, git status, git log, git diff, ...) are permitted while commands that touch the filesystem, VCS state, or install packages are blocked.

## Implementation

- Parser masks quoted text, heredoc bodies (including `<<-` variants), escapes, and comments so tokens inside them cannot false-positive against the allowlist.
- Splits on shell control operators (`;`, `|`, `||`, `&&`, `&`, newline) and requires every segment to be independently read-only.
- Handles `git` subcommand phrases (`git status` vs `git commit`; `git stash list` vs `git stash push`) explicitly.
- Rejects in-place editors (`sed -i`, `perl -i`, `gawk -i inplace`, `sort -o`), `find -delete`, `xargs rm`, command substitution `$(...)`, `<(...)`, `>(...)`, package-manager invocations (npm, pip, cargo, docker, ...).
- Redirect analysis allows `/dev/*` and `/tmp/*` targets but rejects any path containing `..` traversal.

## Wiring

- `src/plan/index.ts`: `PlanModeManager.checkToolExecution(toolName, command?)` accepts an optional command string and consults `isCommandReadOnly` when `allowReadOnlyBash` is set. `withToolCheck` also forwards the command.
- `src/tool/tools/bash.ts`: pre-flight plan-mode check before spawning; bash tool now gates on the plan-mode decision.

## Tests

- `tests/tool/tools/bash-command-parser.test.ts` — 145 test cases covering allowlists, blocklists, in-place editors, redirects, package managers, find flags, xargs, nested shells, quoting/heredoc/comment masking, pipelines, env-prefix assignments, edge cases, and internal helpers.
- `tests/tool/tools/bash-planmode-allowlist.test.ts` — 6 integration tests for plan+allow, plan+deny, build mode; verifies non-bash write tools remain blocked.

## Gates

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm run test:coverage` — 3669 passed, lines 67.03% (well above 40% CI threshold)
- `npm run build` — clean