### PR TITLE
feat(core): add json export format to session export (#1292)

### DIFF
--- a/src/cli/commands/__tests__/sessions.test.ts
+++ b/src/cli/commands/__tests__/sessions.test.ts
@@ -11,12 +11,15 @@ import { Command } from 'commander';
 import type { SessionMetadata } from '../../../core/sessionManager.js';
 
 const listSessionsMock: ReturnType<typeof vi.fn> = vi.fn();
+const exportToMarkdownMock: ReturnType<typeof vi.fn> = vi.fn();
+const exportToJSONMock: ReturnType<typeof vi.fn> = vi.fn();
 
 vi.mock('../../../core/sessionManager.js', () => {
   // Use a real class so `new SessionManager()` works at runtime.
   class SessionManager {
     listSessions = listSessionsMock;
-    exportToMarkdown = vi.fn();
+    exportToMarkdown = exportToMarkdownMock;
+    exportToJSON = exportToJSONMock;
     deleteSession = vi.fn();
   }
   return { SessionManager };
@@ -62,6 +65,8 @@ describe('alexi sessions command', () => {
 
   beforeEach(() => {
     listSessionsMock.mockReset();
+    exportToMarkdownMock.mockReset();
+    exportToJSONMock.mockReset();
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
@@ -221,5 +226,105 @@ describe('alexi sessions command', () => {
       errSpy.mockRestore();
       exitSpy.mockRestore();
     });
+  });
+});
+
+describe('alexi session-export command', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    exportToMarkdownMock.mockReset();
+    exportToJSONMock.mockReset();
+    exportToMarkdownMock.mockReturnValue('# markdown output\n');
+    exportToJSONMock.mockReturnValue('{"version":"1.0"}');
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('defaults to markdown when no --format is provided', async () => {
+    const program = buildProgram();
+    await program.parseAsync(['node', 'alexi', 'session-export', '-s', 'sess-001']);
+
+    expect(exportToMarkdownMock).toHaveBeenCalledWith('sess-001');
+    expect(exportToJSONMock).not.toHaveBeenCalled();
+
+    const output = (logSpy.mock.calls as unknown[][]).map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('# markdown output');
+  });
+
+  it('routes to exportToMarkdown when --format markdown is provided', async () => {
+    const program = buildProgram();
+    await program.parseAsync([
+      'node',
+      'alexi',
+      'session-export',
+      '-s',
+      'sess-001',
+      '--format',
+      'markdown',
+    ]);
+
+    expect(exportToMarkdownMock).toHaveBeenCalledWith('sess-001');
+    expect(exportToJSONMock).not.toHaveBeenCalled();
+  });
+
+  it('routes to exportToJSON when --format json is provided', async () => {
+    const program = buildProgram();
+    await program.parseAsync([
+      'node',
+      'alexi',
+      'session-export',
+      '-s',
+      'sess-001',
+      '--format',
+      'json',
+    ]);
+
+    expect(exportToJSONMock).toHaveBeenCalledWith('sess-001');
+    expect(exportToMarkdownMock).not.toHaveBeenCalled();
+
+    const output = (logSpy.mock.calls as unknown[][]).map((c) => c.join(' ')).join('\n');
+    expect(output).toContain('"version":"1.0"');
+  });
+
+  it('is case-insensitive on the format value', async () => {
+    const program = buildProgram();
+    await program.parseAsync([
+      'node',
+      'alexi',
+      'session-export',
+      '-s',
+      'sess-001',
+      '--format',
+      'JSON',
+    ]);
+
+    expect(exportToJSONMock).toHaveBeenCalledWith('sess-001');
+  });
+
+  it('errors out and exits with 1 when --format is invalid', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('process.exit called');
+    }) as never);
+
+    const program = buildProgram();
+
+    await expect(
+      program.parseAsync(['node', 'alexi', 'session-export', '-s', 'sess-001', '--format', 'yaml'])
+    ).rejects.toThrow('process.exit called');
+
+    expect(exportToMarkdownMock).not.toHaveBeenCalled();
+    expect(exportToJSONMock).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith(
+      "Error: invalid --format 'yaml'. Use 'markdown' or 'json'."
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 });

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -86,23 +86,41 @@ export function registerSessionCommands(program: Command): void {
       }
     });
 
-  // Export session to markdown
+  // Export session to markdown or JSON
   program
     .command('session-export')
     .requiredOption('-s, --session <id>', 'Session ID to export')
     .option('-o, --output <file>', 'Output file (defaults to stdout)')
