### PR TITLE
feat(providers): support Claude 4.5/4.6/4.7 opus family and skip temperature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,19 @@
 AICORE_SERVICE_KEY='{"serviceurls":{"AI_API_URL":"https://api.ai.***"},"clientid":"***","clientsecret":"***","url":"https://***.authentication.sap.hana.ondemand.com","identityzone":"***","identityzoneid":"***"}'
 AICORE_DEPLOYMENT_ID=xxxxxxxx
 AICORE_RESOURCE_GROUP=default
-AICORE_MODEL=gpt-5
+# Supported model families (see src/providers/sapOrchestration.ts
+# ORCHESTRATION_MODELS for the full catalog):
+#   OpenAI     : gpt-4o, gpt-4o-mini, gpt-4.1, gpt-5, gpt-5-mini
+#   Anthropic  : anthropic--claude-3.7-sonnet,
+#                anthropic--claude-4.5-{haiku,sonnet,opus},
+#                anthropic--claude-4.6-opus,
+#                anthropic--claude-4.7-opus
+#   Google     : gemini-2.5-flash, gemini-2.5-pro
+#   Amazon     : amazon--nova-{micro,lite,pro}
+#   DeepSeek   : deepseek-ai--deepseek-r1
+# Note: the `temperature` parameter is deprecated for Claude Opus 4.1+
+# and is automatically omitted from requests to those models.
+AICORE_MODEL=anthropic--claude-4.7-opus
 
 # OpenAI-compatible proxy (recommended for quick start)
 SAP_PROXY_BASE_URL=http://127.0.0.1:3001/v1

--- a/routing-config.example.json
+++ b/routing-config.example.json
@@ -53,6 +53,15 @@
       "maxTokens": 200000,
       "reasoning": true,
       "enabled": true
+    },
+    {
+      "id": "anthropic--claude-4.7-opus",
+      "type": "claude",
+      "costTier": "expensive",
+      "strengths": ["deep-reasoning", "complex-analysis", "long-context", "research", "advanced-coding"],
+      "maxTokens": 200000,
+      "reasoning": true,
+      "enabled": true
     }
   ],
   "rules": [

--- a/src/providers/__tests__/model-match.test.ts
+++ b/src/providers/__tests__/model-match.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   ANTHROPIC_MODELS,
   isAnthropicModel,
+  isClaudeOpus4,
   modelSupportsReasoningEffort,
   supportsReasoning,
 } from '../model-match.js';
