### PR TITLE
feat(providers): centralize portable reasoning resolution

### DIFF
--- a/src/providers/__tests__/deepseek.test.ts
+++ b/src/providers/__tests__/deepseek.test.ts
@@ -63,6 +63,50 @@ describe('buildDeepSeekRequest', () => {
     });
   });
 
+  describe('portable reasoning integration', () => {
+    it("collapses portable 'max' (xhigh) to 'high' on levels-mode models", () => {
+      // DeepSeek's reasoning_effort field caps at 'high'; the portable
+      // resolver normalizes 'max' -> 'xhigh', which we down-cast to 'high'
+      // here because DeepSeek has no higher tier.
+      const request = buildDeepSeekRequest(messages, {
+        reasoningEffort: 'max',
+        modelId: 'deepseek-r1',
+      });
+      expect(request.reasoning_effort).toBe('high');
+      expect(request.enable_thinking).toBeUndefined();
+    });
+
+    it("treats enabled=true (no explicit level) as 'medium' default", () => {
+      const request = buildDeepSeekRequest(messages, {
+        reasoningEnabled: true,
+        modelId: 'deepseek-r1',
+      });
+      expect(request.reasoning_effort).toBe('medium');
+      expect(request.enable_thinking).toBeUndefined();
+    });
+
+    it('honors explicit disable (enabled=false) by dropping reasoning fields', () => {
+      // Even with a level supplied, explicit disable wins — providers must
+      // be able to turn native reasoning off deterministically.
+      const request = buildDeepSeekRequest(messages, {
+        reasoningEffort: 'high',
+        reasoningEnabled: false,
+        modelId: 'deepseek-r1',
+      });
+      expect(request.reasoning_effort).toBeUndefined();
+      expect(request.enable_thinking).toBeUndefined();
+    });
+
+    it("still routes to enable_thinking on 'binary' mode when max is requested", () => {
+      const request = buildDeepSeekRequest(messages, {
+        reasoningEffort: 'max',
+        modelId: 'binary-thinker-v1',
+      });
+      expect(request.enable_thinking).toBe(true);
+      expect(request.reasoning_effort).toBeUndefined();
+    });
+  });
+
   describe('max_tokens handling (unchanged)', () => {
     it('forwards numeric max_tokens', () => {
       const request = buildDeepSeekRequest(messages, { maxTokens: 256 });

--- a/src/providers/__tests__/reasoning.test.ts
+++ b/src/providers/__tests__/reasoning.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePortableReasoning } from '../reasoning.js';
+
+describe('resolvePortableReasoning', () => {
+  describe('effort level mapping', () => {
+    it('maps low to low', () => {
+      expect(resolvePortableReasoning('low')).toEqual({ effort: 'low' });
+    });
+
+    it('maps medium to medium', () => {
+      expect(resolvePortableReasoning('medium')).toEqual({ effort: 'medium' });
+    });
+
+    it('maps high to high', () => {
+      expect(resolvePortableReasoning('high')).toEqual({ effort: 'high' });
+    });
+
+    it('normalizes max to xhigh (Cline PR #12946 convention)', () => {
+      expect(resolvePortableReasoning('max')).toEqual({ effort: 'xhigh' });
+    });
+  });
+
+  describe('explicit enable/disable', () => {
+    it('maps enabled=true (no level) to medium default', () => {
+      expect(resolvePortableReasoning(undefined, true)).toEqual({ effort: 'medium' });
+    });
+
+    it('maps enabled=false (no level) to none', () => {
+      expect(resolvePortableReasoning(undefined, false)).toEqual({ effort: 'none' });
+    });
+
+    it('explicit disable (enabled=false) overrides an effort level', () => {
+      // Callers may pass both; the explicit disable should win so providers
+      // can turn native reasoning off deterministically.
+      expect(resolvePortableReasoning('high', false)).toEqual({ effort: 'none' });
+    });
+
+    it('effort level with enabled=true prefers the level (level is more specific)', () => {
+      expect(resolvePortableReasoning('low', true)).toEqual({ effort: 'low' });
+    });
+  });
+
+  describe('no reasoning requested', () => {
+    it('returns undefined when neither effortLevel nor enabled is provided', () => {
+      expect(resolvePortableReasoning()).toBeUndefined();
+    });
+
+    it('returns undefined when both args are undefined', () => {
+      expect(resolvePortableReasoning(undefined, undefined)).toBeUndefined();
+    });
+  });
+
+  describe('shape invariants', () => {
+    it('always returns an object with a single effort field when defined', () => {
+      const result = resolvePortableReasoning('medium');
+      expect(result).toBeDefined();
+      expect(Object.keys(result as object)).toEqual(['effort']);
+    });
+
+    it('never emits max on the wire (always normalized)', () => {
+      const result = resolvePortableReasoning('max');
+      expect(result?.effort).not.toBe('max');
+      expect(result?.effort).toBe('xhigh');
+    });
+  });
+});

--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -4,6 +4,7 @@
  */
 
 import { modelSupportsReasoningEffort } from './model-match.js';
+import { resolvePortableReasoning, type ReasoningEffortLevel } from './reasoning.js';
 
 interface Message {
   role: string;
@@ -20,12 +21,32 @@ interface ProviderRequest {
 
 export interface DeepSeekOptions {
   maxTokens?: number | 'max';
-  reasoningEffort?: 'low' | 'medium' | 'high';
+  reasoningEffort?: ReasoningEffortLevel;
+  /**
+   * Optional explicit reasoning toggle. Passed through to
+   * {@link resolvePortableReasoning} for the "enable with default" and
+   * "explicit off" contracts. Existing callers that only pass
+   * `reasoningEffort` are unaffected.
+   */
+  reasoningEnabled?: boolean;
   modelId?: string;
 }
 
 /**
- * Build DeepSeek-specific request with special token handling
+ * Build DeepSeek-specific request with special token handling.
+ *
+ * Reasoning handling:
+ * - Portable resolution happens first via {@link resolvePortableReasoning}
+ *   so the effort/enabled contract stays aligned with other providers.
+ * - The resolved portable option is then adapted to DeepSeek's wire
+ *   format according to the model's capability:
+ *     - "levels"  -> emit `reasoning_effort` (mapping `xhigh` -> `high`,
+ *                    which is the highest tier DeepSeek accepts on the
+ *                    `reasoning_effort` field).
+ *     - "binary"  -> emit `enable_thinking: true` and drop the level.
+ *     - "none"    -> do nothing.
+ * - An explicit portable disable (`effort: 'none'`) leaves both fields
+ *   unset so DeepSeek defaults apply.
  */
 export function buildDeepSeekRequest(
   messages: Message[],
@@ -38,18 +59,25 @@ export function buildDeepSeekRequest(
   // Handle special "max" value for max_tokens
   if (options.maxTokens === 'max') {
     // Let provider use maximum - DeepSeek supports "max" as special value
-    request.max_completion_tokens = 'max' as any;
+    request.max_completion_tokens = 'max' as unknown as number | 'max';
   } else if (options.maxTokens) {
     request.max_tokens = options.maxTokens;
   }
 
-  // Dispatch reasoning_effort handling on per-model capability.
-  // When modelId is omitted, default to 'levels' to preserve existing
-  // DeepSeek behaviour bit-for-bit.
-  if (options.reasoningEffort) {
+  // Centralized portable reasoning resolution. Providers-specific dispatch
+  // (levels vs binary vs none) happens after the resolver so behaviour
+  // stays bit-for-bit compatible with existing DeepSeek callers.
+  const portable = resolvePortableReasoning(options.reasoningEffort, options.reasoningEnabled);
+  if (portable && portable.effort !== 'none') {
+    // When modelId is omitted, default to 'levels' to preserve the
+    // pre-centralization DeepSeek default.
     const mode = options.modelId ? modelSupportsReasoningEffort(options.modelId) : 'levels';
     if (mode === 'levels') {
-      request.reasoning_effort = options.reasoningEffort;
+      // DeepSeek's `reasoning_effort` field accepts low/medium/high.
+      // Portable `xhigh` (from user-facing `max`) collapses to `high`
+      // because DeepSeek has no higher tier on this endpoint.
+      request.reasoning_effort =
+        portable.effort === 'xhigh' ? 'high' : (portable.effort as 'low' | 'medium' | 'high');
     } else if (mode === 'binary') {
       request.enable_thinking = true;
     }

--- a/src/providers/reasoning.ts
+++ b/src/providers/reasoning.ts
@@ -1,0 +1,99 @@
+/**
+ * Portable reasoning resolution for provider implementations.
+ *
+ * Centralizes the mapping between Alexi's user-facing reasoning effort
+ * levels (`low`, `medium`, `high`, `max`) and the portable reasoning
+ * option shape modeled on the AI SDK's portable reasoning API. Provider
+ * modules call {@link resolvePortableReasoning} instead of re-deriving
+ * the mapping themselves, which keeps behaviour aligned across providers
+ * (DeepSeek, SAP Orchestration, adaptive thinking, ...).
+ *
+ * Contract:
+ * - Returns `undefined` when no reasoning is requested (both `effortLevel`
+ *   and `enabled` omitted, or `enabled === false` without an effort).
+ * - `enabled === true` without an explicit level maps to `medium` — this
+ *   matches the Cline "enable thinking with sensible default" contract.
+ * - `enabled === false` returns a `{ effort: 'none' }` sentinel so callers
+ *   can distinguish "explicitly off" from "not specified". Providers that
+ *   have no way to represent an explicit disable can treat `none` the
+ *   same as `undefined`.
+ * - `effortLevel: 'max'` is normalized to `xhigh` so downstream provider
+ *   code has a single canonical highest-tier value to match on. This is
+ *   the same normalization Cline PR #12946 applied to align AI SDK
+ *   providers with Anthropic's `xhigh` extended-thinking budget.
+ *
+ * Reference: Cline #12946 "feat(llms): add portable reasoning resolution
+ * for AI SDK providers" (merged 2026-08-05).
+ */
+
+/** User-facing reasoning effort levels accepted by Alexi. */
+export type ReasoningEffortLevel = 'low' | 'medium' | 'high' | 'max';
+
+/**
+ * Canonical effort values on the wire after normalization.
+ *
+ * - `low` / `medium` / `high` pass through unchanged.
+ * - `max` is normalized to `xhigh` to match the AI SDK portable reasoning
+ *   contract and Anthropic extended-thinking naming.
+ * - `none` is emitted when reasoning was explicitly disabled by the caller
+ *   (`enabled === false`); providers should turn native reasoning off.
+ */
+export type PortableReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'none';
+
+/**
+ * Portable reasoning option returned by {@link resolvePortableReasoning}.
+ *
+ * Providers should treat this as an opaque descriptor and only branch on
+ * `effort`. Additional provider-specific controls (budget tokens, native
+ * disable flags, model-family dispatch) belong in the provider module.
+ */
+export interface PortableReasoningOption {
+  effort: PortableReasoningEffort;
+}
+
+/**
+ * Resolve an Alexi reasoning-effort request into a portable option.
+ *
+ * @param effortLevel Optional effort level (`low` | `medium` | `high` | `max`).
+ * @param enabled Optional explicit toggle. `true` without a level defaults to
+ *                `medium`; `false` forces `none`. When both `effortLevel` and
+ *                `enabled === false` are provided, the explicit disable wins.
+ * @returns A portable reasoning option, or `undefined` when reasoning was
+ *          not requested at all.
+ */
+export function resolvePortableReasoning(
+  effortLevel?: ReasoningEffortLevel,
+  enabled?: boolean
+): PortableReasoningOption | undefined {
+  // Explicit disable wins over any effort level. Providers can use this
+  // sentinel to turn off native reasoning.
+  if (enabled === false) {
+    return { effort: 'none' };
+  }
+
+  if (effortLevel !== undefined) {
+    return { effort: normalizeEffort(effortLevel) };
+  }
+
+  // Enable without a level defaults to medium — the common "just turn on
+  // thinking" contract used by Cline's portable resolver.
+  if (enabled === true) {
+    return { effort: 'medium' };
+  }
+
+  // No reasoning requested.
+  return undefined;
+}
+
+function normalizeEffort(level: ReasoningEffortLevel): PortableReasoningEffort {
+  switch (level) {
+    case 'low':
+      return 'low';
+    case 'medium':
+      return 'medium';
+    case 'high':
+      return 'high';
+    case 'max':
+      return 'xhigh';
+  }
+}


### PR DESCRIPTION
## Summary

Introduces `resolvePortableReasoning(effortLevel, enabled)` in `src/providers/reasoning.ts` as the single mapping between Alexi's user-facing reasoning effort levels (`low` / `medium` / `high` / `max`) and a portable AI-SDK-shaped reasoning option. Provider modules call this resolver instead of re-deriving the mapping themselves, keeping behaviour aligned across providers.

Reference: [Cline PR #12946](https://github.com/cline/cline/pull/12946) `feat(llms): add portable reasoning resolution for AI SDK providers` (merged 2026-08-05).

## Contract

- `low`/`medium`/`high` pass through unchanged.
- `max` is normalized to `xhigh` (Cline / AI SDK convention).
- `enabled: true` (no level) defaults to `medium`.
- `enabled: false` returns `{ effort: 'none' }` sentinel so providers can deterministically turn native reasoning off (explicit disable wins over a supplied level).
- Returns `undefined` when no reasoning was requested.

## DeepSeek integration

`buildDeepSeekRequest` now routes through the resolver first, then applies DeepSeek-specific dispatch (levels / binary / none from `modelSupportsReasoningEffort`). Bit-for-bit compatible with existing callers:

- `reasoning_effort` values for deepseek-r1 unchanged for `low` / `medium` / `high`.
- Portable `xhigh` (from user-facing `max`) collapses to `high` on levels-mode models — DeepSeek has no higher tier on the `reasoning_effort` field.
- `enable_thinking: true` still emitted for binary-mode models.
- New `reasoningEnabled` option added to `DeepSeekOptions` for the enable/disable contract (opt-in, backward compatible).

## SAP Orchestration

`sapOrchestration.ts` currently has **no** reasoning-related code (a grep for `reasoning` returns only a doc comment). There is no existing duplication to centralize there yet, so this PR does not touch `sapOrchestration.ts`. When a future PR wires reasoning through SAP AI Core, it should call `resolvePortableReasoning` first and then map the portable option to SAP-specific `providerOptions` per the Cline pattern.

## Testing

- `src/providers/__tests__/reasoning.test.ts` (new) — 11 tests covering all effort levels, `max` -> `xhigh` normalization, enabled/disabled contract, explicit-disable-wins, and shape invariants.
- `src/providers/__tests__/deepseek.test.ts` — 4 new tests covering `max` collapse on levels mode, `enabled=true` default, explicit disable, and `max` routing to `enable_thinking` on binary mode.
- Full suite: 3685 passed / 62 skipped.

## Verification

```
npm run lint          # 0 errors
npm run typecheck     # clean
npm run format:check  # clean
npm test              # 3685 passed
npm run build         # clean
```

Closes #1290