-    .description('Export session to markdown')
-    .action(async (opts: { session: string; output?: string }) => {
+    .option(
+      '-f, --format <format>',
+      'Export format: "markdown" (default) or "json" (preserves full metadata)',
+      'markdown'
+    )
+    .description(
+      'Export a session. Default format is markdown (human-readable); ' +
+        'use --format json to emit machine-readable JSON preserving all ' +
+        'message metadata (timestamps, tokens, reasoning, tool calls/results).'
+    )
+    .action(async (opts: { session: string; output?: string; format?: string }) => {
       try {
+        const format = (opts.format || 'markdown').toLowerCase();
+        if (format !== 'markdown' && format !== 'json') {
+          console.error(`Error: invalid --format '${opts.format}'. Use 'markdown' or 'json'.`);
+          process.exit(1);
+        }
+
         const sessionManager = new SessionManager();
-        const markdown = sessionManager.exportToMarkdown(opts.session);
+        const content =
+          format === 'json'
+            ? sessionManager.exportToJSON(opts.session)
+            : sessionManager.exportToMarkdown(opts.session);
 
         if (opts.output) {
           const fs = await import('fs');
-          fs.writeFileSync(opts.output, markdown, 'utf-8');
+          fs.writeFileSync(opts.output, content, 'utf-8');
           console.log(`Session exported to ${opts.output}`);
         } else {
-          console.log(markdown);
+          console.log(content);
         }
       } catch (e) {
         console.error(String(e));

--- a/src/cli/interactive.ts
+++ b/src/cli/interactive.ts
@@ -187,7 +187,10 @@ export function printHelp(): void {
   console.log(c('yellow', '  /sessions') + c('gray', '          - List all sessions'));
   console.log(c('yellow', '  /session load <id>') + c('gray', ' - Load a previous session'));
   console.log(c('yellow', '  /session new') + c('gray', '       - Start a new session'));
-  console.log(c('yellow', '  /session export') + c('gray', '    - Export session to markdown'));
+  console.log(
+    c('yellow', '  /session export [markdown|json]') +
+      c('gray', ' - Export session to file (default markdown)')
+  );
   console.log(c('yellow', '  /clear') + c('gray', '             - Clear screen'));
   console.log(c('yellow', '  /history') + c('gray', '           - Show conversation history'));
   console.log(c('yellow', '  /autoroute') + c('gray', '         - Toggle auto model routing'));
@@ -454,12 +457,29 @@ export async function handleCommand(input: string, state: ReplState): Promise<bo
         }
       } else if (args[0] === 'export') {
         const session = state.sessionManager.getCurrentSession();
-        if (session) {
-          const markdown = state.sessionManager.exportToMarkdown();
-          console.log(c('cyan', '\n  Session Export:\n'));
-          console.log(markdown);
-        } else {
+        if (!session) {
           console.log(c('yellow', '\n  No active session to export\n'));
+          return true;
+        }
+        // Format is the optional second arg: `/session export [markdown|json]`.
+        // Empty or invalid values fall back to markdown to preserve the
+        // pre-existing behavior of `/session export`.
+        const rawFormat = (args[1] || 'markdown').toLowerCase();
+        const format = rawFormat === 'json' ? 'json' : 'markdown';
+        const content =
+          format === 'json'
+            ? state.sessionManager.exportToJSON()
+            : state.sessionManager.exportToMarkdown();
+        const filename = path.join(
+          process.cwd(),
+          `session-${session.metadata.id}-${Date.now()}.${format === 'json' ? 'json' : 'md'}`
+        );
+        try {
+          fs.writeFileSync(filename, content, 'utf-8');
+          console.log(c('green', `\n  Session exported to ${filename}\n`));
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.log(c('red', `\n  Export failed: ${msg}\n`));
         }
       }
       return true;

--- a/src/core/__tests__/sessionManager.test.ts
+++ b/src/core/__tests__/sessionManager.test.ts
@@ -831,6 +831,125 @@ describe('SessionManager', () => {
     });
   });
 
+  // ========== 15. exportToJSON ==========
+  describe('exportToJSON', () => {
+    it('returns a parseable JSON envelope with version, metadata, and messages', () => {
+      const manager = new SessionManager(tempDir);
+      const session = manager.createSession('gpt-4');
+      manager.addMessage('user', 'Hello world');
+      manager.addMessage('assistant', 'Hi there', { input: 5, output: 10 });
+
+      const json = manager.exportToJSON();
+      const parsed = JSON.parse(json) as {
+        version: string;
+        exported: number;
+        metadata: {
+          id: string;
+          modelId?: string;
+          totalTokens: number;
+          messageCount: number;
+          workdir?: string;
+        } | null;
+        messages: Array<{
+          role: string;
+          content: string;
+          timestamp: number;
+          tokens?: { input?: number; output?: number };
+        }>;
+      };
+
+      expect(parsed.version).toBe('1.0');
+      expect(typeof parsed.exported).toBe('number');
+      expect(parsed.metadata).not.toBeNull();
+      expect(parsed.metadata?.id).toBe(session.metadata.id);
+      expect(parsed.metadata?.modelId).toBe('gpt-4');
+      expect(parsed.metadata?.messageCount).toBe(2);
+      expect(parsed.messages).toHaveLength(2);
+      expect(parsed.messages[0].role).toBe('user');
+      expect(parsed.messages[0].content).toBe('Hello world');
+      expect(parsed.messages[1].role).toBe('assistant');
+      expect(parsed.messages[1].tokens).toEqual({ input: 5, output: 10 });
+    });
+
+    it('returns a valid empty envelope when no session is active', () => {
+      const manager = new SessionManager(tempDir);
+
+      const json = manager.exportToJSON();
+      const parsed = JSON.parse(json) as {
+        version: string;
+        metadata: unknown;
+        messages: unknown[];
+      };
+
+      expect(parsed.version).toBe('1.0');
+      expect(parsed.metadata).toBeNull();
+      expect(parsed.messages).toEqual([]);
+    });
+
+    it('loads a session by ID when sessionId is provided', () => {
+      const manager = new SessionManager(tempDir);
+      const s1 = manager.createSession();
+      manager.addMessage('user', 'First session content');
+      const s1Id = s1.metadata.id;
+
+      manager.createSession();
+      manager.addMessage('user', 'Second session content');
+
+      const json = manager.exportToJSON(s1Id);
+      const parsed = JSON.parse(json) as {
+        metadata: { id: string } | null;
+        messages: Array<{ content: string }>;
+      };
+
+      expect(parsed.metadata?.id).toBe(s1Id);
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0].content).toBe('First session content');
+    });
+
+    it('preserves structured extras (reasoning, toolCalls, toolResults) on messages', () => {
+      const manager = new SessionManager(tempDir);
+      const session = manager.createSession();
+      manager.addMessage('user', 'What is 2+2?');
+      manager.addMessage('assistant', 'The answer is 4', { input: 3, output: 5 });
+
+      // Inject structured extras directly on the on-disk session, matching
+      // how richer producers may write messages.
+      const sessionPath = path.join(tempDir, `${session.metadata.id}.json`);
+      const raw = JSON.parse(fs.readFileSync(sessionPath, 'utf-8')) as Session;
+      (raw.messages[1] as unknown as Record<string, unknown>).reasoning = 'chain-of-thought';
+      (raw.messages[1] as unknown as Record<string, unknown>).toolCalls = [
+        { name: 'calculator', args: { a: 2, b: 2 } },
+      ];
+      (raw.messages[1] as unknown as Record<string, unknown>).toolResults = [{ result: 4 }];
+      fs.writeFileSync(sessionPath, JSON.stringify(raw), 'utf-8');
+
+      const json = manager.exportToJSON(session.metadata.id);
+      const parsed = JSON.parse(json) as {
+        messages: Array<{
+          reasoning?: string;
+          toolCalls?: Array<{ name: string }>;
+          toolResults?: Array<{ result: number }>;
+        }>;
+      };
+
+      expect(parsed.messages[1].reasoning).toBe('chain-of-thought');
+      expect(parsed.messages[1].toolCalls).toEqual([{ name: 'calculator', args: { a: 2, b: 2 } }]);
+      expect(parsed.messages[1].toolResults).toEqual([{ result: 4 }]);
+    });
+
+    it('produces pretty-printed JSON (2-space indent)', () => {
+      const manager = new SessionManager(tempDir);
+      manager.createSession('gpt-4');
+      manager.addMessage('user', 'test');
+
+      const json = manager.exportToJSON();
+
+      // Pretty-printed output contains newlines and 2-space indentation.
+      expect(json).toContain('\n');
+      expect(json).toMatch(/\n {2}"version"/);
+    });
+  });
+
   // ========== Subagent parent chain ==========
   describe('subagent parent chain', () => {
     it('records parentSessionId when createSession is called with a parent', () => {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -368,6 +368,97 @@ export class SessionManager {
   }
 
   /**
+   * Export session to JSON.
+   *
+   * Returns a pretty-printed JSON string with the following top-level shape:
+   *   {
+   *     version: '1.0',
+   *     exported: <unix-ms>,
+   *     metadata: { id, created, updated, modelId?, title?, workdir?,
+   *                 parentSessionId?, totalTokens, messageCount },
+   *     messages: Array<{ role, content, timestamp, tokens?,
+   *                       reasoning?, toolCalls?, toolResults? }>,
+   *   }
+   *
+   * Unlike {@link exportToMarkdown}, this format is intended for
+   * machine-readable / round-trip use: `JSON.parse(exported)` always
+   * yields an object matching the shape above. Content is preserved
+   * as-is (no internal-wrapper stripping) so a future re-import can
+   * faithfully reconstruct the session.
+   *
+   * When `sessionId` is provided the session is loaded from disk;
+   * otherwise the active session is used. If no session is available,
+   * a minimal envelope with `metadata: null` and `messages: []` is
+   * returned (still valid JSON).
+   */
+  exportToJSON(sessionId?: string): string {
+    const session = sessionId ? this.loadSession(sessionId) : this.activeSession;
+
+    if (!session) {
+      return JSON.stringify(
+        {
+          version: '1.0',
+          exported: Date.now(),
+          metadata: null,
+          messages: [],
+        },
+        null,
+        2
+      );
+    }
+
+    const messages = session.messages.map((m) => {
+      const entry: Record<string, unknown> = {
+        role: m.role,
+        content: m.content,
+        timestamp: m.timestamp,
+      };
+      if (m.tokens) {
+        entry.tokens = m.tokens;
+      }
+      // Structured extras (reasoning traces, tool calls/results) are
+      // preserved when present on the on-disk message. They are not
+      // part of the base `Message` interface, but sessions written by
+      // richer producers may include them; we surface them verbatim.
+      const extra = m as unknown as {
+        reasoning?: unknown;
+        toolCalls?: unknown;
+        toolResults?: unknown;
+      };
+      if (extra.reasoning !== undefined) {
+        entry.reasoning = extra.reasoning;
+      }
+      if (extra.toolCalls !== undefined) {
+        entry.toolCalls = extra.toolCalls;
+      }
+      if (extra.toolResults !== undefined) {
+        entry.toolResults = extra.toolResults;
+      }
+      return entry;
+    });
+
+    const meta = session.metadata;
+    const exportObject = {
+      version: '1.0',
+      exported: Date.now(),
+      metadata: {
+        id: meta.id,
+        created: meta.created,
+        updated: meta.updated,
+        modelId: meta.modelId,
+        title: meta.title,
+        workdir: meta.workdir,
+        parentSessionId: meta.parentSessionId,
+        totalTokens: meta.totalTokens,
+        messageCount: meta.messageCount,
+      },
+      messages,
+    };
+
+    return JSON.stringify(exportObject, null, 2);
+  }
+
+  /**
    * Export session to markdown
    */
   exportToMarkdown(sessionId?: string): string {


### PR DESCRIPTION
Closes #1292

## Summary

Adds a JSON export format alongside the existing markdown export for sessions. JSON preserves the full metadata surface (timestamps, tokens, reasoning traces, tool calls/results) so exported sessions can be consumed programmatically or round-tripped through `JSON.parse`.

## Changes

- `src/core/sessionManager.ts`: new `exportToJSON(sessionId?)` returns a pretty-printed JSON envelope:
  ```
  { version: '1.0', exported, metadata, messages[] }
  ```
  Message extras (`reasoning`, `toolCalls`, `toolResults`) are surfaced verbatim when present on the on-disk message. Empty envelope is emitted when no session is active.
- `src/cli/commands/sessions.ts`: `session-export` gains `-f, --format <markdown|json>` (default `markdown`, existing behavior preserved). Invalid values are rejected with a clear error and exit 1. Format matching is case-insensitive.
- `src/cli/interactive.ts`: `/session export [markdown|json]` now writes to a `session-<id>-<ts>.<ext>` file (previously only echoed markdown to stdout). Help text updated.
- Tests: added a full `exportToJSON` suite covering round-trip parse, active/by-id export, structured extras, pretty-print, and empty envelope; extended CLI command tests to cover `--format markdown|json`, default, case-insensitivity, and invalid format.

## Gate results

- `npm run lint`: 0 errors (1344 warnings, unchanged)
- `npm run typecheck`: pass
- `npm run format:check`: pass
- `npm test`: 3695 passed / 62 skipped
- `npm run test:coverage`: 67.1% lines (well above 40% CI threshold)
- `npm run build`: pass

## Design notes

- The pre-existing `/export` interactive command handles full data export (via `getDataExporter()`) and was left intact to avoid breaking users. The session-scoped JSON path is exposed as `/session export json`.
- `exportToJSON` returns a JSON string (matching `exportToMarkdown`'s return-string shape) rather than writing to disk, so callers can decide whether to persist, print, or pipe.
