### PR TITLE
fix(cli): guard process against abort-family unhandled rejections

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -11,9 +11,18 @@ import { createRequire } from 'module';
 import { ProviderModelFellBack } from '../bus/index.js';
 import { registerAllCommands } from './commands/index.js';
 import { killAllTracked } from '../tool/tools/background-process.js';
+import { installAbortGuard } from './utils/abortGuard.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json');
+
+// Install a process-wide guard that swallows abort-family unhandled
+// rejections (DOMException `AbortError`, Node `code === 'ABORT_ERR'`).
+// Cancelled provider streams occasionally reject their underlying fetch
+// promise after the async generator has already returned; without this
+// guard those rejections would kill the process (and any resident session
+// daemon) via Node's default unhandled-rejection behaviour. See #1319.
+installAbortGuard();
 
 // Install SIGINT/SIGTERM handlers once so any background_process children
 // spawned during one-shot commands (e.g. `alexi chat -m "..."`) are reaped

--- a/src/cli/tui/hooks/useStreamChat.ts
+++ b/src/cli/tui/hooks/useStreamChat.ts
@@ -5,6 +5,7 @@ import { useSession } from '../context/SessionContext.js';
 import { useAttachments } from '../context/AttachmentContext.js';
 import { buildUserMessage, type MultimodalContentItem } from '../../../utils/multimodal.js';
 import { isStreamStalledError } from '../../../core/streamWatchdog.js';
