### PR TITLE
fix(core): cap MCP default startup timeout from 30s to 3s (#1339)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -991,11 +991,17 @@ Example error messages and their classification:
 
 MCP has TWO independent timeout budgets and a separate retry policy on top:
 
-- **Startup timeout** (`config.timeout.startup`, default 30000 ms) —
-  bounds the stdio handshake / cold-spawn phase (`client.connect`). A
-  cold `npx -y` install routinely takes 5-15 s; the budget is intentionally
-  generous. Exceeding it raises a named error pointing at
-  `timeout.startup` in `mcp-servers.json`.
+- **Startup timeout** (`config.timeout.startup`, default 3000 ms; see
+  issue #1339 and Cline #13086) — bounds the stdio handshake / cold-spawn
+  phase (`client.connect`). The 3 s cap is aggressive on purpose: a hung
+  MCP server that never responds to `initialize` must NOT stall session
+  creation on the critical path. It covers ~2 s cold `npx -y` warm-cache
+  starters while keeping worst-case per-server connect near ~6 s.
+  JVM-based servers (Oracle SQLcl and similar) OR a first-time cold
+  `npx -y` install exceed this bound and MUST set an explicit
+  `timeout.startup` override in `mcp-servers.json` (typical values
+  15000-45000 ms). Exceeding it raises a named error pointing at
+  `timeout.startup`.
 - **Request timeout** (`config.timeout.request`, default 60000 ms) —
   bounds every metadata or tool call made after the handshake
   (`callTool`, `listTools`, `listResources`, `listPrompts`, `readResource`,

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -177,7 +177,13 @@ interface ToolCache {
 }
 
 const CACHE_TTL_MS = 30000; // 30 seconds
-const DEFAULT_STARTUP_TIMEOUT_MS = 30000; // 30 seconds for cold `npx -y` spawn
+// Aggressive default: cover ~2s cold `npx -y` warm-cache starters while
+// keeping worst-case per-server connect near ~6s (initialize + newline /
+// content-length framing double-round-trip). JVM-based servers such as
+// Oracle SQLcl OR any first-time `npx -y` cold install can exceed this;
+// operators must raise `timeout.startup` in `mcp-servers.json` for those.
+// Aligned with Cline #13086 (30s -> 3s) and issue #1339.
+const DEFAULT_STARTUP_TIMEOUT_MS = 3000; // 3 seconds; hung servers no longer stall session creation
 const DEFAULT_TOOL_CALL_TIMEOUT_MS = 60000; // 60 seconds for per-tool call
 const MAX_PAGES = 100; // Safety cap for paginated tools/list
 
@@ -1316,7 +1322,13 @@ export class McpClientManager {
    *    {@link connectFromConfig}).
    * 3. `MCP_TOOL_TIMEOUT` environment variable (applied to both phases
    *    for backwards-compat).
-   * 4. Built-in defaults (30000ms startup, 60000ms request).
+   * 4. Built-in defaults (3000ms startup, 60000ms request).
+   *
+   * The 3s startup default (see {@link DEFAULT_STARTUP_TIMEOUT_MS}) is
+   * intentionally aggressive so a hung MCP server cannot stall session
+   * creation. JVM-based servers (e.g. Oracle SQLcl) and cold `npx -y`
+   * downloads on a fresh machine WILL need an explicit `timeout.startup`
+   * override in `mcp-servers.json`.
    */
   private getTimeoutsForServer(serverName: string): { startup: number; request: number } {
     const connection = this.connections.get(serverName);

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -41,7 +41,12 @@ export interface McpServerConfig {
    *   budgets. Missing keys fall back to the defaults below.
    *
    * Defaults when unspecified:
-   * - `startup`: 30000 ms (cold `npx -y` installs routinely take 5-15s)
+   * - `startup`: 3000 ms — aggressive cap so a hung MCP server cannot
+   *   stall session creation on the critical path. Covers ~2s cold
+   *   `npx -y` warm-cache starters while keeping worst-case per-server
+   *   connect near ~6s. JVM-based servers (e.g. Oracle SQLcl) OR a
+   *   first-time `npx -y` cold install WILL exceed this and MUST set an
+   *   explicit `timeout.startup` override here (typical values 15000-45000).
    * - `request`: 60000 ms (per-tool call deadline)
    *
    * When this field is absent, the client falls back to the config-file
@@ -97,13 +102,13 @@ export interface McpConfig {
    * - A single number applied to BOTH startup and request phases.
    * - An object `{ startup?: number; request?: number }` for independent
    *   budgets; missing keys fall back to the built-in defaults
-   *   (30000ms startup, 60000ms request).
+   *   (3000ms startup, 60000ms request).
    *
    * Resolution order at call time (per server):
    * 1. Per-server `McpServerConfig.timeout` (if set)
    * 2. Global `McpConfig.timeout` (this field)
    * 3. `MCP_TOOL_TIMEOUT` environment variable (applied to both phases)
-   * 4. Built-in defaults (30000ms startup, 60000ms request)
+   * 4. Built-in defaults (3000ms startup, 60000ms request)
    */
   timeout?: number | { startup?: number; request?: number };
 }
@@ -120,8 +125,10 @@ function getDefaultConfig(): McpConfig {
     // Optional config-file global timeout. Applied to every server that
     // does NOT declare its own `timeout` field. Accepts a bare number
     // (both phases) or `{ startup?, request? }`. Omitted from the default
-    // config so built-in defaults (30s startup, 60s request) apply until
-    // an operator explicitly opts in.
+    // config so built-in defaults (3s startup, 60s request) apply until
+    // an operator explicitly opts in. Slow-starting servers (JVM-based
+    // like Oracle SQLcl, first-time `npx -y` cold installs) MUST bump
+    // `timeout.startup` to avoid tripping the aggressive 3s default.
     // Example:
     //   "timeout": { "startup": 45000, "request": 90000 }
     servers: [

--- a/tests/mcp/client-global-timeout.test.ts
+++ b/tests/mcp/client-global-timeout.test.ts
@@ -262,10 +262,10 @@ describe('MCP global config timeout precedence', () => {
 
     await manager.connect({ ...baseServer, name: 'srv-cleared' });
 
-    // Falls through to DEFAULT_STARTUP_TIMEOUT_MS (30000).
+    // Falls through to DEFAULT_STARTUP_TIMEOUT_MS (3000; issue #1339).
     expect(mockClientConnect).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ timeout: 30000 })
+      expect.objectContaining({ timeout: 3000 })
     );
 
     // Falls through to DEFAULT_TOOL_CALL_TIMEOUT_MS (60000).

--- a/tests/mcp/client-timeout-lifecycle.test.ts
+++ b/tests/mcp/client-timeout-lifecycle.test.ts
@@ -115,6 +115,105 @@ describe('MCP timeout lifecycle', () => {
   });
 
   describe('startup phase', () => {
+    it('hung server (no initialize response) is failed after the 3s default cap', async () => {
+      // Issue #1339: with the default DEFAULT_STARTUP_TIMEOUT_MS at 3000ms,
+      // a server that never responds to initialize must fail within ~3s
+      // instead of blocking session creation for 30s (previous default).
+      mockClientConnect.mockImplementation(hangUntilAborted());
+
+      const cfg: McpServerConfig = { ...baseConfig, name: 'hung-default' };
+
+      const t0 = Date.now();
+      const connectPromise = manager.connect(cfg);
+      await vi.advanceTimersByTimeAsync(3000);
+      const connection = await connectPromise;
+      const elapsed = Date.now() - t0;
+
+      expect(connection.status).toBe('failed');
+      expect(connection.error).toMatch(/^MCP connect timed out after 3000ms /);
+      expect(connection.error).toContain("(startup timeout for server 'hung-default')");
+      expect(connection.error).toContain("increase 'timeout.startup' in mcp-servers.json");
+      // Fake-timer clock advances exactly by the amount we ticked; sanity
+      // check that the timeout was tripped by the 3s budget, not something
+      // larger. Anything under 4000ms is acceptable.
+      expect(elapsed).toBeLessThan(4000);
+    });
+
+    it('configured startup timeout overrides the 3s default', async () => {
+      // A server that legitimately needs 10s to start (JVM-based like
+      // Oracle SQLcl, or a first-time `npx -y` cold install) must be
+      // able to opt out of the aggressive default via `timeout.startup`.
+      // With `timeout: { startup: 10000 }`, a connect that would trip
+      // after 3s (default) must instead succeed after ~5s.
+      mockClientConnect.mockImplementation(async (_transport, options) => {
+        // Simulate a 5s-slow initialize that respects the caller signal.
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => resolve(), 5000);
+          const signal = (options as { signal?: AbortSignal } | undefined)?.signal;
+          if (signal) {
+            signal.addEventListener('abort', () => {
+              clearTimeout(timer);
+              const err = new Error('The operation was aborted');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          }
+        });
+      });
+
+      const cfg: McpServerConfig = {
+        ...baseConfig,
+        name: 'slow-cold-start',
+        timeout: { startup: 10000 },
+      };
+
+      const connectPromise = manager.connect(cfg);
+      // Advance past the 3s default (which must NOT trip) and up to the
+      // 5s the simulated server needs.
+      await vi.advanceTimersByTimeAsync(5000);
+      const connection = await connectPromise;
+
+      expect(connection.status).toBe('connected');
+      expect(connection.error).toBeUndefined();
+      // Confirm the SDK was called with the raised 10s budget, not the
+      // 3s default.
+      expect(mockClientConnect).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ timeout: 10000 })
+      );
+    });
+
+    it('multiple slow servers stay under an aggregate deadline with the 3s cap', async () => {
+      // Three hung servers connected in parallel must each hit the 3s
+      // default independently. Aggregate wall-clock (fake-timer) must
+      // stay well under 10s because Promise.all lets them share the
+      // same clock window rather than serialising 3 x 3s.
+      mockClientConnect.mockImplementation(hangUntilAborted());
+
+      const cfgs: McpServerConfig[] = [
+        { ...baseConfig, name: 'slow-1' },
+        { ...baseConfig, name: 'slow-2' },
+        { ...baseConfig, name: 'slow-3' },
+      ];
+
+      const t0 = Date.now();
+      const connectPromise = Promise.all(cfgs.map((c) => manager.connect(c)));
+      await vi.advanceTimersByTimeAsync(3000);
+      const connections = await connectPromise;
+      const elapsed = Date.now() - t0;
+
+      // All three must have failed with the same actionable message.
+      for (const conn of connections) {
+        expect(conn.status).toBe('failed');
+        expect(conn.error).toMatch(/^MCP connect timed out after 3000ms /);
+        expect(conn.error).toContain("increase 'timeout.startup' in mcp-servers.json");
+      }
+      // Aggregate window: 3 hung servers connected in parallel must
+      // resolve within a single 3s budget, not 9s. 10s is a generous
+      // upper bound catching any accidental serialization regression.
+      expect(elapsed).toBeLessThan(10000);
+    });
+
     it('aborts client.connect() when the startup budget elapses and names the bound', async () => {
       // Make the SDK connect hang until its signal aborts.
       mockClientConnect.mockImplementation(hangUntilAborted());

--- a/tests/mcp/client-timeout.test.ts
+++ b/tests/mcp/client-timeout.test.ts
@@ -277,12 +277,13 @@ describe('MCP Tool Call Timeout', () => {
       );
     });
 
-    it('should use default startup timeout for connect when no config timeout', async () => {
+    it('should use default startup timeout (3s) for connect when no config timeout', async () => {
       await manager.connect(stdioConfig);
 
+      // Issue #1339: hung-server guard — default startup shrunk 30s -> 3s.
       expect(mockClientConnect).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ timeout: 30000 })
+        expect.objectContaining({ timeout: 3000 })
       );
     });
 

--- a/tests/mcp/timeout.test.ts
+++ b/tests/mcp/timeout.test.ts
@@ -175,10 +175,10 @@ describe('MCP split startup / request timeouts', () => {
 
     await manager.connect(cfg);
 
-    // Default startup timeout is 30000ms
+    // Default startup timeout is 3000ms (issue #1339: hung-server guard).
     expect(mockClientConnect).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ timeout: 30000 })
+      expect.objectContaining({ timeout: 3000 })
     );
 
     const result = await runTimingCall(manager, 'request-only', 2000);
@@ -191,10 +191,10 @@ describe('MCP split startup / request timeouts', () => {
 
     await manager.connect(cfg);
 
-    // Default startup: 30000ms
+    // Default startup: 3000ms (issue #1339: hung-server guard).
     expect(mockClientConnect).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ timeout: 30000 })
+      expect.objectContaining({ timeout: 3000 })
     );
 
     // Default request: 60000ms


### PR DESCRIPTION
## Summary

Cap the default MCP `startup` timeout from 30s to 3s so a hung MCP server that never completes `initialize` can no longer stall session creation on the critical path.

Cline #13086 landed the same 30s -> 3s reduction upstream. Alexi had the same 30s default and the same issue.

## Changes

- `src/mcp/client.ts`: `DEFAULT_STARTUP_TIMEOUT_MS` 30000 -> 3000, with a comment explaining the trade-off and pointing at issue #1339 + Cline #13086.
- `src/mcp/config.ts`: JSDoc on `McpServerConfig.timeout` and `McpConfig.timeout` updated to name the new 3s default and call out that JVM-based servers (Oracle SQLcl) OR first-time cold `npx -y` installs MUST set an explicit `timeout.startup` override.
- `docs/ARCHITECTURE.md`: MCP timeout section reflects the new default and lists the JVM/cold-`npx` exception.
- Tests updated: assertions that previously expected the SDK to be called with `timeout: 30000` now expect `timeout: 3000` (`timeout.test.ts`, `client-timeout.test.ts`, `client-global-timeout.test.ts`).
- New tests in `client-timeout-lifecycle.test.ts`:
  - Hung server (no initialize response) is failed after 3s using the default cap.
  - Configured `timeout.startup=10000` overrides the 3s default.
  - Three parallel hung servers stay under a 10s aggregate deadline (parallel connects share a single 3s window, not 3x3s).

## Config override path (verified unchanged)

Resolution order from `McpClientManager.getTimeoutsForServer`:
1. Per-server `McpServerConfig.timeout` (bare number OR `{ startup?, request? }`)
2. Global `McpConfig.timeout`
3. `MCP_TOOL_TIMEOUT` env var
4. Built-in defaults (now 3000ms startup, 60000ms request)

Existing tests that pin per-server startup budgets (`client-timeout-lifecycle.test.ts` uses `4000`-`30000`ms explicitly) continue to pass unchanged, confirming per-server override wins over the new default. `client-global-timeout.test.ts` continues to verify the global override layer.

## Verification

Local gate all green:

- `npm run lint` -> 0 errors
- `npm run typecheck` -> clean
- `npm run format:check` -> clean
- `npm run test:coverage` -> 264 files, 3774 pass, lines 67.03% (well above 40% CI threshold)
- `npm run build` -> clean

Closes #1339