### PR TITLE
feat: Extract WarpGrep to standalone MCP server (#1370)

### DIFF
--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -1,0 +1,122 @@
+# MCP Servers
+
+Alexi speaks the [Model Context Protocol](https://modelcontextprotocol.io)
+(MCP) natively. External MCP servers extend the built-in tool surface
+without adding weight to the `alexi` CLI binary and can be versioned
+independently.
+
+## Where to register servers
+
+Alexi loads MCP server definitions from `mcp-servers.json` in the workspace
+root, and (as a fallback) from `~/.alexi/mcp-servers.json`. The schema is:
+
+```json
+{
+  "mcpServers": {
+    "<local-name>": {
+      "command": "<executable>",
+      "args": ["<arg1>", "<arg2>"],
+      "env": {
+        "<VAR>": "${VAR}"
+      }
+    }
+  }
+}
+```
+
+The `<local-name>` is only used to identify the connection in Alexi logs;
+tool names come from the server itself.
+
+## Bundled servers
+
+### `alexi-mcp-warpgrep` - semantic code search
+
+The `codebase_search` (WarpGrep) tool used to be built into `alexi`. It is
+now shipped as a standalone MCP server package:
+[`alexi-mcp-warpgrep`](../packages/alexi-mcp-warpgrep/README.md).
+
+#### Why the migration
+
+- Smaller `alexi` binary and dependency tree (`@morphllm/morphsdk` stays
+  optional).
+- The tool can evolve on its own release cadence.
+- Consistent with the upstream Kilo MCP-first architecture direction
+  (Kilo #13084).
+
+#### Installation
+
+```bash
+npm install alexi-mcp-warpgrep @morphllm/morphsdk
+```
+
+or globally:
+
+```bash
+npm install -g alexi-mcp-warpgrep @morphllm/morphsdk
+```
+
+#### Configuration
+
+Add the server to `mcp-servers.json`:
+
+```json
+{
+  "mcpServers": {
+    "alexi-warpgrep": {
+      "command": "node",
+      "args": ["./node_modules/alexi-mcp-warpgrep/dist/index.js"],
+      "env": {
+        "MORPH_API_KEY": "${MORPH_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+If installed globally:
+
+```json
+{
+  "mcpServers": {
+    "alexi-warpgrep": {
+      "command": "alexi-mcp-warpgrep",
+      "env": {
+        "MORPH_API_KEY": "${MORPH_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Restart your Alexi session; `codebase_search` will now be provided by the
+MCP server. The tool name and parameter shape are unchanged, so no prompt
+or agent updates are required.
+
+#### Deprecation timeline
+
+- **Now**: the built-in `codebase_search` tool is functional but emits a
+  one-shot deprecation warning to the log on first use.
+- **Next major release**: the built-in implementation will be removed.
+  Users relying on semantic search must have `alexi-mcp-warpgrep`
+  registered.
+
+If both the built-in tool and the MCP server are available, the built-in
+tool wins (it registers first). To force the MCP path early, uninstall or
+disable `@morphllm/morphsdk` from the `alexi` install so the built-in
+availability check returns `false`.
+
+## Writing your own MCP server
+
+Follow the pattern in
+[`packages/alexi-mcp-warpgrep/src/index.ts`](../packages/alexi-mcp-warpgrep/src/index.ts):
+
+1. Depend on `@modelcontextprotocol/server` and `zod`.
+2. Create an `McpServer` instance with name/version.
+3. Call `server.registerTool(name, { description, inputSchema }, handler)`
+   for each tool.
+4. `await server.connect(new StdioServerTransport())` in `main()`.
+5. Ship an executable bin so `mcp-servers.json` can spawn it via
+   `command`/`args`.
+
+Prefer stdio transport for local servers; use HTTP/WebSocket only when the
+server must be shared across multiple clients.

--- a/packages/alexi-mcp-warpgrep/.gitignore
+++ b/packages/alexi-mcp-warpgrep/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.log

--- a/packages/alexi-mcp-warpgrep/.npmignore
+++ b/packages/alexi-mcp-warpgrep/.npmignore
@@ -1,0 +1,6 @@
+src/
+tests/
+tsconfig.json
+*.log
+node_modules/
+.gitignore

--- a/packages/alexi-mcp-warpgrep/README.md
+++ b/packages/alexi-mcp-warpgrep/README.md
@@ -1,0 +1,97 @@
+# alexi-mcp-warpgrep
+
+Standalone [Model Context Protocol](https://modelcontextprotocol.io) server
+exposing [WarpGrep](https://morphllm.com/) semantic code search as a
+`codebase_search` tool.
+
+This package replaces the built-in `codebase_search` tool that used to ship
+inside the Alexi CLI. Bundling it as an MCP server keeps the Alexi core
+lean and lets you version / distribute semantic search independently.
+
+## Requirements
+
+- Node.js `>= 22.12.0`
+- `@morphllm/morphsdk` installed (optional peer dependency)
+- Optional: `MORPH_API_KEY` environment variable. During the Kilo free
+  period the server falls back to the `api.kilo.ai` proxy when no key is
+  set.
+
+## Installation
+
+```bash
+npm install alexi-mcp-warpgrep @morphllm/morphsdk
+```
+
+You can also install globally so the `alexi-mcp-warpgrep` bin is on `$PATH`:
+
+```bash
+npm install -g alexi-mcp-warpgrep @morphllm/morphsdk
+```
+
+## Configuration
+
+Add the server to your `mcp-servers.json` (Alexi looks up this file from the
+current workspace and from `~/.alexi/`):
+
+```json
+{
+  "mcpServers": {
+    "alexi-warpgrep": {
+      "command": "node",
+      "args": ["./node_modules/alexi-mcp-warpgrep/dist/index.js"],
+      "env": {
+        "MORPH_API_KEY": "${MORPH_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+If the server is installed globally, replace the `command` and `args` with:
+
+```json
+{
+  "mcpServers": {
+    "alexi-warpgrep": {
+      "command": "alexi-mcp-warpgrep",
+      "env": {
+        "MORPH_API_KEY": "${MORPH_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+## Tool: `codebase_search`
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `query` | `string` | Natural-language description of the code you are looking for. |
+
+Returns a JSON payload with `spans` (each `{ filePath, startLine, endLine, content }`) and the original `query`. Empty result sets return a plain text hint so LLM clients can distinguish "no matches" from "error".
+
+## Migrating from the built-in tool
+
+The built-in `codebase_search` tool inside `alexi` is deprecated and now
+emits a warning when invoked. It will be removed in a future major release.
+To switch:
+
+1. Install this package plus `@morphllm/morphsdk`.
+2. Register the server in `mcp-servers.json` as shown above.
+3. Restart your Alexi session.
+
+The tool name is identical (`codebase_search`), so no prompt changes are
+required.
+
+## Development
+
+```bash
+npm install
+npm run typecheck
+npm run test
+npm run build
+```
+
+## License
+
+MIT

--- a/packages/alexi-mcp-warpgrep/package.json
+++ b/packages/alexi-mcp-warpgrep/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "alexi-mcp-warpgrep",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "WarpGrep MCP server for semantic code search - standalone MCP server exposing @morphllm/morphsdk as a `codebase_search` tool",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "alexi-mcp-warpgrep": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/server": "^2.0.0",
+    "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "@morphllm/morphsdk": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@morphllm/morphsdk": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "warpgrep",
+    "codebase-search",
+    "semantic-search",
+    "alexi"
+  ],
+  "author": "Ausard",
+  "license": "MIT"
+}

--- a/packages/alexi-mcp-warpgrep/src/index.ts
+++ b/packages/alexi-mcp-warpgrep/src/index.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * alexi-mcp-warpgrep - MCP server entry point
+ *
+ * Exposes the `codebase_search` tool over the MCP protocol using stdio
+ * transport. Designed to be registered in `mcp-servers.json` and driven by
+ * an MCP client (Alexi, Claude Desktop, etc.).
+ */
+
+import { McpServer } from '@modelcontextprotocol/server';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+
+import { WARPGREP_DESCRIPTION, WarpGrepParamsSchema, warpgrepExecute } from './warpgrep.js';
+
+/**
+ * Build a fresh, unstarted `McpServer` with the `codebase_search` tool
+ * registered. Exported for tests so they can inspect registration without
+ * connecting to a live transport.
+ */
+export function createWarpgrepServer(opts: { repoRoot?: string } = {}): McpServer {
+  const server = new McpServer({
+    name: 'alexi-mcp-warpgrep',
+    version: '1.0.0',
+  });
+
+  server.registerTool(
+    'codebase_search',
+    {
+      title: 'Codebase Search',
+      description: WARPGREP_DESCRIPTION,
+      inputSchema: WarpGrepParamsSchema,
+    },
+    async ({ query }) => {
+      const outcome = await warpgrepExecute({ query }, { repoRoot: opts.repoRoot });
+
+      if (!outcome.success) {
+        return {
+          content: [{ type: 'text' as const, text: outcome.error }],
+          isError: true,
+        };
+      }
+
+      const payload =
+        outcome.data.spans.length === 0
+          ? (outcome.hint ?? 'No relevant code found for the given query.')
+          : JSON.stringify(outcome.data, null, 2);
+
+      return {
+        content: [{ type: 'text' as const, text: payload }],
+      };
+    }
+  );
+
+  return server;
+}
+
+/**
+ * Boot the server on stdio and block until the transport closes.
+ */
+export async function main(): Promise<void> {
+  const server = createWarpgrepServer({ repoRoot: process.cwd() });
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // Log to stderr so it does not corrupt the JSON-RPC stream on stdout.
+  process.stderr.write('[alexi-mcp-warpgrep] MCP server started on stdio\n');
+}
+
+// Only auto-run when this module is invoked directly (not when imported by
+// tests or other consumers). Guarded by an `import.meta.url` check that
+// works under both `node dist/index.js` and `alexi-mcp-warpgrep` bin usage.
+const isEntry =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (isEntry) {
+  main().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[alexi-mcp-warpgrep] fatal: ${message}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/alexi-mcp-warpgrep/src/types.ts
+++ b/packages/alexi-mcp-warpgrep/src/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared types for the alexi-mcp-warpgrep server.
+ */
+
+/**
+ * A single code span returned by the underlying WarpGrep search.
+ */
+export interface CodeSpan {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  content: string;
+}
+
+/**
+ * Successful WarpGrep search result. The `spans` array may be empty when
+ * the query produced no matches; callers should treat an empty array as a
+ * valid "no results" outcome, not an error.
+ */
+export interface WarpGrepResult {
+  spans: CodeSpan[];
+  query: string;
+}
+
+/**
+ * Structured error returned by `warpgrepExecute` when the search cannot be
+ * performed. Kept separate from `WarpGrepResult` so callers can pattern
+ * match on the discriminated union.
+ */
+export interface WarpGrepError {
+  error: string;
+}
+
+/**
+ * Discriminated union returned by `warpgrepExecute`. Consumers should
+ * narrow on `success` before accessing `data`/`error`.
+ */
+export type WarpGrepOutcome =
+  | { success: true; data: WarpGrepResult; hint?: string }
+  | { success: false; error: string };

--- a/packages/alexi-mcp-warpgrep/src/warpgrep.ts
+++ b/packages/alexi-mcp-warpgrep/src/warpgrep.ts
@@ -1,0 +1,208 @@
+/**
+ * WarpGrep core - AI-powered semantic code search.
+ *
+ * This module is a standalone extraction of the built-in `codebase_search`
+ * tool from Alexi. It intentionally has no dependency on Alexi internals
+ * (telemetry, tool registry, permission system) so the MCP server can be
+ * distributed independently.
+ */
+
+import { z } from 'zod';
+import type { CodeSpan, WarpGrepOutcome } from './types.js';
+
+/**
+ * Zod schema for `codebase_search` parameters. Exported so callers (the MCP
+ * server entry point, tests, and downstream integrators) can share a single
+ * source of truth.
+ */
+export const WarpGrepParamsSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      'Search query describing what code you are looking for. Be specific and descriptive for best results.'
+    ),
+});
+
+export type WarpGrepParams = z.infer<typeof WarpGrepParamsSchema>;
+
+/**
+ * Tool description shown to LLM clients via `tools/list`. Kept in sync with
+ * the built-in tool description in `alexi/src/tool/tools/warpgrep.ts` so a
+ * client migrating from built-in to MCP sees identical guidance.
+ */
+export const WARPGREP_DESCRIPTION = `Find code snippets by semantic meaning and return ranked matches with file paths and line ranges.
+
+## When to use
+
+- Explore an unfamiliar code area before you know exact identifiers
+- Find related implementations of a concept or behavior across the workspace
+- Search by intent such as authentication, caching, or session resume logic
+- Narrow a large codebase before following up with \`Read\` or \`Grep\`
+
+## When NOT to use
+
+- Search for an exact symbol or regex pattern - use \`Grep\`
+- Find files by filename or extension - use \`Glob\`
+- Read the contents of a known file - use \`Read\`
+- Explore files outside the current workspace - use \`Grep\`, \`Glob\`, and \`Read\`
+
+## Constraints
+
+- Write the query in English.`;
+
+/**
+ * FREE_PERIOD_TODO: Remove KILO_WARPGREP_PROXY_URL constant and the proxy
+ * fallback below. After the free period ends, require MORPH_API_KEY and
+ * return an error when it is missing.
+ */
+const KILO_WARPGREP_PROXY_URL = 'https://api.kilo.ai/api/gateway';
+
+/**
+ * Injection point for `@morphllm/morphsdk`. Kept as a module-level function
+ * so tests can override it via `setWarpgrepClientLoader` without needing to
+ * mock the ESM module graph.
+ */
+type WarpGrepClientCtor = new (config: {
+  morphApiKey: string;
+  morphApiUrl?: string;
+  timeout?: number;
+}) => {
+  execute: (input: {
+    searchTerm: string;
+    repoRoot: string;
+  }) => Promise<{ success: boolean; error?: string; codeSpans?: CodeSpan[] }>;
+};
+
+let clientLoader: () => Promise<WarpGrepClientCtor | null> = async () => {
+  try {
+    // `@morphllm/morphsdk` is an optional peer dependency; the standard
+    // dynamic import path returns `null` when it is not installed so the
+    // MCP server can respond with a helpful error instead of crashing.
+    const morphSDK = (await import(
+      // @ts-expect-error - optional peer dep, not resolvable at build time
+      '@morphllm/morphsdk'
+    )) as { WarpGrepClient?: WarpGrepClientCtor };
+    return morphSDK.WarpGrepClient ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Override the loader used to obtain the `WarpGrepClient` constructor.
+ * Primarily for tests that want to inject a stub without touching the
+ * module graph.
+ */
+export function setWarpgrepClientLoader(
+  loader: () => Promise<WarpGrepClientCtor | null>
+): void {
+  clientLoader = loader;
+}
+
+/**
+ * Reset the client loader to the default `@morphllm/morphsdk` dynamic
+ * import. Use in test `afterEach` blocks to isolate mocks.
+ */
+export function resetWarpgrepClientLoader(): void {
+  clientLoader = async () => {
+    try {
+      const morphSDK = (await import(
+        // @ts-expect-error - optional peer dep, not resolvable at build time
+        '@morphllm/morphsdk'
+      )) as { WarpGrepClient?: WarpGrepClientCtor };
+      return morphSDK.WarpGrepClient ?? null;
+    } catch {
+      return null;
+    }
+  };
+}
+
+/**
+ * Check whether `@morphllm/morphsdk` can be resolved at runtime. Returns
+ * true when the package is installed and importable, false otherwise.
+ */
+export function isWarpgrepAvailable(): boolean {
+  try {
+    // `import.meta.resolve` is synchronous in Node >= 20.
+    import.meta.resolve('@morphllm/morphsdk');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Execute a semantic code search using WarpGrep.
+ *
+ * @param params - Parsed `WarpGrepParams` (the schema is enforced by the
+ *   MCP layer, but this function also parses to stay usable standalone).
+ * @param opts.repoRoot - Absolute path to the repository root to search.
+ *   Defaults to `process.cwd()`.
+ * @returns A `WarpGrepOutcome` discriminated union. Never throws.
+ */
+export async function warpgrepExecute(
+  params: unknown,
+  opts: { repoRoot?: string } = {}
+): Promise<WarpGrepOutcome> {
+  const parsed = WarpGrepParamsSchema.safeParse(params);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: `Invalid parameters: ${parsed.error.message}`,
+    };
+  }
+
+  const WarpGrepClient = await clientLoader();
+  if (!WarpGrepClient) {
+    return {
+      success: false,
+      error:
+        'WarpGrep requires @morphllm/morphsdk to be installed. Run: npm install @morphllm/morphsdk',
+    };
+  }
+
+  const apiKey = process.env['MORPH_API_KEY'];
+  const repoRoot = opts.repoRoot ?? process.cwd();
+
+  // FREE_PERIOD_TODO: Remove proxy fallback - require apiKey, error if missing.
+  const client = new WarpGrepClient({
+    morphApiKey: apiKey ?? 'kilo-free',
+    ...(apiKey ? {} : { morphApiUrl: KILO_WARPGREP_PROXY_URL }),
+    timeout: 60000,
+  });
+
+  try {
+    const result = await client.execute({
+      searchTerm: parsed.data.query,
+      repoRoot,
+    });
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: `Search failed: ${result.error ?? 'Unknown error'}`,
+      };
+    }
+
+    const spans: CodeSpan[] = result.codeSpans ?? [];
+
+    if (spans.length === 0) {
+      return {
+        success: true,
+        data: { spans: [], query: parsed.data.query },
+        hint: 'No relevant code found for the given query.',
+      };
+    }
+
+    return {
+      success: true,
+      data: { spans, query: parsed.data.query },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      error: `WarpGrep search failed: ${message}`,
+    };
+  }
+}

--- a/packages/alexi-mcp-warpgrep/tsconfig.json
+++ b/packages/alexi-mcp-warpgrep/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/src/tool/tools/warpgrep.ts
+++ b/src/tool/tools/warpgrep.ts
@@ -5,6 +5,19 @@
 import { z } from 'zod';
 import { defineTool, type ToolResult } from '../index.js';
 import { Telemetry } from '../../utils/telemetry.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Track whether the deprecation warning has already been emitted this
+ * process so we do not spam the log on every tool call. Exported for
+ * tests to reset between cases.
+ */
+let deprecationWarningEmitted = false;
+
+/** @internal - reset the module-level deprecation flag. Test-only. */
+export function _resetWarpgrepDeprecationWarning(): void {
+  deprecationWarningEmitted = false;
+}
 
 /**
  * Check whether `@morphllm/morphsdk` can be resolved at runtime.
@@ -81,6 +94,19 @@ export const warpgrepTool = defineTool<typeof WarpGrepParamsSchema, WarpGrepResu
   parameters: WarpGrepParamsSchema,
 
   async execute(params, context): Promise<ToolResult<WarpGrepResult>> {
+    // Deprecation notice: WarpGrep is being migrated to a standalone MCP
+    // server (`alexi-mcp-warpgrep`). The built-in tool remains functional
+    // for backward compatibility but will be removed in a future major
+    // release. Emit the warning once per process to avoid log noise.
+    if (!deprecationWarningEmitted) {
+      logger.warn(
+        'The built-in `codebase_search` (WarpGrep) tool is deprecated. ' +
+          'A standalone MCP server (`alexi-mcp-warpgrep`) is now available. ' +
+          'See docs/mcp-servers.md for the migration guide.'
+      );
+      deprecationWarningEmitted = true;
+    }
+
     // Check if MorphSDK is available
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let WarpGrepClient: any;

--- a/tests/packages/alexi-mcp-warpgrep/warpgrep.test.ts
+++ b/tests/packages/alexi-mcp-warpgrep/warpgrep.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  WarpGrepParamsSchema,
+  WARPGREP_DESCRIPTION,
+  isWarpgrepAvailable,
+  resetWarpgrepClientLoader,
+  setWarpgrepClientLoader,
+  warpgrepExecute,
+} from '../../../packages/alexi-mcp-warpgrep/src/warpgrep.js';
+import { createWarpgrepServer } from '../../../packages/alexi-mcp-warpgrep/src/index.js';
+
+describe('alexi-mcp-warpgrep - core', () => {
+  afterEach(() => {
+    resetWarpgrepClientLoader();
+    delete process.env['MORPH_API_KEY'];
+  });
+
+  describe('WarpGrepParamsSchema', () => {
+    it('parses a valid query', () => {
+      const result = WarpGrepParamsSchema.safeParse({ query: 'user login' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.query).toBe('user login');
+      }
+    });
+
+    it('rejects a missing query', () => {
+      const result = WarpGrepParamsSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a non-string query', () => {
+      const result = WarpGrepParamsSchema.safeParse({ query: 42 });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('WARPGREP_DESCRIPTION', () => {
+    it('exposes usage guidance for LLM clients', () => {
+      expect(WARPGREP_DESCRIPTION).toContain('semantic meaning');
+      expect(WARPGREP_DESCRIPTION).toContain('When to use');
+      expect(WARPGREP_DESCRIPTION).toContain('When NOT to use');
+    });
+  });
+
+  describe('isWarpgrepAvailable', () => {
+    it('returns false when @morphllm/morphsdk is not resolvable', () => {
+      // In this test environment, @morphllm/morphsdk is not installed.
+      expect(isWarpgrepAvailable()).toBe(false);
+    });
+  });
+
+  describe('warpgrepExecute - error paths', () => {
+    it('returns an error when @morphllm/morphsdk is unavailable', async () => {
+      setWarpgrepClientLoader(async () => null);
+      const outcome = await warpgrepExecute({ query: 'anything' });
+      expect(outcome.success).toBe(false);
+      if (!outcome.success) {
+        expect(outcome.error).toContain('@morphllm/morphsdk');
+      }
+    });
+
+    it('returns an error on invalid parameters', async () => {
+      setWarpgrepClientLoader(async () => {
+        throw new Error('should not be called');
+      });
+      const outcome = await warpgrepExecute({ notAQuery: true });
+      expect(outcome.success).toBe(false);
+      if (!outcome.success) {
+        expect(outcome.error).toContain('Invalid parameters');
+      }
+    });
+
+    it('surfaces underlying client failures', async () => {
+      setWarpgrepClientLoader(async () => {
+        return class FakeClient {
+          async execute(): Promise<{ success: boolean; error: string }> {
+            return { success: false, error: 'upstream 502' };
+          }
+        } as unknown as Parameters<typeof setWarpgrepClientLoader>[0] extends () => Promise<infer T>
+          ? T
+          : never;
+      });
+
+      const outcome = await warpgrepExecute({ query: 'x' });
+      expect(outcome.success).toBe(false);
+      if (!outcome.success) {
+        expect(outcome.error).toContain('Search failed');
+        expect(outcome.error).toContain('upstream 502');
+      }
+    });
+
+    it('wraps thrown client errors', async () => {
+      setWarpgrepClientLoader(async () => {
+        return class ExplodingClient {
+          async execute(): Promise<never> {
+            throw new Error('boom');
+          }
+        } as unknown as Parameters<typeof setWarpgrepClientLoader>[0] extends () => Promise<infer T>
+          ? T
+          : never;
+      });
+
+      const outcome = await warpgrepExecute({ query: 'x' });
+      expect(outcome.success).toBe(false);
+      if (!outcome.success) {
+        expect(outcome.error).toContain('WarpGrep search failed');
+        expect(outcome.error).toContain('boom');
+      }
+    });
+  });
+
+  describe('warpgrepExecute - success paths', () => {
+    it('returns spans on a successful search', async () => {
+      const spans = [
+        {
+          filePath: 'src/auth.ts',
+          startLine: 10,
+          endLine: 20,
+          content: 'export function login() {}',
+        },
+      ];
+
+      const captured: { searchTerm?: string; repoRoot?: string } = {};
+      setWarpgrepClientLoader(async () => {
+        return class OkClient {
+          constructor(_config: unknown) {}
+          async execute(input: {
+            searchTerm: string;
+            repoRoot: string;
+          }): Promise<{ success: boolean; codeSpans: typeof spans }> {
+            captured.searchTerm = input.searchTerm;
+            captured.repoRoot = input.repoRoot;
+            return { success: true, codeSpans: spans };
+          }
+        } as unknown as Parameters<typeof setWarpgrepClientLoader>[0] extends () => Promise<infer T>
+          ? T
+          : never;
+      });
+
+      const outcome = await warpgrepExecute(
+        { query: 'user login' },
+        { repoRoot: '/tmp/some/repo' }
+      );
+      expect(outcome.success).toBe(true);
+      if (outcome.success) {
+        expect(outcome.data.spans).toEqual(spans);
+        expect(outcome.data.query).toBe('user login');
+      }
+      expect(captured.searchTerm).toBe('user login');
+      expect(captured.repoRoot).toBe('/tmp/some/repo');
+    });
+
+    it('returns a hint when there are zero spans', async () => {
+      setWarpgrepClientLoader(async () => {
+        return class EmptyClient {
+          constructor(_config: unknown) {}
+          async execute(): Promise<{ success: boolean; codeSpans: [] }> {
+            return { success: true, codeSpans: [] };
+          }
+        } as unknown as Parameters<typeof setWarpgrepClientLoader>[0] extends () => Promise<infer T>
+          ? T
+          : never;
+      });
+
+      const outcome = await warpgrepExecute({ query: 'nothing here' });
+      expect(outcome.success).toBe(true);
+      if (outcome.success) {
+        expect(outcome.data.spans).toEqual([]);
+        expect(outcome.hint).toContain('No relevant code found');
+      }
+    });
+
+    it('uses the api key when MORPH_API_KEY is set', async () => {
+      process.env['MORPH_API_KEY'] = 'secret-key';
+      const configs: Array<{ morphApiKey: string; morphApiUrl?: string }> = [];
+
+      setWarpgrepClientLoader(async () => {
+        return class ConfigCaptureClient {
+          constructor(config: { morphApiKey: string; morphApiUrl?: string }) {
+            configs.push(config);
+          }
+          async execute(): Promise<{ success: boolean; codeSpans: [] }> {
+            return { success: true, codeSpans: [] };
+          }
+        } as unknown as Parameters<typeof setWarpgrepClientLoader>[0] extends () => Promise<infer T>
+          ? T
+          : never;
+      });
+
+      await warpgrepExecute({ query: 'x' });
+      expect(configs.length).toBe(1);
+      expect(configs[0].morphApiKey).toBe('secret-key');
+      expect(configs[0].morphApiUrl).toBeUndefined();
+    });
+
+    it('falls back to the kilo proxy url when MORPH_API_KEY is missing', async () => {
+      delete process.env['MORPH_API_KEY'];
+      const configs: Array<{ morphApiKey: string; morphApiUrl?: string }> = [];
+
+      setWarpgrepClientLoader(async () => {
+        return class ConfigCaptureClient {
+          constructor(config: { morphApiKey: string; morphApiUrl?: string }) {
+            configs.push(config);
+          }
+          async execute(): Promise<{ success: boolean; codeSpans: [] }> {
+            return { success: true, codeSpans: [] };
+          }
+        } as unknown as Parameters<typeof setWarpgrepClientLoader>[0] extends () => Promise<infer T>
+          ? T
+          : never;
+      });
+
+      await warpgrepExecute({ query: 'x' });
+      expect(configs.length).toBe(1);
+      expect(configs[0].morphApiKey).toBe('kilo-free');
+      expect(configs[0].morphApiUrl).toBe('https://api.kilo.ai/api/gateway');
+    });
+  });
+});
+
+describe('alexi-mcp-warpgrep - MCP server', () => {
+  afterEach(() => {
+    resetWarpgrepClientLoader();
+  });
+
+  it('creates an McpServer with codebase_search registered', () => {
+    const server = createWarpgrepServer();
+    // The high-level McpServer type does not expose a public tools() getter,
+    // but it exposes the underlying `server` field. We assert on the
+    // JSON-Schema shape indirectly through `toolInputSchemaJson`.
+    const schema = (
+      server as unknown as {
+        toolInputSchemaJson: (name: string) => Record<string, unknown> | undefined;
+      }
+    ).toolInputSchemaJson('codebase_search');
+    expect(schema).toBeDefined();
+    expect(schema).toMatchObject({ type: 'object' });
+  });
+
+  it('does not register any tool other than codebase_search', () => {
+    const server = createWarpgrepServer();
+    const schema = (
+      server as unknown as {
+        toolInputSchemaJson: (name: string) => Record<string, unknown> | undefined;
+      }
+    ).toolInputSchemaJson('some_other_tool');
+    expect(schema).toBeUndefined();
+  });
+});
+
+describe('alexi-mcp-warpgrep - entry module', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('exports createWarpgrepServer and main', async () => {
+    const mod = await import('../../../packages/alexi-mcp-warpgrep/src/index.js');
+    expect(typeof mod.createWarpgrepServer).toBe('function');
+    expect(typeof mod.main).toBe('function');
+  });
+});

--- a/tests/tool/tools/warpgrep-deprecation.test.ts
+++ b/tests/tool/tools/warpgrep-deprecation.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Verifies the built-in `codebase_search` (WarpGrep) tool emits a one-shot
+ * deprecation warning pointing users at the standalone MCP server.
+ *
+ * The tool itself falls back to an "SDK missing" error path in the test
+ * environment (because `@morphllm/morphsdk` is not installed), which is
+ * exactly the code path we need to exercise: the deprecation warning is
+ * emitted BEFORE the SDK availability check.
+ */
+describe('warpgrep built-in tool - deprecation warning', () => {
+  const warnMock = vi.fn();
+
+  beforeEach(async () => {
+    vi.resetModules();
+    warnMock.mockClear();
+
+    // Mock the logger so we can assert on `warn` calls. Must be registered
+    // BEFORE the SUT is imported, hence the `vi.doMock` + dynamic import
+    // pattern rather than a top-level `vi.mock`.
+    vi.doMock('../../../src/utils/logger.js', () => ({
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: warnMock,
+        error: vi.fn(),
+        print: vi.fn(),
+        setLevel: vi.fn(),
+      },
+      default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: warnMock,
+        error: vi.fn(),
+        print: vi.fn(),
+        setLevel: vi.fn(),
+      },
+    }));
+
+    // Also mock telemetry to avoid pulling in real reporting during tests.
+    vi.doMock('../../../src/utils/telemetry.js', () => ({
+      Telemetry: {
+        track: vi.fn(),
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../../../src/utils/logger.js');
+    vi.doUnmock('../../../src/utils/telemetry.js');
+  });
+
+  it('emits the deprecation warning on first call', async () => {
+    const mod = await import('../../../src/tool/tools/warpgrep.js');
+    mod._resetWarpgrepDeprecationWarning();
+
+    const result = await mod.warpgrepTool.executeUnsafe({ query: 'anything' }, { workdir: '/tmp' });
+
+    // The SDK is not installed in the test environment, so we expect the
+    // "SDK missing" failure. What we care about here is the warn call.
+    expect(result.success).toBe(false);
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    const warnMessage = String(warnMock.mock.calls[0][0]);
+    expect(warnMessage).toContain('deprecated');
+    expect(warnMessage).toContain('alexi-mcp-warpgrep');
+  });
+
+  it('only emits the deprecation warning once per process', async () => {
+    const mod = await import('../../../src/tool/tools/warpgrep.js');
+    mod._resetWarpgrepDeprecationWarning();
+
+    await mod.warpgrepTool.executeUnsafe({ query: 'first' }, { workdir: '/tmp' });
+    await mod.warpgrepTool.executeUnsafe({ query: 'second' }, { workdir: '/tmp' });
+    await mod.warpgrepTool.executeUnsafe({ query: 'third' }, { workdir: '/tmp' });
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation of #1370 by **Kilo CLI** via the agent factory (role=engineering).

## Checks ✅

All checks pass


- ✅ typecheck
- ✅ lint
- ✅ format
- ✅ build
- ✅ tests

## Changes

- **Files changed**: 12
- **Branch**: `auto/1370-extract-warpgrep-to-standalone-mcp-server`

## Review Checklist

- [ ] Code changes match the issue requirements
- [ ] Tests cover the new functionality
- [ ] No unintended side effects
- [ ] Documentation updated if needed

---
Implemented by [Kilo CLI](https://kilo.ai) with SAP AI Core · Closes #1370