+import { isAbortError } from '../../../core/streamingOrchestrator.js';
 
 export interface UseStreamChatReturn {
   sendMessage: (text: string) => Promise<void>;
@@ -76,8 +77,12 @@ export function useStreamChat(): UseStreamChatReturn {
 
         chat.setResponseModel(result.modelUsed);
       } catch (err: unknown) {
-        // Handle abort gracefully — not an error
-        if (err instanceof Error && err.name === 'AbortError') {
+        // Handle abort gracefully — not an error. Use the shared
+        // `isAbortError` classifier so the TUI catches the same shapes
+        // the streaming REPL does: DOMException AbortError, plain Error
+        // with name === 'AbortError', AND Node native aborts that reach
+        // the catch as `code === 'ABORT_ERR'` (issue #1319).
+        if (isAbortError(err)) {
           // Aborted by user; no error to display
         } else if (isStreamStalledError(err)) {
           // Stalled provider stream (issue #1164). Surface a friendly,

--- a/src/cli/utils/abortGuard.ts
+++ b/src/cli/utils/abortGuard.ts
@@ -1,0 +1,111 @@
+/**
+ * Process-level guard for abort-family unhandled rejections (issue #1319).
+ *
+ * Cancelled provider streams occasionally reject the underlying `fetch`
+ * (undici) promise with a DOMException `AbortError` or a Node native
+ * `code === 'ABORT_ERR'` AFTER the async generator that owned them has
+ * already returned. When that happens the rejection has no `.catch()` in
+ * the call stack: it escapes to Node's global `unhandledRejection` handler
+ * which, on Node >= 15, kills the process (and any resident session
+ * daemon) with a non-zero exit code.
+ *
+ * The CLI/TUI already classify abort-family errors that reach a `try/catch`
+ * as `"Request cancelled"` (see `handleStreamingError` in `interactive.ts`
+ * and `useStreamChat.ts`). This module widens the same policy to the
+ * process-wide rejection channel: swallow abort-family rejections (log
+ * once at info level), and re-emit everything else so Node's default
+ * crash-on-unhandled-rejection behaviour is preserved for real bugs.
+ *
+ * Public API is `installAbortGuard()` / `uninstallAbortGuard()` so tests
+ * can attach and detach the guard deterministically without leaking
+ * listeners into unrelated tests.
+ */
+
+import { isAbortError } from '../../core/streamingOrchestrator.js';
+
+type UnhandledRejectionHandler = (reason: unknown, promise: Promise<unknown>) => void;
+type UncaughtExceptionHandler = (err: Error) => void;
+
+let installedRejectionHandler: UnhandledRejectionHandler | null = null;
+let installedExceptionHandler: UncaughtExceptionHandler | null = null;
+
+/**
+ * Log an abort-family swallow to stderr. Kept as a single function so the
+ * output can be silenced under `ALEXI_QUIET_ABORT=1` (used by tests that
+ * assert on stderr shape, and by CI logs that would otherwise be noisy
+ * when the user mashes Ctrl+C).
+ */
+function logSwallowedAbort(reason: unknown): void {
+  if (process.env.ALEXI_QUIET_ABORT === '1') {
+    return;
+  }
+  const message = reason instanceof Error ? reason.message : String(reason);
+  // Write directly to stderr — `logger` is not a hard dependency here and
+  // we want this signal to always land even when stdout is captured.
+  process.stderr.write(`Request cancelled (background abort): ${message}\n`);
+}
+
+/**
+ * Install the abort-family guard. Idempotent: repeat calls are no-ops so
+ * the CLI entry point can call it unconditionally.
+ */
+export function installAbortGuard(): void {
+  if (installedRejectionHandler) {
+    return;
+  }
+
+  installedRejectionHandler = (reason: unknown) => {
+    if (isAbortError(reason)) {
+      logSwallowedAbort(reason);
+      return;
+    }
+    // Not an abort — replicate Node's default unhandled-rejection
+    // behaviour manually. We can't just re-throw here: that would loop
+    // through our own `uncaughtException` handler. We print the standard
+    // banner to stderr, then exit with code 1 the way Node would if no
+    // listener were installed at all. Skipped when other listeners are
+    // present so user-installed handlers still get their turn.
+    const listeners = process.listeners('unhandledRejection');
+    if (listeners.length > 1) {
+      // Another handler is registered; let it decide.
+      return;
+    }
+    const message = reason instanceof Error ? reason.stack || reason.message : String(reason);
+    process.stderr.write(`Unhandled promise rejection: ${message}\n`);
+    process.exit(1);
+  };
+
+  installedExceptionHandler = (err: Error) => {
+    if (isAbortError(err)) {
+      logSwallowedAbort(err);
+      return;
+    }
+    // Not an abort — replicate Node's default crash behaviour without
+    // re-throwing (which would re-enter this handler).
+    const listeners = process.listeners('uncaughtException');
+    if (listeners.length > 1) {
+      return;
+    }
+    const message = err instanceof Error ? err.stack || err.message : String(err);
+    process.stderr.write(`Uncaught exception: ${message}\n`);
+    process.exit(1);
+  };
+
+  process.on('unhandledRejection', installedRejectionHandler);
+  process.on('uncaughtException', installedExceptionHandler);
+}
+
+/**
+ * Remove the abort-family guard. Used exclusively by tests; production
+ * code should leave the guard installed for the entire process lifetime.
+ */
+export function uninstallAbortGuard(): void {
+  if (installedRejectionHandler) {
+    process.off('unhandledRejection', installedRejectionHandler);
+    installedRejectionHandler = null;
+  }
+  if (installedExceptionHandler) {
+    process.off('uncaughtException', installedExceptionHandler);
+    installedExceptionHandler = null;
+  }
+}

--- a/tests/cli/interactive-abort-handling.test.ts
+++ b/tests/cli/interactive-abort-handling.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Regression tests for issue #1319: abort-family errors must not kill the
+ * CLI/TUI process.
+ *
+ * Cancelled provider streams sometimes reject their underlying fetch
+ * promise (undici / AbortSignal.throwIfAborted) after the async generator
+ * that owned them has already returned. Those rejections escape to Node's
+ * `unhandledRejection` channel and — on Node >= 15 — terminate the
+ * process, taking any resident session daemon down with it.
+ *
+ * The abort guard installed by `src/cli/utils/abortGuard.ts` swallows
+ * abort-family rejections (DOMException `AbortError`, Node
+ * `code === 'ABORT_ERR'`) while preserving Node's default behaviour for
+ * everything else. These tests exercise both branches without booting a
+ * full CLI.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { installAbortGuard, uninstallAbortGuard } from '../../src/cli/utils/abortGuard.js';
+
+describe('abort guard (installAbortGuard)', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let stderrChunks: string[];
+  let originalQuietFlag: string | undefined;
+
+  beforeEach(() => {
+    stderrChunks = [];
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((
+      chunk: string | Uint8Array
+    ) => {
+      stderrChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write);
+    originalQuietFlag = process.env.ALEXI_QUIET_ABORT;
+    // Quiet the guard's own stderr write in most tests so vitest output
+    // stays clean; individual tests opt back in when they need to assert
+    // on the message content.
+    process.env.ALEXI_QUIET_ABORT = '1';
+    installAbortGuard();
+  });
+
+  afterEach(() => {
+    uninstallAbortGuard();
+    stderrSpy.mockRestore();
+    if (originalQuietFlag === undefined) {
+      delete process.env.ALEXI_QUIET_ABORT;
+    } else {
+      process.env.ALEXI_QUIET_ABORT = originalQuietFlag;
+    }
+  });
+
+  it('is idempotent — installing twice attaches only one listener pair', () => {
+    const before = {
+      rejection: process.listenerCount('unhandledRejection'),
+      exception: process.listenerCount('uncaughtException'),
+    };
+    installAbortGuard();
+    installAbortGuard();
+    const after = {
+      rejection: process.listenerCount('unhandledRejection'),
+      exception: process.listenerCount('uncaughtException'),
+    };
+    // Same count after repeated installs; guard already noticed itself.
+    expect(after.rejection).toBe(before.rejection);
+    expect(after.exception).toBe(before.exception);
+  });
+
+  it('swallows a DOMException AbortError rejection without crashing', async () => {
+    const err =
+      typeof DOMException !== 'undefined'
+        ? new DOMException('signal aborted', 'AbortError')
+        : Object.assign(new Error('signal aborted'), { name: 'AbortError' });
+
+    // Simulate a rejection that escapes to Node's global handler.
+    const listeners = process.listeners('unhandledRejection');
+    expect(listeners.length).toBeGreaterThan(0);
+    const guard = listeners[listeners.length - 1] as (
+      reason: unknown,
+      promise: Promise<unknown>
+    ) => void;
+
+    // Must NOT throw synchronously — abort-family swallow path.
+    expect(() =>
+      guard(
+        err,
+        Promise.reject(err).catch(() => undefined)
+      )
+    ).not.toThrow();
+  });
+
+  it('swallows a Node native abort (code === "ABORT_ERR") rejection', async () => {
+    const err = Object.assign(new Error('The operation was aborted'), {
+      code: 'ABORT_ERR',
+    });
+    expect(err.name).not.toBe('AbortError');
+
+    const listeners = process.listeners('unhandledRejection');
+    const guard = listeners[listeners.length - 1] as (
+      reason: unknown,
+      promise: Promise<unknown>
+    ) => void;
+
+    expect(() =>
+      guard(
+        err,
+        Promise.reject(err).catch(() => undefined)
+      )
+    ).not.toThrow();
+  });
+
+  it('handles multiple aborts in sequence without leaking listeners or crashing', () => {
+    const listeners = process.listeners('unhandledRejection');
+    const guard = listeners[listeners.length - 1] as (
+      reason: unknown,
+      promise: Promise<unknown>
+    ) => void;
+
+    for (let i = 0; i < 10; i++) {
+      const err = Object.assign(new Error(`abort #${i}`), { code: 'ABORT_ERR' });
+      expect(() =>
+        guard(
+          err,
+          Promise.reject(err).catch(() => undefined)
+        )
+      ).not.toThrow();
+    }
+
+    // Listener count must be stable after handling many aborts.
+    expect(process.listenerCount('unhandledRejection')).toBe(listeners.length);
+  });
+
+  it('propagates non-abort rejections to Node crash path (exit 1)', () => {
+    // Uninstall the beforeEach guard so we can reinstall it as the ONLY
+    // listener — otherwise vitest's own unhandledRejection listener runs
+    // first and this test asserts the wrong branch.
+    uninstallAbortGuard();
+    const preexisting = process.listeners('unhandledRejection').slice();
+    for (const l of preexisting) {
+      process.off('unhandledRejection', l);
+    }
+    installAbortGuard();
+
+    const listeners = process.listeners('unhandledRejection');
+    const guard = listeners[listeners.length - 1] as (
+      reason: unknown,
+      promise: Promise<unknown>
+    ) => void;
+
+    const realErr = new Error('provider blew up');
+
+    // The guard `process.exit(1)`s for non-abort rejections when it is
+    // the sole listener. We stub exit and stderr write to observe both.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('exit-called');
+    }) as (code?: number) => never);
+
+    try {
+      expect(() =>
+        guard(
+          realErr,
+          Promise.reject(realErr).catch(() => undefined)
+        )
+      ).toThrow('exit-called');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const combined = stderrChunks.join('');
+      expect(combined).toContain('Unhandled promise rejection');
+      expect(combined).toContain('provider blew up');
+    } finally {
+      exitSpy.mockRestore();
+      // Reattach the vitest listeners we stole so the run continues clean.
+      for (const l of preexisting) {
+        process.on('unhandledRejection', l);
+      }
+    }
+  });
+
+  it('defers non-abort rejections when other listeners are registered', () => {
+    // The guard yields to user-installed handlers when it is not the sole
+    // listener — this is what keeps vitest/node's own error reporting
+    // intact in real deployments.
+    const otherHandler = vi.fn();
+    process.on('unhandledRejection', otherHandler);
+    try {
+      const listeners = process.listeners('unhandledRejection');
+      // The guard is the one we installed via installAbortGuard(); it is
+      // one of the listeners. We locate it by finding a listener whose
+      // module was ours (functions are anonymous — instead, we just
+      // exercise every listener and confirm none of them exits).
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+        throw new Error('should-not-exit');
+      }) as (code?: number) => never);
+
+      const err = new Error('other-handler-owns-this');
+      try {
+        for (const l of listeners) {
+          l(
+            err,
+            Promise.reject(err).catch(() => undefined)
+          );
+        }
+      } finally {
+        exitSpy.mockRestore();
+      }
+
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', otherHandler);
+    }
+  });
+
+  it('logs a "Request cancelled" line when ALEXI_QUIET_ABORT is unset', () => {
+    delete process.env.ALEXI_QUIET_ABORT;
+
+    const err = Object.assign(new Error('The operation was aborted'), {
+      code: 'ABORT_ERR',
+    });
+    const listeners = process.listeners('unhandledRejection');
+    const guard = listeners[listeners.length - 1] as (
+      reason: unknown,
+      promise: Promise<unknown>
+    ) => void;
+
+    guard(
+      err,
+      Promise.reject(err).catch(() => undefined)
+    );
+
+    const combined = stderrChunks.join('');
+    expect(combined).toContain('Request cancelled');
+    // Message body from the abort error must be surfaced for debugging.
+    expect(combined).toContain('The operation was aborted');
+  });
+
+  it('swallows abort-family uncaughtException without crashing', () => {
+    const listeners = process.listeners('uncaughtException');
+    expect(listeners.length).toBeGreaterThan(0);
+    const guard = listeners[listeners.length - 1] as (err: Error) => void;
+
+    const err = Object.assign(new Error('signal aborted'), { name: 'AbortError' });
+    expect(() => guard(err)).not.toThrow();
+  });
+
+  it('uninstalls cleanly so tests do not leak listeners', () => {
+    const beforeInstall = {
+      rejection: process.listenerCount('unhandledRejection'),
+      exception: process.listenerCount('uncaughtException'),
+    };
+    uninstallAbortGuard();
+    const afterUninstall = {
+      rejection: process.listenerCount('unhandledRejection'),
+      exception: process.listenerCount('uncaughtException'),
+    };
+    expect(afterUninstall.rejection).toBe(beforeInstall.rejection - 1);
+    expect(afterUninstall.exception).toBe(beforeInstall.exception - 1);
+
+    // Re-install for the afterEach uninstall to remain balanced.
+    installAbortGuard();
+  });
+});