@@ -107,5 +108,112 @@ describe('isAnthropicModel', () => {
     expect(isAnthropicModel('deepseek-r1')).toBe(false);
     expect(isAnthropicModel('gemini-2.5-pro')).toBe(false);
     expect(isAnthropicModel('')).toBe(false);
+  });
+});
+
+describe('ANTHROPIC_MODELS catalog - Aider #5173 additions', () => {
+  it('includes bare Anthropic opus 4.1 / 4.5 / 4.6 / 4.7 ids', () => {
+    expect(ANTHROPIC_MODELS).toContain('claude-opus-4-1');
+    expect(ANTHROPIC_MODELS).toContain('claude-opus-4-5');
+    expect(ANTHROPIC_MODELS).toContain('claude-opus-4-6');
+    expect(ANTHROPIC_MODELS).toContain('claude-opus-4-7');
+  });
+
+  it('includes dated snapshot ids for opus 4.1+ variants', () => {
+    expect(ANTHROPIC_MODELS).toContain('claude-opus-4-1-20250805');
+    expect(ANTHROPIC_MODELS).toContain('claude-opus-4-5-20251101');
+    expect(ANTHROPIC_MODELS).toContain('claude-opus-4-6-20260205');
+    expect(ANTHROPIC_MODELS).toContain('claude-opus-4-7-20260416');
+  });
+
+  it('includes the dated claude-3-7-sonnet snapshot id', () => {
+    expect(ANTHROPIC_MODELS).toContain('claude-3-7-sonnet-20250219');
+  });
+
+  it('includes SAP-shaped 4.5 / 4.6 / 4.7 opus aliases', () => {
+    expect(ANTHROPIC_MODELS).toContain('claude-4.5-opus');
+    expect(ANTHROPIC_MODELS).toContain('claude-4.6-opus');
+    expect(ANTHROPIC_MODELS).toContain('claude-4.7-opus');
+  });
+});
+
+describe('isAnthropicModel - new Claude opus 4.1+ ids', () => {
+  it('recognizes bare opus-4-N ids', () => {
+    expect(isAnthropicModel('claude-opus-4-1')).toBe(true);
+    expect(isAnthropicModel('claude-opus-4-5')).toBe(true);
+    expect(isAnthropicModel('claude-opus-4-6')).toBe(true);
+    expect(isAnthropicModel('claude-opus-4-7')).toBe(true);
+  });
+
+  it('recognizes dated snapshot ids', () => {
+    expect(isAnthropicModel('claude-opus-4-1-20250805')).toBe(true);
+    expect(isAnthropicModel('claude-opus-4-7-20260416')).toBe(true);
+  });
+
+  it('recognizes SAP AI Core provider-prefixed opus 4.1+ ids', () => {
+    expect(isAnthropicModel('sap-ai-core/anthropic--claude-4.5-opus')).toBe(true);
+    expect(isAnthropicModel('sap-ai-core/anthropic--claude-4.6-opus')).toBe(true);
+    expect(isAnthropicModel('sap-ai-core/anthropic--claude-4.7-opus')).toBe(true);
+  });
+});
+
+describe('isClaudeOpus4', () => {
+  it('returns true for bare opus-4-N ids', () => {
+    expect(isClaudeOpus4('claude-opus-4-1')).toBe(true);
+    expect(isClaudeOpus4('claude-opus-4-5')).toBe(true);
+    expect(isClaudeOpus4('claude-opus-4-6')).toBe(true);
+    expect(isClaudeOpus4('claude-opus-4-7')).toBe(true);
+  });
+
+  it('returns true for dated snapshot ids', () => {
+    expect(isClaudeOpus4('claude-opus-4-1-20250805')).toBe(true);
+    expect(isClaudeOpus4('claude-opus-4-7-20260416')).toBe(true);
+  });
+
+  it('returns true for SAP double-dash 4.N-opus ids', () => {
+    expect(isClaudeOpus4('anthropic--claude-4.5-opus')).toBe(true);
+    expect(isClaudeOpus4('anthropic--claude-4.6-opus')).toBe(true);
+    expect(isClaudeOpus4('anthropic--claude-4.7-opus')).toBe(true);
+  });
+
+  it('returns true for provider-prefixed SAP forms', () => {
+    expect(isClaudeOpus4('sap-ai-core/anthropic--claude-4.7-opus')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isClaudeOpus4('CLAUDE-OPUS-4-7')).toBe(true);
+    expect(isClaudeOpus4('SAP-AI-CORE/ANTHROPIC--CLAUDE-4.7-OPUS')).toBe(true);
+  });
+
+  it('returns false for unversioned claude-4-opus (backwards compatibility)', () => {
+    // The deprecation only applies to 4.1+ per Aider #5173. The bare
+    // `claude-4-opus` alias must keep sending `temperature` for callers
+    // that still rely on it.
+    expect(isClaudeOpus4('claude-4-opus')).toBe(false);
+  });
+
+  it('returns false for the SAP extended-context claude-opus-4-1221-v1 alias', () => {
+    // `-1221-v1` is a Cline-side extended-context version tag on the
+    // UNVERSIONED opus-4, not the Anthropic 4.1 minor revision. Matching
+    // it as opus-4.1 would incorrectly drop temperature for a family
+    // that still accepts it.
+    expect(isClaudeOpus4('claude-opus-4-1221-v1')).toBe(false);
+  });
+
+  it('returns false for bare claude-opus-4 (no minor revision)', () => {
+    expect(isClaudeOpus4('claude-opus-4')).toBe(false);
+  });
+
+  it('returns false for Claude Sonnet and Haiku variants', () => {
+    expect(isClaudeOpus4('claude-4.5-sonnet')).toBe(false);
+    expect(isClaudeOpus4('anthropic--claude-4.5-sonnet')).toBe(false);
+    expect(isClaudeOpus4('anthropic--claude-4.5-haiku')).toBe(false);
+    expect(isClaudeOpus4('claude-3.7-sonnet')).toBe(false);
+  });
+
+  it('returns false for non-Anthropic models', () => {
+    expect(isClaudeOpus4('gpt-4o')).toBe(false);
+    expect(isClaudeOpus4('deepseek-r1')).toBe(false);
+    expect(isClaudeOpus4('')).toBe(false);
   });
 });

