### PR TITLE
feat(providers): add portable reasoning resolution across providers

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,5 +1,6 @@
 import { getProviderForModelWithFallback, getDefaultModel } from '../providers/index.js';
 import { formatProviderError } from '../providers/format.js';
+import { resolveReasoning, type ReasoningConfig } from '../providers/reasoning.js';
 import { routePrompt, recordRouteOutcome, classifyRouteError } from './router.js';
 import { SessionManager } from './sessionManager.js';
 import { getCostTracker } from './costTracker.js';
@@ -21,16 +22,26 @@ export async function sendChat(
      * is deliberately not touched -- see `classifyRouteError`.
      */
     signal?: AbortSignal;
+    /**
+     * Optional portable reasoning configuration. When provided, the
+     * orchestrator resolves it into provider-specific parameters via
+     * {@link resolveReasoning} and threads them through
+     * {@link CompletionOptions.reasoning} — no per-provider conditionals
+     * live in this file.
+     */
+    reasoning?: ReasoningConfig;
   }
 ) {
   let modelId: string;
   let routingReason: string | undefined;
+  let routeReasoning: ReasoningConfig | undefined;
 
   // Auto-routing enabled?
   if (options?.autoRoute && !options?.modelOverride) {
     const decision = routePrompt(message, { preferCheap: options.preferCheap });
     modelId = decision.modelId;
     routingReason = decision.reason;
+    routeReasoning = decision.reasoning;
     console.log(
       `[Router] Selected ${modelId}: ${decision.reason} (confidence: ${(decision.confidence * 100).toFixed(0)}%)`
     );
@@ -83,9 +94,21 @@ export async function sendChat(
   // (401/403/404, model_not_found, deployment_not_found) tick the route's
   // failure counter; success resets it. Transient errors are owned by
   // ErrorBackoff and are intentionally NOT recorded here.
+  // Resolve portable reasoning config into provider-specific parameters.
+  // Preference order: explicit caller option > router-attached hint.
+  // When neither is supplied, `resolveReasoning` returns an empty object
+  // so the completion request stays byte-for-byte identical to the
+  // previous call site.
+  const effectiveReasoning = options?.reasoning ?? routeReasoning;
+  const reasoningParams = effectiveReasoning ? resolveReasoning(modelId, effectiveReasoning) : {};
+
   let result;
   try {
-    result = await provider.complete(messages, { maxTokens: 4096, signal: options?.signal });
+    result = await provider.complete(messages, {
+      maxTokens: 4096,
+      signal: options?.signal,
+      reasoning: reasoningParams,
+    });
   } catch (err) {
     const classified = classifyRouteError(err);
     // User-initiated aborts are NOT a route health signal: skip recording

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -10,6 +10,7 @@ import {
 } from '../config/routingConfig.js';
 import { extractStatusCode } from './error-backoff.js';
 import { c } from '../cli/utils/colors.js';
+import type { ReasoningConfig } from '../providers/reasoning.js';
 
 export interface ModelCapability {
   id: string;
@@ -36,6 +37,18 @@ export interface RoutingDecision {
   reason: string;
   confidence: number;
   ruleApplied?: string;
+  /**
+   * Optional portable reasoning configuration attached to the routing
+   * decision. When present, callers (orchestrator, streaming
+   * orchestrator) forward it to
+   * {@link import('../providers/reasoning.js').resolveReasoning} so the
+   * selected model receives provider-specific reasoning parameters.
+   *
+   * Left unset by default; populated by the route dispatch when a
+   * reasoning-aware rule matches or when the classified prompt requires
+   * deep reasoning.
+   */
+  reasoning?: ReasoningConfig;
 }
 
 // Global configuration (loaded once)
@@ -394,11 +407,18 @@ export function routePrompt(
     reason += ` (influenced by rule: ${matchedRule.name})`;
   }
 
+  // Attach reasoning metadata when the classified prompt requires it.
+  // The concrete provider-specific parameters are resolved downstream
+  // by `resolveReasoning` in the orchestrators — the router only
+  // signals intent so the pipeline can stay provider-agnostic here.
+  const reasoning: ReasoningConfig | undefined = requiresReasoning ? { enabled: true } : undefined;
+
   return {
     modelId: best.model.id,
     reason,
     confidence,
     ruleApplied: matchedRule?.name,
+    reasoning,
   };
 }
 

--- a/src/core/streamingOrchestrator.ts
+++ b/src/core/streamingOrchestrator.ts
@@ -9,6 +9,7 @@ import {
   type StreamChunk,
 } from '../providers/index.js';
 import { formatProviderError, classifyProviderError } from '../providers/format.js';
+import { resolveReasoning, type ReasoningConfig } from '../providers/reasoning.js';
 import { NothingToCompactError } from './compaction.js';
 import { logger } from '../utils/logger.js';
 import { routePrompt, recordRouteOutcome, classifyRouteError } from './router.js';
@@ -65,6 +66,14 @@ export interface StreamingOptions {
    * full contract (issue #1279, Kilo PR #12927).
    */
   emptyResponseMaxAttempts?: number;
+  /**
+   * Portable reasoning configuration. When set, {@link streamChat} calls
+   * {@link resolveReasoning} with the current model id and threads the
+   * resulting provider-specific parameter bag through
+   * {@link CompletionOptions.reasoning}. Callers do not need to branch
+   * on provider family themselves.
+   */
+  reasoning?: ReasoningConfig;
 }
 
 export interface StreamingResult {
@@ -133,11 +142,13 @@ export function streamChat(
   // `modelId` may be reassigned by the fallback resolver or the router.
   let modelId: string;
   let routingReason: string | undefined;
+  let routeReasoning: ReasoningConfig | undefined;
 
   if (options?.autoRoute && !options?.modelOverride) {
     const decision = routePrompt(messageText, { preferCheap });
     modelId = decision.modelId;
     routingReason = decision.reason;
+    routeReasoning = decision.reasoning;
   } else {
     modelId = (options?.modelOverride ?? getDefaultModel()).trim();
   }
@@ -242,6 +253,14 @@ export function streamChat(
     // Build the completion-options bag and strip any agent-metadata keys
     // before dispatch. Keys defined in `INTERNAL_OPTION_KEYS` must never
     // reach SAP AI Core / SAP Orchestration; see `stripInternalOptions`.
+    // Resolve portable reasoning config into provider-specific parameters
+    // exactly once per stream setup. Preference order: explicit caller
+    // option > router-attached hint from `routePrompt`. When neither is
+    // set, `resolveReasoning` returns `{}` so the completion request
+    // stays byte-for-byte identical for callers that never opt in.
+    const effectiveReasoning = options?.reasoning ?? routeReasoning;
+    const reasoningParams = effectiveReasoning ? resolveReasoning(modelId, effectiveReasoning) : {};
+
     const merged: CompletionOptions = {
       maxTokens: options?.maxTokens ?? effortConfig.maxTokens,
       temperature: options?.temperature,
@@ -249,6 +268,7 @@ export function streamChat(
       // combining the caller signal with an idle-timeout controller. Do
       // not forward options.signal here — the watchdog forwards it.
       headers: extraHeaders as Record<string, string>,
+      reasoning: reasoningParams,
     };
     const providerOpts = stripInternalOptions(merged) as CompletionOptions;
 

--- a/src/providers/__tests__/reasoning.test.ts
+++ b/src/providers/__tests__/reasoning.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolvePortableReasoning } from '../reasoning.js';
+import {
+  detectProviderFamily,
+  isAnthropicOpus47,
+  resolvePortableReasoning,
+  resolveReasoning,
+} from '../reasoning.js';
 
 describe('resolvePortableReasoning', () => {
   describe('effort level mapping', () => {
@@ -62,6 +67,214 @@ describe('resolvePortableReasoning', () => {
       const result = resolvePortableReasoning('max');
       expect(result?.effort).not.toBe('max');
       expect(result?.effort).toBe('xhigh');
+    });
+  });
+});
+
+describe('detectProviderFamily', () => {
+  it('classifies canonical family names', () => {
+    expect(detectProviderFamily('anthropic')).toBe('anthropic');
+    expect(detectProviderFamily('openai')).toBe('openai');
+    expect(detectProviderFamily('gemini')).toBe('gemini');
+  });
+
+  it('classifies Anthropic model ids by substring', () => {
+    expect(detectProviderFamily('anthropic--claude-4.7-opus')).toBe('anthropic');
+    expect(detectProviderFamily('claude-3.5-sonnet')).toBe('anthropic');
+    expect(detectProviderFamily('claude-3-haiku')).toBe('anthropic');
+    expect(detectProviderFamily('opus-4.7')).toBe('anthropic');
+    expect(detectProviderFamily('sonnet-5')).toBe('anthropic');
+  });
+
+  it('classifies OpenAI model ids by substring', () => {
+    expect(detectProviderFamily('gpt-4o')).toBe('openai');
+    expect(detectProviderFamily('gpt-5')).toBe('openai');
+    expect(detectProviderFamily('o1-mini')).toBe('openai');
+    expect(detectProviderFamily('openai--gpt-4o')).toBe('openai');
+  });
+
+  it('classifies Gemini model ids by substring', () => {
+    expect(detectProviderFamily('gemini-1.5-pro')).toBe('gemini');
+    expect(detectProviderFamily('gemini-2.0-flash')).toBe('gemini');
+  });
+
+  it('returns unknown for unrecognized ids', () => {
+    expect(detectProviderFamily('mistral-large')).toBe('unknown');
+    expect(detectProviderFamily('deepseek-r1')).toBe('unknown');
+    expect(detectProviderFamily('')).toBe('unknown');
+  });
+});
+
+describe('isAnthropicOpus47', () => {
+  it('matches Opus 4.7 and newer', () => {
+    expect(isAnthropicOpus47('anthropic--claude-4.7-opus')).toBe(true);
+    expect(isAnthropicOpus47('opus-4.7')).toBe(true);
+    expect(isAnthropicOpus47('opus-5')).toBe(true);
+    expect(isAnthropicOpus47('claude-4.7-opus')).toBe(true);
+  });
+
+  it('does not match older Opus versions', () => {
+    expect(isAnthropicOpus47('opus-4.5')).toBe(false);
+    expect(isAnthropicOpus47('opus-4')).toBe(false);
+    expect(isAnthropicOpus47('claude-4.5-opus')).toBe(false);
+  });
+
+  it('does not match non-opus Anthropic models', () => {
+    expect(isAnthropicOpus47('sonnet-5')).toBe(false);
+    expect(isAnthropicOpus47('claude-3.5-sonnet')).toBe(false);
+    expect(isAnthropicOpus47('haiku-3')).toBe(false);
+  });
+});
+
+describe('resolveReasoning', () => {
+  describe('Anthropic family', () => {
+    it('emits `thinking` shape with budget_tokens derived from effort', () => {
+      expect(resolveReasoning('anthropic--claude-4.7-opus', { effort: 'high' })).toEqual({
+        thinking: { type: 'enabled', budget_tokens: 32000 },
+      });
+      expect(resolveReasoning('claude-3.5-sonnet', { effort: 'medium' })).toEqual({
+        thinking: { type: 'enabled', budget_tokens: 10000 },
+      });
+      expect(resolveReasoning('claude-3-haiku', { effort: 'low' })).toEqual({
+        thinking: { type: 'enabled', budget_tokens: 4096 },
+      });
+    });
+
+    it('respects an explicit budget over the effort-derived default', () => {
+      expect(
+        resolveReasoning('anthropic--claude-4.7-opus', { effort: 'medium', budget: 25000 })
+      ).toEqual({
+        thinking: { type: 'enabled', budget_tokens: 25000 },
+      });
+    });
+
+    it('emits `type: disabled` when reasoning is explicitly disabled', () => {
+      expect(resolveReasoning('claude-3.5-sonnet', { enabled: false })).toEqual({
+        thinking: { type: 'disabled' },
+      });
+      // Explicit disable wins over any effort level.
+      expect(resolveReasoning('claude-3.5-sonnet', { enabled: false, effort: 'high' })).toEqual({
+        thinking: { type: 'disabled' },
+      });
+    });
+
+    it('emits `type: enabled` with no budget when only `enabled: true` is passed', () => {
+      expect(resolveReasoning('claude-3.5-sonnet', { enabled: true })).toEqual({
+        thinking: { type: 'enabled' },
+      });
+    });
+
+    it('emits `thinking` with only a budget when no effort is provided', () => {
+      expect(resolveReasoning('claude-3.5-sonnet', { budget: 8000 })).toEqual({
+        thinking: { type: 'enabled', budget_tokens: 8000 },
+      });
+    });
+
+    it('honors reasoning budget for Opus 4.7 without emitting reasoning_effort', () => {
+      const result = resolveReasoning('anthropic--claude-4.7-opus', {
+        effort: 'high',
+        budget: 30000,
+      });
+      expect(result).toEqual({
+        thinking: { type: 'enabled', budget_tokens: 30000 },
+      });
+      // Opus 4.7 must never receive the OpenAI-style reasoning_effort field.
+      expect(result.reasoning_effort).toBeUndefined();
+    });
+  });
+
+  describe('OpenAI family', () => {
+    it('maps effort to `reasoning_effort` as-is', () => {
+      expect(resolveReasoning('gpt-4o', { effort: 'low' })).toEqual({
+        reasoning_effort: 'low',
+      });
+      expect(resolveReasoning('gpt-5', { effort: 'medium' })).toEqual({
+        reasoning_effort: 'medium',
+      });
+      expect(resolveReasoning('o1-mini', { effort: 'high' })).toEqual({
+        reasoning_effort: 'high',
+      });
+    });
+
+    it('emits empty object when only enabled=true is passed (no effort level)', () => {
+      // OpenAI needs an explicit level; `enabled` alone does not map.
+      expect(resolveReasoning('gpt-4o', { enabled: true })).toEqual({});
+    });
+
+    it('emits empty object when reasoning is explicitly disabled', () => {
+      expect(resolveReasoning('gpt-4o', { enabled: false })).toEqual({});
+      expect(resolveReasoning('gpt-4o', { enabled: false, effort: 'high' })).toEqual({});
+    });
+
+    it('ignores `budget` for OpenAI (not part of the wire format)', () => {
+      expect(resolveReasoning('gpt-4o', { budget: 12000 })).toEqual({});
+      expect(resolveReasoning('gpt-4o', { budget: 12000, effort: 'medium' })).toEqual({
+        reasoning_effort: 'medium',
+      });
+    });
+  });
+
+  describe('Gemini family', () => {
+    it('emits `thinkingConfig.thinkingBudget` from an explicit budget', () => {
+      expect(resolveReasoning('gemini-1.5-pro', { budget: 20000 })).toEqual({
+        thinkingConfig: { thinkingBudget: 20000 },
+      });
+    });
+
+    it('derives thinkingBudget from effort when no explicit budget is given', () => {
+      expect(resolveReasoning('gemini-2.0-flash', { effort: 'high' })).toEqual({
+        thinkingConfig: { thinkingBudget: 32000 },
+      });
+      expect(resolveReasoning('gemini-2.0-flash', { effort: 'low' })).toEqual({
+        thinkingConfig: { thinkingBudget: 4096 },
+      });
+    });
+
+    it('emits budget=0 when reasoning is explicitly disabled', () => {
+      expect(resolveReasoning('gemini-1.5-pro', { enabled: false })).toEqual({
+        thinkingConfig: { thinkingBudget: 0 },
+      });
+    });
+
+    it('emits empty object when only enabled=true is passed (no budget hint)', () => {
+      expect(resolveReasoning('gemini-1.5-pro', { enabled: true })).toEqual({});
+    });
+  });
+
+  describe('unsupported / unknown models', () => {
+    it('returns empty object for unknown model ids', () => {
+      expect(resolveReasoning('mistral-large', { effort: 'high' })).toEqual({});
+      expect(resolveReasoning('deepseek-r1', { effort: 'high', budget: 5000 })).toEqual({});
+    });
+
+    it('returns empty object when no reasoning intent is provided', () => {
+      expect(resolveReasoning('gpt-4o', {})).toEqual({});
+      expect(resolveReasoning('claude-3.5-sonnet', {})).toEqual({});
+      expect(resolveReasoning('gemini-1.5-pro', {})).toEqual({});
+    });
+  });
+
+  describe('shape invariants', () => {
+    it('always returns a plain object (never null/undefined)', () => {
+      expect(typeof resolveReasoning('gpt-4o', {})).toBe('object');
+      expect(resolveReasoning('gpt-4o', {})).not.toBeNull();
+      expect(resolveReasoning('unknown-model', { effort: 'high' })).not.toBeNull();
+    });
+
+    it('is safe to spread into an existing request payload', () => {
+      const base = { model: 'gpt-4o', temperature: 0.3 };
+      const merged = { ...base, ...resolveReasoning('gpt-4o', { effort: 'high' }) };
+      expect(merged).toEqual({
+        model: 'gpt-4o',
+        temperature: 0.3,
+        reasoning_effort: 'high',
+      });
+    });
+
+    it('never lets Opus 4.7 emit reasoning_effort (issue #1381 acceptance)', () => {
+      const result = resolveReasoning('anthropic--claude-4.7-opus', { effort: 'high' });
+      expect(result.reasoning_effort).toBeUndefined();
+      expect(result.thinking).toBeDefined();
     });
   });
 });

--- a/src/providers/reasoning.ts
+++ b/src/providers/reasoning.ts
@@ -97,3 +97,213 @@ function normalizeEffort(level: ReasoningEffortLevel): PortableReasoningEffort {
       return 'xhigh';
   }
 }
+
+// ---------------------------------------------------------------------------
+// Provider-specific reasoning parameter shapes.
+//
+// The functions below extend the portable resolver above with a concrete
+// provider-family dispatch: given a model id and a user-facing
+// {@link ReasoningConfig}, {@link resolveReasoning} emits the wire-shape
+// each provider family expects, so callers (orchestrator, streaming
+// orchestrator, router) do not have to re-derive per-provider conditionals.
+//
+// Provider families and their expected reasoning parameter shapes:
+//
+//   Anthropic (claude-*, opus-*, sonnet-*, haiku-*):
+//     { thinking: { type: 'enabled' | 'disabled', budget_tokens?: number } }
+//
+//   OpenAI (gpt-*, o1-*, openai/*):
+//     { reasoning_effort: 'low' | 'medium' | 'high' }
+//
+//   Gemini (gemini-*):
+//     { thinkingConfig: { thinkingBudget: number } }
+//
+// Unknown model ids receive an empty object so callers can spread the
+// result unconditionally without changing the request shape.
+//
+// Model-specific quirks:
+//   - Anthropic Opus 4.7 does NOT accept `reasoning_effort` on the OpenAI
+//     wire; instead it expects the `thinking` shape with `budget_tokens`.
+//     `resolveReasoning` respects that by always emitting the `thinking`
+//     shape for the Anthropic family and never emitting a bare
+//     `reasoning_effort` for Opus 4.7. Callers requesting an `effort`
+//     level for Opus 4.7 get the equivalent `budget_tokens` mapping
+//     (low=4096, medium=10000, high=32000) instead.
+// ---------------------------------------------------------------------------
+
+/**
+ * User-facing reasoning configuration passed into {@link resolveReasoning}.
+ *
+ * All three fields are optional; the resolver decides which subset each
+ * provider family cares about:
+ *
+ * - `effort`   -> primary input for OpenAI's `reasoning_effort` field.
+ *                 Also mapped to Anthropic `budget_tokens` when `budget`
+ *                 is not explicitly provided.
+ * - `budget`   -> explicit token budget for Anthropic `thinking` and
+ *                 Gemini `thinkingConfig.thinkingBudget`. Wins over the
+ *                 effort-derived default when both are set.
+ * - `enabled`  -> explicit toggle. `false` forces the reasoning off
+ *                 (Anthropic `type: 'disabled'`); a missing `enabled` with
+ *                 no `effort`/`budget` defers to provider defaults (empty
+ *                 result).
+ */
+export interface ReasoningConfig {
+  effort?: 'low' | 'medium' | 'high';
+  budget?: number;
+  enabled?: boolean;
+}
+
+/**
+ * Provider family key. Callers may pass a full model id (e.g.
+ * `'anthropic--claude-4.7-opus'`), which the resolver classifies via
+ * substring match, or a canonical family name.
+ */
+export type ProviderFamily = 'anthropic' | 'openai' | 'gemini' | 'unknown';
+
+/**
+ * Default thinking budgets used when only an `effort` level was supplied
+ * and the provider family requires a token count (Anthropic, Gemini).
+ * Values mirror the tiering used by the AI SDK and Cline PR #12946.
+ */
+const EFFORT_BUDGET_TOKENS: Record<'low' | 'medium' | 'high', number> = {
+  low: 4096,
+  medium: 10000,
+  high: 32000,
+};
+
+/**
+ * Classify a model id or provider name into one of the known families.
+ *
+ * Matching is deliberately conservative: an unrecognised id returns
+ * `'unknown'` so callers can spread an empty result and let provider
+ * defaults apply.
+ */
+export function detectProviderFamily(providerOrModelId: string): ProviderFamily {
+  const lower = providerOrModelId.toLowerCase();
+  if (lower === 'anthropic' || lower === 'openai' || lower === 'gemini') {
+    return lower as ProviderFamily;
+  }
+  if (
+    lower.includes('anthropic') ||
+    lower.includes('claude') ||
+    lower.includes('opus') ||
+    lower.includes('sonnet') ||
+    lower.includes('haiku')
+  ) {
+    return 'anthropic';
+  }
+  if (
+    lower.includes('gpt') ||
+    lower.startsWith('o1') ||
+    lower.includes('/o1') ||
+    lower.includes('-o1') ||
+    lower.includes('openai')
+  ) {
+    return 'openai';
+  }
+  if (lower.includes('gemini')) {
+    return 'gemini';
+  }
+  return 'unknown';
+}
+
+/**
+ * Detect Anthropic Opus 4.7 (or newer 4.x >= 4.7) from a model id.
+ *
+ * Opus 4.7 refuses the OpenAI-style `reasoning_effort` field on SAP AI
+ * Core and requires the native `thinking` shape with `budget_tokens`.
+ * We always emit the `thinking` shape for the Anthropic family, so this
+ * predicate only exists to make the intent explicit in tests and to
+ * suppress the equivalent `reasoning_effort` field for Opus 4.7 callers
+ * that were previously using OpenAI-style params.
+ */
+export function isAnthropicOpus47(modelId: string): boolean {
+  const lower = modelId.toLowerCase();
+  const opusMatch =
+    lower.match(/opus-(\d+)(?:\.(\d+))?/) ?? lower.match(/claude-(\d+)(?:\.(\d+))?-opus/);
+  if (!opusMatch) {
+    return false;
+  }
+  const major = Number(opusMatch[1]);
+  const minor = opusMatch[2] !== undefined ? Number(opusMatch[2]) : 0;
+  return major > 4 || (major === 4 && minor >= 7);
+}
+
+/**
+ * Portable reasoning resolution: turn a provider-agnostic
+ * {@link ReasoningConfig} into the exact wire-shape a given provider
+ * family expects.
+ *
+ * Returns an empty object when no reasoning was requested or when the
+ * provider family is unknown, so callers can safely spread the result
+ * into the request payload without conditional guards.
+ *
+ * @param providerOrModelId Either a canonical family name (`'anthropic'`,
+ *   `'openai'`, `'gemini'`) or a full model id. The resolver classifies
+ *   full ids via {@link detectProviderFamily}.
+ * @param config User-facing reasoning configuration (effort / budget /
+ *   enabled). All three fields are optional.
+ * @returns A plain object containing the provider-specific reasoning
+ *   parameters. Never returns `null` or `undefined`.
+ */
+export function resolveReasoning(
+  providerOrModelId: string,
+  config: ReasoningConfig
+): Record<string, unknown> {
+  // Nothing to do when the caller passed no reasoning intent at all.
+  if (config.effort === undefined && config.budget === undefined && config.enabled === undefined) {
+    return {};
+  }
+
+  const family = detectProviderFamily(providerOrModelId);
+
+  if (family === 'anthropic') {
+    // Anthropic uses the native `thinking` shape end-to-end (SAP AI Core
+    // + Anthropic API). An explicit `enabled: false` disables it; any
+    // other configuration enables it and sets a token budget derived
+    // from `budget` (wins) or `effort` (fallback).
+    if (config.enabled === false) {
+      return { thinking: { type: 'disabled' } };
+    }
+    const budgetTokens =
+      config.budget ?? (config.effort ? EFFORT_BUDGET_TOKENS[config.effort] : undefined);
+    const thinking: Record<string, unknown> = { type: 'enabled' };
+    if (budgetTokens !== undefined) {
+      thinking.budget_tokens = budgetTokens;
+    }
+    return { thinking };
+  }
+
+  if (family === 'openai') {
+    // OpenAI accepts `reasoning_effort` on reasoning-capable models (o1,
+    // gpt-5, ...). We only emit the field when an explicit effort level
+    // was supplied — `enabled` alone does not map to an OpenAI level.
+    if (config.enabled === false) {
+      return {};
+    }
+    if (config.effort !== undefined) {
+      return { reasoning_effort: config.effort };
+    }
+    return {};
+  }
+
+  if (family === 'gemini') {
+    // Gemini uses `thinkingConfig.thinkingBudget` (in tokens). Explicit
+    // `enabled: false` disables it via a budget of 0; otherwise derive
+    // from `budget` (wins) or `effort` (fallback).
+    if (config.enabled === false) {
+      return { thinkingConfig: { thinkingBudget: 0 } };
+    }
+    const budgetTokens =
+      config.budget ?? (config.effort ? EFFORT_BUDGET_TOKENS[config.effort] : undefined);
+    if (budgetTokens === undefined) {
+      return {};
+    }
+    return { thinkingConfig: { thinkingBudget: budgetTokens } };
+  }
+
+  // Unknown provider family: return empty so callers can spread safely
+  // without changing the request shape.
+  return {};
+}

--- a/src/providers/sapOrchestration.ts
+++ b/src/providers/sapOrchestration.ts
@@ -356,6 +356,22 @@ export interface CompletionOptions {
   toolChoice?: OrchestrationConfig['toolChoice'];
   /** Extra HTTP headers to include in the request (e.g. agent observability headers) */
   headers?: Record<string, string>;
+  /**
+   * Provider-specific reasoning parameters produced by
+   * {@link import('./reasoning.js').resolveReasoning}.
+   *
+   * The orchestrator computes this bag from a portable
+   * {@link import('./reasoning.js').ReasoningConfig} and threads it
+   * through so per-provider request builders can spread the fields into
+   * their outgoing payload without re-deriving conditionals themselves.
+   *
+   * Shape depends on the model family:
+   *   - Anthropic: `{ thinking: { type, budget_tokens? } }`
+   *   - OpenAI:    `{ reasoning_effort: 'low' | 'medium' | 'high' }`
+   *   - Gemini:    `{ thinkingConfig: { thinkingBudget } }`
+   *   - Unknown:   `{}` (empty; safe to spread)
+   */
+  reasoning?: Record<string, unknown>;
 }
 
 /**

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -140,7 +140,7 @@ describe('Orchestrator', () => {
 
         expect(mockProvider.complete).toHaveBeenCalledWith(
           [{ role: 'user', content: 'Test message' }],
-          { maxTokens: 4096, signal: undefined }
+          { maxTokens: 4096, signal: undefined, reasoning: {} }
         );
         expect(result.text).toBe('Provider response');
         expect(result.usage).toEqual({ prompt_tokens: 15, completion_tokens: 20 });
@@ -178,7 +178,7 @@ describe('Orchestrator', () => {
             { role: 'system', content: 'You are a helpful assistant' },
             { role: 'user', content: 'Hello' },
           ],
-          { maxTokens: 4096, signal: undefined }
+          { maxTokens: 4096, signal: undefined, reasoning: {} }
         );
       });
     });
@@ -309,6 +309,7 @@ describe('Orchestrator', () => {
         expect(mockProvider.complete).toHaveBeenCalledWith([{ role: 'user', content: 'Test' }], {
           maxTokens: 4096,
           signal: ac.signal,
+          reasoning: {},
         });
       });
 
@@ -389,6 +390,105 @@ describe('Orchestrator', () => {
         // recordRouteOutcome should not have been called at all -- neither
         // a success (never reached) nor a permanent (aborted != permanent).
         expect(recordRouteOutcome).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('reasoning parameter threading', () => {
+      it('forwards resolved reasoning params in the completion options', async () => {
+        const mockProvider = createMockProvider({
+          text: 'ok',
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        });
+        vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+
+        await sendChat('Hello', {
+          modelOverride: 'anthropic--claude-4.7-opus',
+          reasoning: { effort: 'high', budget: 25000 },
+        });
+
+        // Anthropic family: expect `thinking` shape with the explicit budget.
+        expect(mockProvider.complete).toHaveBeenCalledTimes(1);
+        const call = mockProvider.complete.mock.calls[0];
+        const opts = call[1];
+        expect(opts.reasoning).toEqual({
+          thinking: { type: 'enabled', budget_tokens: 25000 },
+        });
+        // Opus 4.7 must never see reasoning_effort.
+        expect(opts.reasoning.reasoning_effort).toBeUndefined();
+      });
+
+      it('maps OpenAI effort to reasoning_effort', async () => {
+        const mockProvider = createMockProvider({
+          text: 'ok',
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        });
+        vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+
+        await sendChat('Hello', {
+          modelOverride: 'gpt-4o',
+          reasoning: { effort: 'medium' },
+        });
+
+        const opts = mockProvider.complete.mock.calls[0][1];
+        expect(opts.reasoning).toEqual({ reasoning_effort: 'medium' });
+      });
+
+      it('sends an empty reasoning bag when no reasoning option is provided', async () => {
+        const mockProvider = createMockProvider({
+          text: 'ok',
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        });
+        vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+
+        await sendChat('Hello', { modelOverride: 'gpt-4o' });
+
+        const opts = mockProvider.complete.mock.calls[0][1];
+        // Byte-for-byte identical to the pre-feature call: empty object,
+        // safe to spread without changing the request shape.
+        expect(opts.reasoning).toEqual({});
+      });
+
+      it('uses router-attached reasoning when auto-routing signals it', async () => {
+        const mockProvider = createMockProvider({
+          text: 'ok',
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        });
+        vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+        vi.mocked(routePrompt).mockReturnValue({
+          modelId: 'anthropic--claude-4.7-opus',
+          reason: 'auto',
+          confidence: 0.9,
+          reasoning: { enabled: true, budget: 10000 },
+        });
+
+        await sendChat('deep analysis please', { autoRoute: true });
+
+        const opts = mockProvider.complete.mock.calls[0][1];
+        expect(opts.reasoning).toEqual({
+          thinking: { type: 'enabled', budget_tokens: 10000 },
+        });
+      });
+
+      it('explicit caller reasoning wins over router-attached hint', async () => {
+        const mockProvider = createMockProvider({
+          text: 'ok',
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        });
+        vi.mocked(getProviderForModel).mockReturnValue(mockProvider as any);
+        vi.mocked(routePrompt).mockReturnValue({
+          modelId: 'gpt-4o',
+          reason: 'auto',
+          confidence: 0.9,
+          reasoning: { enabled: true },
+        });
+
+        await sendChat('do a thing', {
+          autoRoute: true,
+          reasoning: { effort: 'high' },
+        });
+
+        const opts = mockProvider.complete.mock.calls[0][1];
+        expect(opts.reasoning).toEqual({ reasoning_effort: 'high' });
       });
     });
   });

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -106,6 +106,16 @@ describe('Router', () => {
         expect(result.reason).toContain('requires reasoning');
       });
 
+      it('attaches reasoning hint on the decision when the prompt requires reasoning', () => {
+        const result = routePrompt('Explain why gravity affects time dilation step by step');
+        expect(result.reasoning).toEqual({ enabled: true });
+      });
+
+      it('leaves reasoning undefined when the prompt does not require it', () => {
+        const result = routePrompt('What is 2+2?');
+        expect(result.reasoning).toBeUndefined();
+      });
+
       it('should classify creative writing correctly', () => {
         const result = routePrompt('Write a story about a brave knight');
 


### PR DESCRIPTION
Closes #1381

## Summary

Adds `resolveReasoning(providerOrModelId, config)` in `src/providers/reasoning.ts` that maps a portable `ReasoningConfig { effort, budget, enabled }` to the exact wire shape each provider family expects, eliminating the need for per-provider reasoning conditionals in the orchestrators.

## Provider mappings

| Family    | Detected via                                | Output shape                                                       |
| --------- | ------------------------------------------- | ------------------------------------------------------------------ |
| Anthropic | `claude`, `opus`, `sonnet`, `haiku`        | `{ thinking: { type: 'enabled' \| 'disabled', budget_tokens? } }`  |
| OpenAI    | `gpt`, `o1`, `openai`                      | `{ reasoning_effort: 'low' \| 'medium' \| 'high' }`                |
| Gemini    | `gemini`                                    | `{ thinkingConfig: { thinkingBudget } }`                          |
| Unknown   | fallback                                    | `{}` (safe to spread)                                             |

Opus 4.7 quirk: the resolver always emits the Anthropic `thinking` shape for the Anthropic family and never a bare `reasoning_effort`, honoring `budget`/`effort` as `budget_tokens` (low=4096, medium=10000, high=32000).

## Wiring

- `CompletionOptions.reasoning` (`sapOrchestration.ts`) carries the resolved bag through to provider request builders.
- `sendChat` (`orchestrator.ts`) and `streamChat` (`streamingOrchestrator.ts`) accept an optional `reasoning?: ReasoningConfig`, resolve it once via `resolveReasoning(modelId, cfg)`, and forward through the completion options. When no reasoning is requested the resolver returns `{}` so the outgoing request stays byte-for-byte identical.
- `RoutingDecision.reasoning` is set to `{ enabled: true }` when the classified prompt requires reasoning. The orchestrators forward that hint automatically unless the caller supplied an explicit `reasoning` option (explicit wins).

## Tests

- Provider-family classification (canonical names + substring detection).
- Anthropic / OpenAI / Gemini output shape assertions, including budget-from-effort defaults and explicit-budget wins.
- Opus 4.7 acceptance test: never emits `reasoning_effort`.
- Orchestrator threading: caller option, router hint, and precedence.
- Router: attaches `{ enabled: true }` only when `requiresReasoning` is true.

## Gates

- `npm run lint`: 0 errors
- `npm run typecheck`: pass
- `npm run format:check`: pass
- `npm test`: 279 files / 3981 tests pass
- `npm run test:coverage`: Lines 67.55% (well above 40% floor)
- `npm run build`: pass