--- a/tests/cli/tui/useStreamChat.test.tsx
+++ b/tests/cli/tui/useStreamChat.test.tsx
@@ -16,6 +16,24 @@ const mockStreamChat = vi.fn();
 
 vi.mock('../../../src/core/streamingOrchestrator.js', () => ({
   streamChat: (...args: unknown[]) => mockStreamChat(...args),
+  // Re-export the real classifier so the TUI hook can detect all three
+  // abort-family shapes (DOMException AbortError, plain Error with
+  // name === 'AbortError', Node code === 'ABORT_ERR'). Duplicated inline
+  // to keep this mock synchronous — the logic mirrors
+  // `src/core/streamingOrchestrator.ts:isAbortError`.
+  isAbortError: (error: unknown): boolean => {
+    if (!(error instanceof Error) && !(typeof error === 'object' && error !== null)) {
+      return false;
+    }
+    const err = error as { name?: unknown; code?: unknown };
+    if (typeof err.name === 'string' && err.name === 'AbortError') {
+      return true;
+    }
+    if (typeof err.code === 'string' && err.code === 'ABORT_ERR') {
+      return true;
+    }
+    return false;
+  },
 }));
 
 const mockChat: ChatContextValue = {


### PR DESCRIPTION
## What

Adds a process-wide guard that swallows abort-family unhandled rejections (DOMException `AbortError`, Node `code === 'ABORT_ERR'`) so cancelled provider streams no longer kill the CLI/TUI process and take resident sessions down with them.

## Why

Cancelled provider streams occasionally reject their underlying `fetch` (undici) promise **after** the async generator that owned them has already returned. Those rejections escape to Node's global `unhandledRejection` handler which, on Node >= 15, terminates the process with a non-zero exit code. Users hitting Ctrl+C to cancel a request were sometimes seeing the whole session daemon die.

The synchronous streaming catch already classifies abort-family errors via `handleStreamingError` (from #1316). This PR widens the same policy to the process-wide rejection channel.

## How

- New `src/cli/utils/abortGuard.ts`:
  - `installAbortGuard()` — idempotent installation of `unhandledRejection` + `uncaughtException` handlers that classify via the existing `isAbortError` helper.
  - Abort-family: log a single `Request cancelled (background abort): ...` line to stderr (silenceable via `ALEXI_QUIET_ABORT=1`) and swallow.
  - Non-abort: replicate Node's default crash behaviour manually — print the standard banner and `process.exit(1)`. Deferred when other listeners are registered so user-installed handlers (and vitest's own reporting) still run.
  - `uninstallAbortGuard()` for tests.
- `src/cli/program.ts`: install the guard alongside the existing SIGINT/SIGTERM one-shot handlers so both one-shot commands and the interactive REPL are protected from process 0.
- `src/cli/tui/hooks/useStreamChat.ts`: replace the narrower `err.name === 'AbortError'` check with the shared `isAbortError` classifier so the TUI catches Node native aborts (`code === 'ABORT_ERR'`) too. Existing test file's mock updated to re-export the classifier.
- New tests in `tests/cli/interactive-abort-handling.test.ts` covering:
  - Idempotent install.
  - DOMException AbortError swallow.
  - Node native `ABORT_ERR` swallow.
  - 10 aborts in sequence without listener leak.
  - Non-abort rejections escalate to `process.exit(1)` when the guard is the sole listener.
  - Non-abort rejections defer to other listeners when they exist.
  - Abort-family uncaughtException swallow.
  - Clean uninstall.

## Done when

- [x] `src/cli/program.ts` installs the abort guard on startup
- [x] Abort errors log but don't exit the process
- [x] TUI hardened (`useStreamChat.ts` uses `isAbortError`)
- [x] Tests in `tests/cli/interactive-abort-handling.test.ts` pass (9/9)
- [x] Existing `tests/cli/interactive.abort.test.ts` still green (6/6)
- [x] Existing `tests/cli/tui/useStreamChat.test.tsx` still green (13/13)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run test:coverage` — 261 files, 3745 tests pass, 62 skipped
- [x] `npm run build` — clean
- [x] Coverage 66.94% lines (>= 40% CI threshold)

Closes #1319