--- a/src/providers/model-match.ts
+++ b/src/providers/model-match.ts
@@ -91,6 +91,15 @@ export function isClaude(modelId: string): boolean {
  *
  * Added claude-opus-4, sonnet-4.5, sonnet-4.7 + -1221-v1 variants
  * (Cline #12620, 2026-07-20).
+ *
+ * Added claude-opus-4-1 / -4-5 / -4-6 / -4-7 and their dated snapshot ids
+ * (Aider #5173, 2026-08-10). SAP AI Core's naming convention uses the
+ * double-dash form (e.g. `anthropic--claude-4.5-opus`), so both forms are
+ * included: the SAP-native `claude-<major>.<minor>-opus` shape is already
+ * covered by substring detection via `claude-opus-4`, but the bare Anthropic
+ * `claude-opus-4-<minor>` and dated `claude-opus-4-<minor>-<yyyymmdd>` ids
+ * are listed explicitly so they are recognized when a routing config or
+ * environment variable references upstream Anthropic ids directly.
  */
 export const ANTHROPIC_MODELS: readonly string[] = [
   // Claude 3 family
@@ -100,17 +109,28 @@ export const ANTHROPIC_MODELS: readonly string[] = [
   'claude-3.5-sonnet',
   'claude-3.5-haiku',
   'claude-3.7-sonnet',
+  'claude-3-7-sonnet-20250219',
   // Claude 4 family
   'claude-4-opus',
   'claude-4-sonnet',
   'claude-opus-4',
   'claude-opus-4-1221-v1',
+  'claude-opus-4-1',
+  'claude-opus-4-1-20250805',
+  'claude-opus-4-5',
+  'claude-opus-4-5-20251101',
+  'claude-opus-4-6',
+  'claude-opus-4-6-20260205',
+  'claude-opus-4-7',
+  'claude-opus-4-7-20260416',
   'claude-sonnet-4',
   'claude-sonnet-4.5',
   'claude-sonnet-4.5-1221-v1',
   'claude-sonnet-4.7',
   'claude-sonnet-4.7-1221-v1',
   // Alexi-pinned agent model (SAP AI Core provider-prefixed form)
+  'claude-4.5-opus',
+  'claude-4.6-opus',
   'claude-4.7-opus',
 ];
 
@@ -131,6 +151,49 @@ export function isAnthropicModel(modelId: string): boolean {
     }
   }
   return isClaude(modelId);
+}
+
+/**
+ * Check if a model id refers to a Claude Opus 4 family variant (any minor
+ * revision >= 4, including dated snapshots and SAP-prefixed forms).
+ *
+ * Anthropic deprecated the `temperature` sampling parameter for the Opus 4
+ * family in favour of adaptive reasoning controls (per Aider #5173). Callers
+ * that assemble a request payload for these models MUST omit `temperature`
+ * — sending it triggers an API-side warning and, in some SAP AI Core
+ * deployment revisions, a `400 invalid_request` response.
+ *
+ * Detection rules (case-insensitive, any match wins):
+ *  - `opus-4` or `opus-4-<n>` (bare Anthropic naming), including dated
+ *    snapshot ids like `claude-opus-4-1-20250805`.
+ *  - `4.<n>-opus` (SAP AI Core double-dash naming, e.g.
+ *    `anthropic--claude-4.5-opus`).
+ *  - Provider-prefixed forms like `sap-ai-core/anthropic--claude-4.7-opus`
+ *    are matched via the substring rules above.
+ *
+ * Deliberately NOT matched:
+ *  - `claude-4-opus` (unversioned Claude 4 opus alias — the deprecation
+ *    only applies to 4.1+ per Aider #5173; keep temperature for the
+ *    unversioned family alias for backwards compatibility).
+ *
+ * @param modelId - The model identifier to test
+ * @returns true when the model belongs to the Claude Opus 4.1+ family
+ */
+export function isClaudeOpus4(modelId: string): boolean {
+  const lower = modelId.toLowerCase();
+  // Bare Anthropic naming: `opus-4-<n>` where <n> is a single-digit minor
+  // revision. Dated snapshots (`opus-4-<n>-<yyyymmdd>`) match because the
+  // year suffix begins with a non-digit separator after the minor number.
+  // The negative lookahead prevents `claude-opus-4-1221-v1` (SAP extended-
+  // context variant of the unversioned opus-4) from matching as opus-4.1.
+  if (/\bopus-4-\d(?!\d)/.test(lower)) {
+    return true;
+  }
+  // SAP double-dash naming: `4.<n>-opus` (e.g. `anthropic--claude-4.5-opus`).
+  if (/\b4\.\d+-opus\b/.test(lower)) {
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/src/providers/sapOrchestration.ts
+++ b/src/providers/sapOrchestration.ts
@@ -42,6 +42,7 @@ import {
   ReauthenticationRequiredError,
   NoRefreshTokenError,
 } from './auth.js';
+import { isClaudeOpus4 } from './model-match.js';
 import { env } from '../config/env.js';
 
 // Types are exported from the main package
@@ -973,8 +974,24 @@ export class SapOrchestrationProvider {
     // Build model params
     const modelParams: Record<string, unknown> = {
       max_tokens: options?.maxTokens ?? this.config.maxTokens ?? 4096,
-      temperature: options?.temperature ?? this.config.temperature ?? 0.7,
     };
+
+    // Anthropic deprecated the `temperature` parameter for the Claude Opus 4
+    // family (4.1+) in favour of adaptive reasoning controls (Aider #5173,
+    // 2026-08-10). Sending `temperature` to these models triggers an API-side
+    // warning and, in some SAP AI Core deployment revisions, a
+    // `400 invalid_request`. Older Anthropic families and non-Anthropic
+    // models still accept `temperature` normally and keep the previous
+    // default of 0.7 when neither the caller nor the config supplies one.
+    if (!isClaudeOpus4(this.config.modelName)) {
+      modelParams.temperature = options?.temperature ?? this.config.temperature ?? 0.7;
+    } else if (options?.temperature !== undefined || this.config.temperature !== undefined) {
+      // Caller explicitly asked for a temperature on an Opus 4 model.
+      // Honour the explicit request — the caller may be pinning behaviour
+      // for a specific deployment revision that still accepts it — but do
+      // NOT synthesise a default when neither side asked for one.
+      modelParams.temperature = options?.temperature ?? this.config.temperature;
+    }
 
     if (options?.topP !== undefined || this.config.topP !== undefined) {
       modelParams.top_p = options?.topP ?? this.config.topP;
@@ -1507,8 +1524,22 @@ export function createToolResponse(toolCallId: string, content: string | object)
 // ============================================================================
 
 /**
- * List of models available through SAP AI Core Orchestration
- * Based on SAP documentation
+ * List of models available through SAP AI Core Orchestration.
+ *
+ * Naming convention: SAP AI Core uses a double-dash form
+ * `<vendor>--<model-name>` (e.g. `anthropic--claude-4.5-opus`). Anthropic
+ * ids in this list use the `<major>.<minor>-<opus|sonnet|haiku>` shape,
+ * which is the SAP-side spelling of the underlying Anthropic model id.
+ * When calling `SapOrchestrationProvider` with a model that is NOT in
+ * this catalog, callers must supply the `deploymentId` escape hatch —
+ * a mismatch between the SAP AI Core deployment and the id here will
+ * surface as an `Invalid model` error from the SDK.
+ *
+ * Anthropic Opus 4.1+ variants (`4.5-opus`, `4.6-opus`, `4.7-opus`)
+ * added to keep parity with SAP's rolling deployment of the Claude
+ * Opus 4 family (Aider #5173, 2026-08-10). The `temperature` parameter
+ * is intentionally omitted from requests to these models — see
+ * `buildModuleConfig` and `isClaudeOpus4` in `./model-match.js`.
  */
 export const ORCHESTRATION_MODELS = [
   // OpenAI models
@@ -1522,6 +1553,7 @@ export const ORCHESTRATION_MODELS = [
   'anthropic--claude-4.5-haiku',
   'anthropic--claude-4.5-sonnet',
   'anthropic--claude-4.5-opus',
+  'anthropic--claude-4.6-opus',
   'anthropic--claude-4.7-opus',
   // Google models
   'gemini-2.5-flash',

--- a/tests/providers/sapOrchestration-temperature.test.ts
+++ b/tests/providers/sapOrchestration-temperature.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for temperature plumbing in the SAP Orchestration provider.
+ *
+ * Anthropic deprecated the `temperature` sampling parameter for the
+ * Claude Opus 4 family (4.1+) in favour of adaptive reasoning controls
+ * (Aider #5173, 2026-08-10). These tests verify that:
+ *
+ *  - `temperature` is omitted from `modelParams` for Opus 4.1+ ids when
+ *    neither the config nor the per-call options request one.
+ *  - An explicitly requested `temperature` is still forwarded for Opus
+ *    4.1+ ids (caller override wins).
+ *  - Other Anthropic families (haiku, sonnet, older opus) and non-
+ *    Anthropic models still receive the default `temperature` of 0.7
+ *    when unspecified.
+ *  - Per-call `temperature` overrides `config.temperature` for
+ *    non-Opus-4 families.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture module configs the provider hands to OrchestrationClient
+let capturedModuleConfigs: Array<Record<string, unknown>> = [];
+
+vi.mock('@sap-ai-sdk/orchestration', () => {
+  class MockOrchestrationClient {
+    constructor(
+      public _moduleConfig: Record<string, unknown>,
+      public _deploymentConfig: unknown
+    ) {
+      capturedModuleConfigs.push(_moduleConfig);
+    }
+
+    async chatCompletion(_params: { messages: unknown[] }) {
+      return {
+        getContent: () => 'ok',
+        getFinishReason: () => 'stop',
+        getTokenUsage: () => ({
+          completion_tokens: 1,
+          prompt_tokens: 1,
+          total_tokens: 2,
+        }),
+        getToolCalls: () => [],
+        getAllMessages: () => [],
+      };
+    }
+  }
+
+  return {
+    OrchestrationClient: MockOrchestrationClient,
+    OrchestrationEmbeddingClient: vi.fn(),
+    buildAzureContentSafetyFilter: vi.fn().mockReturnValue({}),
+    buildLlamaGuard38BFilter: vi.fn().mockReturnValue({}),
+    buildDpiMaskingProvider: vi.fn().mockReturnValue({}),
+    buildDocumentGroundingConfig: vi.fn().mockReturnValue({}),
+    buildTranslationConfig: vi.fn().mockReturnValue({}),
+  };
+});
+
+vi.mock('../../src/config/env.js', () => ({
+  env: vi.fn((key: string) => {
+    if (key === 'AICORE_RESOURCE_GROUP') {
+      return 'default';
+    }
+    return undefined;
+  }),
+}));
+
+import { SapOrchestrationProvider } from '../../src/providers/sapOrchestration.js';
+
+type ModuleConfigShape = {
+  promptTemplating?: {
+    model?: {
+      name?: string;
+      version?: string;
+      params?: Record<string, unknown>;
+    };
+  };
+};
+
+function getModelParams(mc: Record<string, unknown>): Record<string, unknown> {
+  const model = (mc as ModuleConfigShape).promptTemplating?.model;
+  return (model?.params ?? {}) as Record<string, unknown>;
+}
+
+describe('SapOrchestrationProvider temperature plumbing - Opus 4.1+', () => {
+  beforeEach(() => {
+    capturedModuleConfigs = [];
+  });
+
+  it('omits temperature from modelParams for anthropic--claude-4.5-opus', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-4.5-opus',
+      deploymentId: 'test-deployment',
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }]);
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect('temperature' in modelParams).toBe(false);
+  });
+
+  it('omits temperature for anthropic--claude-4.6-opus', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-4.6-opus',
+      deploymentId: 'test-deployment',
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }]);
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect('temperature' in modelParams).toBe(false);
+  });
+
+  it('omits temperature for anthropic--claude-4.7-opus (pinned agent model)', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-4.7-opus',
+      deploymentId: 'test-deployment',
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }]);
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect('temperature' in modelParams).toBe(false);
+  });
+
+  it('still forwards temperature when the caller explicitly requests one on Opus 4.1+', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-4.7-opus',
+      deploymentId: 'test-deployment',
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }], { temperature: 0.2 });
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect(modelParams.temperature).toBe(0.2);
+  });
+
+  it('still forwards config.temperature when set for Opus 4.1+', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-4.7-opus',
+      deploymentId: 'test-deployment',
+      temperature: 0.4,
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }]);
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect(modelParams.temperature).toBe(0.4);
+  });
+});
+
+describe('SapOrchestrationProvider temperature plumbing - non-Opus-4 families', () => {
+  beforeEach(() => {
+    capturedModuleConfigs = [];
+  });
+
+  it('applies the default temperature of 0.7 for gpt-4o when unspecified', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'gpt-4o',
+      deploymentId: 'test-deployment',
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }]);
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect(modelParams.temperature).toBe(0.7);
+  });
+
+  it('applies the default temperature of 0.7 for anthropic--claude-4.5-sonnet', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-4.5-sonnet',
+      deploymentId: 'test-deployment',
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }]);
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect(modelParams.temperature).toBe(0.7);
+  });
+
+  it('applies the default temperature of 0.7 for anthropic--claude-3.7-sonnet', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'anthropic--claude-3.7-sonnet',
+      deploymentId: 'test-deployment',
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }]);
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect(modelParams.temperature).toBe(0.7);
+  });
+
+  it('honours per-call temperature override over config.temperature', async () => {
+    const provider = new SapOrchestrationProvider({
+      modelName: 'gpt-4o',
+      deploymentId: 'test-deployment',
+      temperature: 0.3,
+    });
+
+    await provider.complete([{ role: 'user', content: 'hi' }], { temperature: 0.9 });
+
+    const modelParams = getModelParams(capturedModuleConfigs[0]);
+    expect(modelParams.temperature).toBe(0.9);
+  });
+});


