### PR TITLE
feat(cli): enhanced TUI tool output with disclosure

### DIFF
--- a/src/cli/tui/components/DiffView.tsx
+++ b/src/cli/tui/components/DiffView.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Box, Text } from 'ink';
+import { highlight } from 'cli-highlight';
 
 import { useTheme } from '../context/ThemeContext.js';
 import type { DiffHunk, DiffLine } from '../context/ChatContext.js';
+import { guessLanguageFromPath } from '../utils/formatToolOutput.js';
 
 export interface DiffViewProps {
   filePath: string;
@@ -75,12 +77,29 @@ function countChanges(hunks: DiffHunk[]): { additions: number; deletions: number
  * - diffLineNumber color for gutter
  * - Collapsible long diffs (first 10 lines + "N more")
  */
+/**
+ * Best-effort syntax highlight of a single line. Falls back to the raw
+ * text on any highlighter failure (unknown language, illegal input, …)
+ * so a broken highlighter never breaks the diff render.
+ */
+function highlightLine(content: string, language: string | undefined): string {
+  if (!language || content.length === 0) {
+    return content;
+  }
+  try {
+    return highlight(content, { language, ignoreIllegals: true });
+  } catch {
+    return content;
+  }
+}
+
 export function DiffView({ filePath, hunks }: DiffViewProps): React.JSX.Element {
   const { theme } = useTheme();
   const { colors } = theme;
 
   const gutterWidth = computeGutterWidth(hunks);
   const { additions, deletions } = countChanges(hunks);
+  const language = guessLanguageFromPath(filePath);
 
   return (
     <Box flexDirection="column">
@@ -140,12 +159,14 @@ export function DiffView({ filePath, hunks }: DiffViewProps): React.JSX.Element 
 
                   const gutter = `${padNum(leftNum, gutterWidth)} ${padNum(rightNum, gutterWidth)}`;
 
+                  const highlighted = highlightLine(line.content, language);
+
                   return (
                     <Box key={lineIdx}>
                       <Text color={colors.diffLineNumber}>{gutter} </Text>
                       <Text color={lineColor} backgroundColor={bgColor}>
                         {linePrefix(line.type)}
-                        {line.content}
+                        {highlighted}
                       </Text>
                     </Box>
                   );

--- a/src/cli/tui/components/MessageArea.tsx
+++ b/src/cli/tui/components/MessageArea.tsx
@@ -4,7 +4,7 @@ import { Box, Text } from 'ink';
 import { MessageBubble } from './MessageBubble.js';
 import { MarkdownRenderer } from './MarkdownRenderer.js';
 import { Spinner } from './Spinner.js';
-import { ToolCallBlock } from './ToolCallBlock.js';
+import { ToolRow } from './ToolRow.js';
 import type { ToolCallState } from '../context/ChatContext.js';
 import { useTheme } from '../context/ThemeContext.js';
 import type { ImageAttachmentPreview } from '../context/AttachmentContext.js';
@@ -82,7 +82,7 @@ export function MessageArea({
             images={msg.images}
           />
           {msg.toolCalls.map((tc) => (
-            <ToolCallBlock
+            <ToolRow
               key={tc.id}
               toolName={tc.toolName}
               params={tc.params}
@@ -99,7 +99,7 @@ export function MessageArea({
 
       {/* Active tool calls (currently executing) */}
       {activeToolCalls.map((tc) => (
-        <ToolCallBlock
+        <ToolRow
           key={tc.id}
           toolName={tc.toolName}
           params={tc.params}

--- a/src/cli/tui/components/ToolCallBlock.tsx
+++ b/src/cli/tui/components/ToolCallBlock.tsx
@@ -1,193 +1,21 @@
 import React from 'react';
-import { Box, Text } from 'ink';
 
-import { useTheme } from '../context/ThemeContext.js';
-import { DiffView } from './DiffView.js';
-import { Spinner } from './Spinner.js';
-import type { DiffData } from '../context/ChatContext.js';
+import { ToolRow, type ToolRowProps } from './ToolRow.js';
 
-export interface ToolCallBlockProps {
-  toolName: string;
-  params: Record<string, unknown>;
-  status: 'pending' | 'running' | 'completed' | 'failed';
-  output: string | null;
-  error: string | null;
-  isExpanded: boolean;
-  onToggle: () => void;
-  diff: DiffData | null;
-  /** Duration in ms (set on completion) */
-  duration?: number;
-}
-
-const MAX_OUTPUT_LINES = 20;
-const TRUNCATED_OUTPUT_LINES = 15;
-
-/** Tool-specific icons */
-const TOOL_ICONS: Record<string, string> = {
-  read: '📄',
-  write: '✏️',
-  edit: '✏️',
-  grep: '🔍',
-  glob: '🔍',
-  bash: '⚡',
-  fetch: '🌐',
-};
+export type ToolCallBlockProps = ToolRowProps;
 
 /**
- * Format tool params as key-value pairs, not raw JSON.
+ * ToolCallBlock — thin wrapper around {@link ToolRow}.
+ *
+ * Historically this component owned the entire rendering logic for a
+ * tool call. It now delegates to `ToolRow` so that the row-level
+ * concerns (disclosure state, status colors, terminal-style command
+ * output, syntax-highlighted diffs) live in one place and can be reused
+ * by consumers that want per-call rendering.
+ *
+ * The public prop shape is preserved so existing callers (MessageArea
+ * and its tests) do not need to change.
  */
-function formatParamsPreview(params: Record<string, unknown>): string {
-  const entries = Object.entries(params);
-  if (entries.length === 0) {
-    return '';
-  }
-  // Show the most relevant param (usually filePath, command, pattern, etc.)
-  const keyParams = ['filePath', 'path', 'file', 'command', 'pattern', 'query'];
-  for (const key of keyParams) {
-    if (key in params) {
-      const val = String(params[key]);
-      return val.length > 50 ? `${key}: ${val.slice(0, 50)}…` : `${key}: ${val}`;
-    }
-  }
-  // Fallback: first param
-  const [key, val] = entries[0];
-  const valStr = String(val);
-  return valStr.length > 50 ? `${key}: ${valStr.slice(0, 50)}…` : `${key}: ${valStr}`;
-}
-
-function truncateOutput(text: string): { text: string; truncated: boolean; remaining: number } {
-  const lines = text.split('\n');
-  if (lines.length > MAX_OUTPUT_LINES) {
-    const remaining = lines.length - TRUNCATED_OUTPUT_LINES;
-    return {
-      text: lines.slice(0, TRUNCATED_OUTPUT_LINES).join('\n'),
-      truncated: true,
-      remaining,
-    };
-  }
-  return { text, truncated: false, remaining: 0 };
-}
-
-function formatDuration(ms: number): string {
-  if (ms >= 1000) {
-    return `${(ms / 1000).toFixed(1)}s`;
-  }
-  return `${ms}ms`;
-}
-
-export function ToolCallBlock({
-  toolName,
-  params,
-  status,
-  output,
-  error,
-  isExpanded,
-  onToggle,
-  diff,
-  duration,
-}: ToolCallBlockProps): React.JSX.Element {
-  void onToggle;
-  const { theme } = useTheme();
-  const { colors } = theme;
-
-  const paramsPreview = formatParamsPreview(params);
-  const icon = TOOL_ICONS[toolName] ?? '🔧';
-
-  // Auto-expand on failure
-  const shouldShow = isExpanded || status === 'failed';
-
-  const renderStatusIcon = (): React.JSX.Element => {
-    if (status === 'pending') {
-      return <Text color={colors.dimText}>○ </Text>;
-    }
-    if (status === 'running') {
-      return <Spinner />;
-    }
-    if (status === 'completed') {
-      return <Text color={colors.success}>✓ </Text>;
-    }
-    return <Text color={colors.error}>✗ </Text>;
-  };
-
-  const renderStatusLabel = (): React.JSX.Element => {
-    if (status === 'pending') {
-      return <Text color={colors.dimText}> pending</Text>;
-    }
-    if (status === 'running') {
-      return <Text color={colors.warning}> running…</Text>;
-    }
-    if (status === 'completed') {
-      const dur = duration !== undefined ? ` ${formatDuration(duration)}` : '';
-      return <Text color={colors.dimText}> done{dur}</Text>;
-    }
-    return <Text color={colors.error}> failed</Text>;
-  };
-
-  const renderBody = (): React.JSX.Element | null => {
-    if (!shouldShow) {
-      return null;
-    }
-
-    let bodyContent: React.JSX.Element | null = null;
-
-    if (error !== null) {
-      bodyContent = <Text color={colors.error}>{error}</Text>;
-    } else if (diff !== null) {
-      bodyContent = <DiffView filePath={diff.filePath} hunks={diff.hunks} />;
-    } else if (toolName === 'bash' && output !== null) {
-      const command = typeof params.command === 'string' ? params.command : '';
-      const { text: truncatedText, truncated, remaining } = truncateOutput(output);
-      bodyContent = (
-        <Box flexDirection="column">
-          <Text color={colors.toolOutput}>
-            <Text bold>$ {command}</Text>
-            {'\n'}
-            {truncatedText}
-          </Text>
-          {truncated ? <Text color={colors.dimText}>... ({remaining} more lines)</Text> : null}
-        </Box>
-      );
-    } else if (output !== null) {
-      const { text: truncatedText, truncated, remaining } = truncateOutput(output);
-      bodyContent = (
-        <Box flexDirection="column">
-          <Text color={colors.toolOutput}>{truncatedText}</Text>
-          {truncated ? <Text color={colors.dimText}>... ({remaining} more lines)</Text> : null}
-        </Box>
-      );
-    }
-
-    if (bodyContent === null) {
-      return null;
-    }
-
-    return (
-      <Box
-        borderLeft
-        borderStyle="single"
-        borderColor={colors.borderDim}
-        paddingLeft={1}
-        borderTop={false}
-        borderRight={false}
-        borderBottom={false}
-      >
-        {bodyContent}
-      </Box>
-    );
-  };
-
-  return (
-    <Box flexDirection="column" paddingLeft={2}>
-      <Box>
-        {renderStatusIcon()}
-        <Text>{icon} </Text>
-        <Text color={colors.toolHeader} bold>
-          {toolName}
-        </Text>
-        {paramsPreview && <Text color={colors.dimText}> {paramsPreview}</Text>}
-        {renderStatusLabel()}
-      </Box>
-      {renderBody()}
-    </Box>
-  );
+export function ToolCallBlock(props: ToolCallBlockProps): React.JSX.Element {
+  return <ToolRow {...props} />;
 }

--- a/src/cli/tui/components/ToolRow.tsx
+++ b/src/cli/tui/components/ToolRow.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+import { useTheme } from '../context/ThemeContext.js';
+import { DiffView } from './DiffView.js';
+import { Spinner } from './Spinner.js';
+import type { DiffData } from '../context/ChatContext.js';
+import {
+  formatBashCommand,
+  formatDuration,
+  formatParamsPreview,
+  truncateOutput,
+} from '../utils/formatToolOutput.js';
+
+export type ToolStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface ToolRowProps {
+  toolName: string;
+  params: Record<string, unknown>;
+  status: ToolStatus;
+  output: string | null;
+  error: string | null;
+  isExpanded: boolean;
+  onToggle: () => void;
+  diff: DiffData | null;
+  /** Duration in ms (set on completion) */
+  duration?: number;
+}
+
+/** Tool-specific icons */
+const TOOL_ICONS: Record<string, string> = {
+  read: '\u{1F4C4}',
+  write: '\u270F\uFE0F',
+  edit: '\u270F\uFE0F',
+  grep: '\u{1F50D}',
+  glob: '\u{1F50D}',
+  bash: '\u26A1',
+  fetch: '\u{1F310}',
+};
+
+/**
+ * ToolRow — a single tool call rendered as one row (header) with an
+ * optional expanded body underneath.
+ *
+ * Behaviour:
+ * - Row header shows a status icon, tool icon, tool name, params preview,
+ *   and status label. Header color follows the tool's status.
+ * - Body renders only when `isExpanded` is true OR the tool has failed
+ *   (failures auto-expand so users see errors without having to interact).
+ * - Bash commands render with a terminal-style `$ command` prefix.
+ * - Edit diffs render through `DiffView` (which applies syntax
+ *   highlighting when a language can be inferred from the file path).
+ *
+ * `onToggle` is invoked when the user interacts with the row (via the
+ * keyboard handler in the parent). This component itself does not bind
+ * input — that stays with the parent to keep the render tree pure.
+ */
+export function ToolRow({
+  toolName,
+  params,
+  status,
+  output,
+  error,
+  isExpanded,
+  onToggle,
+  diff,
+  duration,
+}: ToolRowProps): React.JSX.Element {
+  void onToggle;
+  const { theme } = useTheme();
+  const { colors } = theme;
+
+  const paramsPreview = formatParamsPreview(params);
+  const icon = TOOL_ICONS[toolName] ?? '\u{1F527}';
+
+  const shouldShow = isExpanded || status === 'failed';
+
+  const statusColor: string =
+    status === 'running'
+      ? colors.toolRunning
+      : status === 'failed'
+        ? colors.toolFailed
+        : status === 'completed'
+          ? colors.toolCompleted
+          : colors.dimText;
+
+  const renderStatusIcon = (): React.JSX.Element => {
+    if (status === 'pending') {
+      return <Text color={colors.dimText}>{'\u25CB '}</Text>;
+    }
+    if (status === 'running') {
+      return <Spinner />;
+    }
+    if (status === 'completed') {
+      return <Text color={colors.success}>{'\u2713 '}</Text>;
+    }
+    return <Text color={colors.toolFailed}>{'\u2717 '}</Text>;
+  };
+
+  const renderStatusLabel = (): React.JSX.Element => {
+    if (status === 'pending') {
+      return <Text color={colors.dimText}> pending</Text>;
+    }
+    if (status === 'running') {
+      return <Text color={colors.toolRunning}>{' running\u2026'}</Text>;
+    }
+    if (status === 'completed') {
+      const dur = duration !== undefined ? ` ${formatDuration(duration)}` : '';
+      return <Text color={colors.toolCompleted}> done{dur}</Text>;
+    }
+    return <Text color={colors.toolFailed}> failed</Text>;
+  };
+
+  const renderBody = (): React.JSX.Element | null => {
+    if (!shouldShow) {
+      return null;
+    }
+
+    let bodyContent: React.JSX.Element | null = null;
+
+    if (error !== null) {
+      bodyContent = <Text color={colors.error}>{error}</Text>;
+    } else if (diff !== null) {
+      bodyContent = <DiffView filePath={diff.filePath} hunks={diff.hunks} />;
+    } else if (toolName === 'bash' && output !== null) {
+      const command = typeof params.command === 'string' ? params.command : '';
+      const commandLine = formatBashCommand(command);
+      const { text: truncatedText, truncated, remaining } = truncateOutput(output);
+      bodyContent = (
+        <Box flexDirection="column">
+          <Text color={colors.toolOutput}>
+            <Text bold>{commandLine}</Text>
+            {'\n'}
+            {truncatedText}
+          </Text>
+          {truncated ? <Text color={colors.dimText}>... ({remaining} more lines)</Text> : null}
+        </Box>
+      );
+    } else if (output !== null) {
+      const { text: truncatedText, truncated, remaining } = truncateOutput(output);
+      bodyContent = (
+        <Box flexDirection="column">
+          <Text color={colors.toolOutput}>{truncatedText}</Text>
+          {truncated ? <Text color={colors.dimText}>... ({remaining} more lines)</Text> : null}
+        </Box>
+      );
+    }
+
+    if (bodyContent === null) {
+      return null;
+    }
+
+    return (
+      <Box
+        borderLeft
+        borderStyle="single"
+        borderColor={colors.borderDim}
+        paddingLeft={1}
+        borderTop={false}
+        borderRight={false}
+        borderBottom={false}
+      >
+        {bodyContent}
+      </Box>
+    );
+  };
+
+  return (
+    <Box flexDirection="column" paddingLeft={2}>
+      <Box>
+        {renderStatusIcon()}
+        <Text>{icon} </Text>
+        <Text color={statusColor} bold>
+          {toolName}
+        </Text>
+        {paramsPreview && <Text color={colors.dimText}> {paramsPreview}</Text>}
+        {renderStatusLabel()}
+      </Box>
+      {renderBody()}
+    </Box>
+  );
+}

--- a/src/cli/tui/theme/dark.ts
+++ b/src/cli/tui/theme/dark.ts
@@ -22,6 +22,11 @@ export const darkTheme: ThemeColors = {
   warning: '#f5a742',
   info: '#56b6c2',
 
+  // Tool-call status
+  toolRunning: '#9d7cd8', // violet — active/running
+  toolCompleted: '#6a6a6a', // dim — succeeded
+  toolFailed: '#e06c75', // red — failed
+
   // Agent colors
   agents: {
     code: '#7fd88f',

--- a/src/cli/tui/theme/light.ts
+++ b/src/cli/tui/theme/light.ts
@@ -22,6 +22,11 @@ export const lightTheme: ThemeColors = {
   warning: '#d68c27',
   info: '#318795',
 
+  // Tool-call status
+  toolRunning: '#7b5bb6', // violet — active/running
+  toolCompleted: '#8a8a8a', // dim — succeeded
+  toolFailed: '#d1383d', // red — failed
+
   // Agent colors
   agents: {
     code: '#3d9a57',

--- a/src/cli/tui/theme/types.ts
+++ b/src/cli/tui/theme/types.ts
@@ -22,6 +22,11 @@ export interface ThemeColors {
   warning: string;
   info: string;
 
+  // Tool-call status colors (drive per-row styling in ToolRow)
+  toolRunning: string;
+  toolCompleted: string;
+  toolFailed: string;
+
   // Agent colors
   agents: Record<AgentName, string>;
 

--- a/src/cli/tui/utils/formatToolOutput.ts
+++ b/src/cli/tui/utils/formatToolOutput.ts
@@ -1,0 +1,122 @@
+/**
+ * Utilities for formatting tool output in the TUI.
+ *
+ * These helpers are pure string transformations kept separate from the
+ * React components so they can be unit-tested without a render harness.
+ */
+
+const DEFAULT_MAX_OUTPUT_LINES = 20;
+const DEFAULT_TRUNCATED_OUTPUT_LINES = 15;
+const DEFAULT_PARAM_PREVIEW_LEN = 50;
+
+/**
+ * Format a bash command with the classic terminal `$ ` prefix.
+ *
+ * The prefix is intentionally NOT bolded here — styling is applied by the
+ * caller through Ink's `<Text bold>` element so the raw string stays easy
+ * to test and reason about.
+ */
+export function formatBashCommand(command: string): string {
+  const trimmed = command.trimEnd();
+  return `$ ${trimmed}`;
+}
+
+export interface TruncatedOutput {
+  text: string;
+  truncated: boolean;
+  remaining: number;
+}
+
+/**
+ * Truncate multi-line output to at most `maxLines`. When truncation is
+ * triggered we keep the first `keepLines` lines and return how many were
+ * hidden so the caller can render a "N more lines" hint.
+ */
+export function truncateOutput(
+  text: string,
+  maxLines: number = DEFAULT_MAX_OUTPUT_LINES,
+  keepLines: number = DEFAULT_TRUNCATED_OUTPUT_LINES
+): TruncatedOutput {
+  const lines = text.split('\n');
+  if (lines.length > maxLines) {
+    const remaining = lines.length - keepLines;
+    return {
+      text: lines.slice(0, keepLines).join('\n'),
+      truncated: true,
+      remaining,
+    };
+  }
+  return { text, truncated: false, remaining: 0 };
+}
+
+/**
+ * Render a compact "key: value" preview of the most relevant tool
+ * parameter. Long values are truncated with an ellipsis.
+ */
+export function formatParamsPreview(
+  params: Record<string, unknown>,
+  maxLen: number = DEFAULT_PARAM_PREVIEW_LEN
+): string {
+  const entries = Object.entries(params);
+  if (entries.length === 0) {
+    return '';
+  }
+  const keyParams = ['filePath', 'path', 'file', 'command', 'pattern', 'query'];
+  for (const key of keyParams) {
+    if (key in params) {
+      const val = String(params[key]);
+      return val.length > maxLen ? `${key}: ${val.slice(0, maxLen)}\u2026` : `${key}: ${val}`;
+    }
+  }
+  const [key, val] = entries[0];
+  const valStr = String(val);
+  return valStr.length > maxLen ? `${key}: ${valStr.slice(0, maxLen)}\u2026` : `${key}: ${valStr}`;
+}
+
+/**
+ * Human-friendly duration string (ms or s with one decimal).
+ */
+export function formatDuration(ms: number): string {
+  if (ms >= 1000) {
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+  return `${ms}ms`;
+}
+
+/**
+ * Best-effort language guess for a file path, used to drive syntax
+ * highlighting of diffs. Returns `undefined` when no reasonable guess
+ * can be made — callers should fall back to plain text in that case.
+ */
+export function guessLanguageFromPath(filePath: string): string | undefined {
+  const match = /\.([a-zA-Z0-9]+)$/.exec(filePath);
+  if (!match) {
+    return undefined;
+  }
+  const ext = match[1].toLowerCase();
+  const map: Record<string, string> = {
+    ts: 'typescript',
+    tsx: 'typescript',
+    js: 'javascript',
+    jsx: 'javascript',
+    mjs: 'javascript',
+    cjs: 'javascript',
+    json: 'json',
+    md: 'markdown',
+    yml: 'yaml',
+    yaml: 'yaml',
+    sh: 'bash',
+    bash: 'bash',
+    py: 'python',
+    rb: 'ruby',
+    go: 'go',
+    rs: 'rust',
+    java: 'java',
+    css: 'css',
+    scss: 'scss',
+    html: 'html',
+    xml: 'xml',
+    toml: 'toml',
+  };
+  return map[ext];
+}

--- a/tests/cli/tui/ToolRow.test.tsx
+++ b/tests/cli/tui/ToolRow.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+
+import { ToolRow, type ToolRowProps } from '../../../src/cli/tui/components/ToolRow.js';
+import { ThemeProvider } from '../../../src/cli/tui/context/ThemeContext.js';
+import type { DiffData } from '../../../src/cli/tui/context/ChatContext.js';
+
+const defaultProps = (): ToolRowProps => ({
+  toolName: 'read',
+  params: { filePath: '/tmp/test.ts' },
+  status: 'completed',
+  output: 'file contents here',
+  error: null,
+  isExpanded: true,
+  onToggle: vi.fn(),
+  diff: null,
+});
+
+function renderRow(overrides: Partial<ToolRowProps> = {}) {
+  return render(
+    <ThemeProvider>
+      <ToolRow {...defaultProps()} {...overrides} />
+    </ThemeProvider>
+  );
+}
+
+describe('ToolRow', () => {
+  it('renders tool name in header', () => {
+    const { lastFrame } = renderRow();
+    expect(lastFrame()).toContain('read');
+  });
+
+  it('renders pending status', () => {
+    const { lastFrame } = renderRow({ status: 'pending' });
+    expect(lastFrame()).toContain('\u25CB');
+    expect(lastFrame()).toContain('pending');
+  });
+
+  it('renders running status label with ellipsis', () => {
+    const { lastFrame } = renderRow({ status: 'running' });
+    expect(lastFrame()).toContain('running\u2026');
+  });
+
+  it('renders completed status with checkmark', () => {
+    const { lastFrame } = renderRow({ status: 'completed' });
+    expect(lastFrame()).toContain('\u2713');
+    expect(lastFrame()).toContain('done');
+  });
+
+  it('renders failed status with cross', () => {
+    const { lastFrame } = renderRow({ status: 'failed' });
+    expect(lastFrame()).toContain('\u2717');
+    expect(lastFrame()).toContain('failed');
+  });
+
+  it('hides output when collapsed and status is not failed', () => {
+    const { lastFrame } = renderRow({
+      isExpanded: false,
+      status: 'completed',
+      output: 'hidden-output',
+    });
+    expect(lastFrame()).not.toContain('hidden-output');
+  });
+
+  it('shows output when expanded', () => {
+    const { lastFrame } = renderRow({
+      isExpanded: true,
+      status: 'completed',
+      output: 'visible-output',
+    });
+    expect(lastFrame()).toContain('visible-output');
+  });
+
+  it('auto-expands when status is failed regardless of isExpanded', () => {
+    const { lastFrame } = renderRow({
+      isExpanded: false,
+      status: 'failed',
+      error: 'something went wrong',
+    });
+    expect(lastFrame()).toContain('something went wrong');
+  });
+
+  it('renders bash command with terminal $ prefix', () => {
+    const { lastFrame } = renderRow({
+      toolName: 'bash',
+      params: { command: 'npm test' },
+      output: 'PASS 1 test',
+      isExpanded: true,
+    });
+    expect(lastFrame()).toContain('$ npm test');
+    expect(lastFrame()).toContain('PASS 1 test');
+  });
+
+  it('renders duration on completed status when provided', () => {
+    const { lastFrame } = renderRow({ status: 'completed', duration: 1500 });
+    expect(lastFrame()).toContain('1.5s');
+  });
+
+  it('renders diff view when a diff is provided and expanded', () => {
+    const diff: DiffData = {
+      filePath: '/src/example.ts',
+      hunks: [
+        {
+          oldStart: 1,
+          oldLines: 3,
+          newStart: 1,
+          newLines: 4,
+          lines: [
+            { type: 'context', content: 'const a = 1;' },
+            { type: 'remove', content: 'const b = 2;' },
+            { type: 'add', content: 'const b = 3;' },
+          ],
+        },
+      ],
+    };
+    const { lastFrame } = renderRow({ diff, isExpanded: true });
+    expect(lastFrame()).toContain('/src/example.ts');
+  });
+
+  it('renders unknown tool with a generic icon (no crash)', () => {
+    const { lastFrame } = renderRow({ toolName: 'mystery' });
+    expect(lastFrame()).toContain('mystery');
+  });
+
+  it('truncates long output with a "more lines" hint', () => {
+    const lines = Array.from({ length: 40 }, (_, i) => `row ${i + 1}`).join('\n');
+    const { lastFrame } = renderRow({ output: lines, isExpanded: true });
+    expect(lastFrame()).toContain('more lines');
+  });
+});

--- a/tests/cli/tui/formatToolOutput.test.ts
+++ b/tests/cli/tui/formatToolOutput.test.ts
@@ -1,0 +1,115 @@
+import {
+  formatBashCommand,
+  formatDuration,
+  formatParamsPreview,
+  guessLanguageFromPath,
+  truncateOutput,
+} from '../../../src/cli/tui/utils/formatToolOutput.js';
+import { describe, it, expect } from 'vitest';
+
+describe('formatBashCommand', () => {
+  it('prefixes command with $ ', () => {
+    expect(formatBashCommand('npm test')).toBe('$ npm test');
+  });
+
+  it('trims trailing whitespace', () => {
+    expect(formatBashCommand('ls -la   ')).toBe('$ ls -la');
+  });
+
+  it('handles empty command', () => {
+    expect(formatBashCommand('')).toBe('$ ');
+  });
+});
+
+describe('truncateOutput', () => {
+  it('returns the input untouched when within maxLines', () => {
+    const text = 'a\nb\nc';
+    const result = truncateOutput(text, 20, 15);
+    expect(result.truncated).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.text).toBe(text);
+  });
+
+  it('truncates output beyond maxLines to keepLines', () => {
+    const lines = Array.from({ length: 25 }, (_, i) => `line ${i + 1}`).join('\n');
+    const result = truncateOutput(lines, 20, 15);
+    expect(result.truncated).toBe(true);
+    expect(result.remaining).toBe(10);
+    expect(result.text.split('\n')).toHaveLength(15);
+    expect(result.text).toContain('line 1');
+    expect(result.text).toContain('line 15');
+    expect(result.text).not.toContain('line 16');
+  });
+
+  it('uses defaults when no bounds are passed', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `l${i}`).join('\n');
+    const result = truncateOutput(lines);
+    expect(result.truncated).toBe(true);
+  });
+});
+
+describe('formatParamsPreview', () => {
+  it('returns empty string for empty params', () => {
+    expect(formatParamsPreview({})).toBe('');
+  });
+
+  it('prefers filePath over other keys', () => {
+    const preview = formatParamsPreview({ filePath: '/tmp/x.ts', foo: 'bar' });
+    expect(preview).toBe('filePath: /tmp/x.ts');
+  });
+
+  it('prefers command for bash-like tools', () => {
+    const preview = formatParamsPreview({ command: 'ls -la' });
+    expect(preview).toBe('command: ls -la');
+  });
+
+  it('falls back to the first param when no known key is present', () => {
+    const preview = formatParamsPreview({ custom: 'value' });
+    expect(preview).toBe('custom: value');
+  });
+
+  it('truncates long values with an ellipsis', () => {
+    const longVal = 'a'.repeat(80);
+    const preview = formatParamsPreview({ filePath: longVal }, 20);
+    expect(preview).toContain('\u2026');
+    expect(preview.length).toBeLessThan(40);
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats sub-second durations in ms', () => {
+    expect(formatDuration(250)).toBe('250ms');
+  });
+
+  it('formats second-scale durations with one decimal', () => {
+    expect(formatDuration(1500)).toBe('1.5s');
+  });
+
+  it('handles zero', () => {
+    expect(formatDuration(0)).toBe('0ms');
+  });
+});
+
+describe('guessLanguageFromPath', () => {
+  it('maps common extensions to languages', () => {
+    expect(guessLanguageFromPath('/src/foo.ts')).toBe('typescript');
+    expect(guessLanguageFromPath('foo.tsx')).toBe('typescript');
+    expect(guessLanguageFromPath('foo.js')).toBe('javascript');
+    expect(guessLanguageFromPath('foo.json')).toBe('json');
+    expect(guessLanguageFromPath('foo.md')).toBe('markdown');
+    expect(guessLanguageFromPath('script.sh')).toBe('bash');
+    expect(guessLanguageFromPath('a.py')).toBe('python');
+  });
+
+  it('returns undefined for unknown extensions', () => {
+    expect(guessLanguageFromPath('foo.xyz')).toBeUndefined();
+  });
+
+  it('returns undefined for paths without an extension', () => {
+    expect(guessLanguageFromPath('Makefile')).toBeUndefined();
+  });
+
+  it('is case-insensitive', () => {
+    expect(guessLanguageFromPath('FOO.TS')).toBe('typescript');
+  });
+});


### PR DESCRIPTION
Closes #1365

## Summary

Refactor tool-call rendering into a per-row component with disclosure state,
terminal-style command output, syntax-highlighted diffs, and status-driven colors.

## Changes

- **New `ToolRow` component** (`src/cli/tui/components/ToolRow.tsx`)
  - Single row per tool call. Expands on demand and auto-expands on failure so errors are always visible.
  - Header color tracks status via new theme tokens (`toolRunning` = violet, `toolCompleted` = dim, `toolFailed` = red).
- **New `formatToolOutput` utility** (`src/cli/tui/utils/formatToolOutput.ts`)
  - Pure string helpers: `formatBashCommand` (`$ command` prefix), `truncateOutput`, `formatParamsPreview`, `formatDuration`, `guessLanguageFromPath`.
  - Covered by `tests/cli/tui/formatToolOutput.test.ts`.
- **`DiffView` gets syntax highlighting** via `cli-highlight`, keyed on the file extension. Falls back to plain text on unknown languages or highlighter errors so the diff never breaks.
- **Theme gains status colors** in `types.ts`/`dark.ts`/`light.ts` (`toolRunning`, `toolCompleted`, `toolFailed`).
- **`MessageArea`** now renders `ToolRow` directly (one row per tool call).
- **`ToolCallBlock`** retained as a thin wrapper around `ToolRow` so existing callers and tests keep working.

## Tests

- New: `tests/cli/tui/ToolRow.test.tsx` (12 tests: disclosure toggle, auto-expand on failure, bash `$` prefix, duration, diff render, truncation, unknown-tool fallback).
- New: `tests/cli/tui/formatToolOutput.test.ts` (unit tests for every helper).
- Existing suites (`ToolCallBlock`, `DiffView`, `MessageArea`) still pass unchanged.

## Gates

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run format:check` — clean
- `npm run test:coverage` — 3868 tests pass, lines 67.33%
- `npm run build` — succeeds