### PR DESCRIPTION
## What

Verify and enhance Claude 4.5/4.6/4.7 model support in the provider layer, aligned with Aider #5173.

- Add new opus-4.1+ ids (bare Anthropic, dated snapshots, and SAP double-dash aliases) to `ANTHROPIC_MODELS`.
- Add `anthropic--claude-4.6-opus` to `ORCHESTRATION_MODELS` (SAP AI Core now deploys 4.5 / 4.6 / 4.7 side-by-side).
- Introduce `isClaudeOpus4()` helper in `src/providers/model-match.ts` and wire it into `SapOrchestrationProvider.buildModuleConfig` so `temperature` is omitted for the Opus 4.1+ family (deprecated by Anthropic).
- Update `.env.example` and `routing-config.example.json` to reflect the current model catalog.

## Why

Anthropic deprecated the `temperature` sampling parameter for the Claude Opus 4 family (4.1+) in favour of adaptive reasoning controls; sending it triggers API warnings and 400s on some SAP AI Core deployment revisions. Alexi needs to recognize the new ids and route the request payload accordingly.

## How

- `isClaudeOpus4` matches:
  - bare Anthropic: `opus-4-<n>` (single-digit minor, so `-1221-v1` extended-context alias is NOT misclassified)
  - dated snapshots: `opus-4-<n>-<yyyymmdd>`
  - SAP double-dash: `4.<n>-opus`
  - all case-insensitive and works with `sap-ai-core/` prefix.
- `buildModuleConfig` omits `temperature` for opus-4.1+ when neither caller nor config supplies one, but still forwards an explicit override (preserving caller-override contract).

## Testing

- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format:check` — clean
- `npm test` — 3800 passed / 62 skipped
- `npm run build` — clean
- Coverage stayed above the 40% line gate (Lines: 67.06%).

## Done when

- [x] All Claude 4.5/4.6/4.7 model IDs from Aider #5173 are recognized
- [x] `ORCHESTRATION_MODELS` and `ANTHROPIC_MODELS` are up-to-date
- [x] Temperature parameter is omitted for opus-4 family models
- [x] Tests cover new model IDs (bare, prefixed, dated) and temperature handling
- [x] All quality gates pass

Closes #1344