### PR TITLE
docs: document image generation feature and capability infrastructure (#1393)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,58 @@ Once in interactive mode, the following commands are available:
 | `/notes clear` | Clear all notes |
 | `/quit` or `/exit` | Exit interactive mode |
 
+## Image Generation
+
+Alexi has infrastructure for **image generation** via SAP AI Core: a capability tag on the provider layer, a helper to gate feature code on it, and streaming-chunk normalisation for both URL-style (OpenAI) and base64-style (Anthropic / Gemini) image payloads. The user-facing surfaces — a dedicated `alexi image` command and an `image_generate` tool the agent can call from within chat — are on the roadmap but not yet shipped. This section documents what works today and where the boundary is, so you can build against the stable pieces without waiting.
+
+> This section is about the model _producing_ an image. Attaching an image _to_ your prompt (drag-and-drop, `/image <path>` in the TUI, Ctrl+V paste from the clipboard) is a separate, fully-shipped feature — see `src/utils/imageValidation.ts` and the `/image` / `/clear-images` slash commands in interactive mode.
+
+### What ships today
+
+- `ModelCapability` union with the `image-generation` tag (`src/providers/sapOrchestration.ts`).
+- `modelHasCapability(modelId, capability, { assumeWhenUnspecified? })` — the gate every image-aware caller should use.
+- `NormalizedImageChunk` discriminated union + `extractImageChunk` / `extractImageChunks` in `src/providers/transform.ts`, normalising both SDK shapes into `{ kind: 'url', url, mimeType? }` or `{ kind: 'base64', data, mimeType? }`.
+
+### What does not ship yet
+
+- No model in the current catalog advertises `image-generation`. The tag exists so a future SAP-hosted image model (Anthropic Claude image output, Gemini Imagen, Stable Diffusion deployments) can be enabled with a single metadata-map edit.
+- No `alexi image "<prompt>"` command. The planned interface is:
+
+  ```bash
+  # PLANNED — not yet implemented
+  alexi image "a diagram showing microservices architecture" \
+    --model anthropic--claude-4.7-opus \
+    --size 1024x1024 \
+    --output diagram.png
+  ```
+
+- No `image_generate` tool the agent loop can call. The planned Zod schema takes `prompt` (required) and optional `model`, `size`, `style`, `quality`, and streams the resulting image back through the same chunk-normalisation path documented below.
+
+### Sample usage from consumer code (works today)
+
+Gate on the capability tag before invoking the transform. The transform is safe to call on any chunk shape — non-image items are silently skipped — but the gate keeps the intent visible and stops it from running against text-only models.
+
+```typescript
+import { modelHasCapability } from './providers/index.js';
+import { extractImageChunks } from './providers/transform.js';
+
+if (modelHasCapability(session.modelId, 'image-generation')) {
+  for (const chunk of extractImageChunks(delta.content)) {
+    if (chunk.kind === 'url') {
+      // fetch chunk.url (mimeType via chunk.mimeType if present)
+    } else {
+      // decode chunk.data (base64) with chunk.mimeType
+    }
+  }
+}
+```
+
+### Deeper reference
+
+- `docs/PROVIDERS.md` — capability tag semantics and `modelHasCapability` resolution rules.
+- `docs/ARCHITECTURE.md` — "Image Generation" section covering the streaming payload shapes, transform guarantees, and the current router boundary.
+- Tracking issues: capability layer (issue #1389, partially landed), tool (#1390), CLI command (#1391), streaming markdown (#1392), documentation (#1393 — this change).
+
 ## Routing Configuration
 
 Create a `routing-config.json` in the project root (see `routing-config.example.json`):
@@ -511,6 +563,7 @@ alexi explain -m "$(cat very_long_document.txt)"
 - [x] Document grounding
 - [x] Translation support
 - [x] Embeddings support
+- [ ] Image generation (capability layer + streaming chunk normalisation landed; CLI command, tool, and image-gen-capable model tags pending — see [Image Generation](#image-generation))
 - [ ] Cost tracking and budget limits
 - [ ] Token usage analytics
 - [ ] Channel integrations (Telegram, Slack, WebChat)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1610,3 +1610,121 @@ The `subscribe` callback is injected so this module stays independent of the con
 - `mergeProviderModels<T>(base, custom): Record<string, T>` — merges a custom provider's model map on top of a base provider's model map without wiping base variants. Custom entries win per-id; base variants survive when the custom map does not redefine the same id.
 
 The pre-existing `sanitizeOpenAISchema`, `enforceStrictSchema`, `isOpenAIShapedModel`, `lowerMcpToolsForOpenAIShaped`, `transformInterleavedReasoning`, and `ensureDeepSeekReasoning` helpers are unchanged.
+
+## Image Generation
+
+Alexi ships **capability infrastructure and streaming payload normalisation** for image generation via SAP AI Core. The end-to-end user surface (a dedicated `alexi image` CLI command and an `image_generate` tool the agent can call) is planned but not yet landed — see [Roadmap and unimplemented pieces](#image-generation-roadmap-and-unimplemented-pieces) below. This section documents what is in the code today so callers can start building against the stable pieces without waiting for the CLI/tool layer.
+
+> Note: this section is about image _generation_ (the model produces an image as output). Attaching an image _to_ a prompt (multimodal input via clipboard paste, `/image <path>` in the TUI, drag-and-drop) is a separate, fully-shipped feature backed by `src/utils/image.ts`, `src/utils/imageValidation.ts`, `src/utils/clipboard.ts`, and `src/cli/tui/context/AttachmentContext.tsx`. Do not conflate the two.
+
+### Capability system
+
+The provider layer publishes a narrow, closed set of capability tags used by feature gates (tool registration, image response handling, embeddings dispatch). Defined in `src/providers/sapOrchestration.ts` and re-exported by `src/providers/index.ts`.
+
+```typescript
+// src/providers/sapOrchestration.ts
+export type ModelCapability = 'image-generation' | 'tools' | 'embeddings';
+
+export interface OrchestrationModelMetadata {
+  /** Capability tags advertised by the model. Missing = unknown. */
+  capabilities?: ModelCapability[];
+}
+
+// Companion map keyed by OrchestrationModel id. Absence of an entry
+// means "capability data not authored yet" (see `assumeWhenUnspecified`).
+export const ORCHESTRATION_MODEL_METADATA: Readonly<
+  Partial<Record<OrchestrationModel, OrchestrationModelMetadata>>
+>;
+```
+
+The router has an unrelated `ModelCapability` interface at `src/core/router.ts:15` that describes a routable model (cost tier, strengths, max tokens). That router-facing type is _not_ the same as the capability-tag union above — the two live in different modules and serve different purposes. When reading or contributing code, always resolve the type via its import path.
+
+### `modelHasCapability`
+
+The single entry point for feature gates. Callers check the tag before invoking capability-specific logic (image chunk extraction, tool schema attachment, embeddings dispatch).
+
+```typescript
+// src/providers/sapOrchestration.ts
+export interface ModelHasCapabilityOptions {
+  /** Default: false. Returned when the model has no metadata entry. */
+  assumeWhenUnspecified?: boolean;
+}
+
+export function modelHasCapability(
+  modelId: string,
+  capability: ModelCapability,
+  options?: ModelHasCapabilityOptions
+): boolean;
+```
+
+Resolution rules:
+
+1. The id is normalised by stripping a leading `<provider>/` prefix (`stripProviderPrefix`), so `sap-ai-core/anthropic--claude-4.7-opus` and `anthropic--claude-4.7-opus` resolve identically.
+2. If the normalised id exists in `ORCHESTRATION_MODEL_METADATA`, the answer is `capabilities?.includes(capability) ?? false`.
+3. If the id is unknown, the answer is `options.assumeWhenUnspecified ?? false`. This is the escape hatch for legacy call sites; new call sites should keep the default `false` so a missing tag stays visible.
+4. Behavioural subtlety: `assumeWhenUnspecified` only fires when there is **no entry at all**. An entry with `capabilities: []` reports `false` for every capability, regardless of the option — this is intentional so authors can distinguish "not authored yet" (missing entry) from "explicitly does not support anything in this dimension" (empty list).
+
+Example usage from a streaming consumer:
+
+```typescript
+import { modelHasCapability } from '../providers/index.js';
+import { extractImageChunks } from '../providers/transform.js';
+
+if (modelHasCapability(session.modelId, 'image-generation')) {
+  const chunks = extractImageChunks(delta.content);
+  for (const chunk of chunks) {
+    if (chunk.kind === 'url') {
+      // fetch chunk.url
+    } else {
+      // decode chunk.data (base64) with chunk.mimeType
+    }
+  }
+}
+```
+
+### Streaming image response handling
+
+SAP AI Core surfaces image payloads in **two shapes** depending on the underlying provider, and `src/providers/transform.ts` normalises both into a discriminated union so downstream code (session log serializer, TUI image renderer once landed) does not need to re-parse SDK payloads.
+
+```typescript
+// src/providers/transform.ts
+export type NormalizedImageChunk =
+  | { kind: 'url'; url: string; mimeType?: string }
+  | { kind: 'base64'; data: string; mimeType?: string };
+
+export function extractImageChunk(item: unknown): NormalizedImageChunk | undefined;
+export function extractImageChunks(content: unknown): NormalizedImageChunk[];
+```
+
+The two supported input shapes:
+
+| SDK shape                                                       | Emitted by                     | Normalised to                                   |
+| --------------------------------------------------------------- | ------------------------------ | ----------------------------------------------- |
+| `{ type: 'image_url', image_url: { url, mime_type? } }`         | OpenAI-style (GPT image)       | `{ kind: 'url', url, mimeType? }`               |
+| `{ type: 'image', image: { b64_json \| data, mime_type? } }` | Anthropic / Gemini-style       | `{ kind: 'base64', data, mimeType? }`           |
+
+Guarantees of the extractors:
+
+- Both accept `unknown` — they compose with the loosely-typed `delta.content` field (`string | Array<{ type; ... }>`) without requiring a caller-side type narrowing.
+- Non-image items are silently skipped, so callers can invoke `extractImageChunks` unconditionally on any streaming payload.
+- Missing / non-string `url` or base64 fields cause the item to be rejected (`undefined`). This guards against upstream schema drift.
+- No I/O, no allocation of oversized buffers — safe to call on every chunk.
+
+Callers **must** gate on `modelHasCapability(modelId, 'image-generation')` before invoking the extractors; the extractors themselves do not check.
+
+### Model routing for image-generation requests
+
+The router (`src/core/router.ts`) does not currently apply image-generation-specific rules — `scoreModel` scores on complexity, task type, cost preference, and the reasoning flag only. The design intent (see issue #1389 in the research notes) is that capability validation happens at the **provider dispatch layer** rather than as new router rules: a request that requires image generation is answered by dispatching to a model that advertises the tag, or by falling back with a clear error when no such model is available.
+
+Practically this means that until an image-gen-capable model is added to `ORCHESTRATION_MODEL_METADATA` (see below), routing an image-generation request through the auto-router will land on a text model and the request will fail at the provider boundary rather than at the router. This is the intended failure mode for the current partial-implementation state.
+
+### Roadmap and unimplemented pieces
+
+The following pieces of the image-generation feature are **not yet in the codebase** and are documented here so contributors and users know the current boundary:
+
+- **`image-generation` on any model in the catalog.** `ORCHESTRATION_MODEL_METADATA` currently tags no model with `image-generation`. The `image-generation` string is a valid `ModelCapability`, and the transform layer will normalise the payloads when a model starts emitting them, but there is no model to route to today. A future SAP-hosted image model (Anthropic Claude with image output, Gemini Imagen, Stable Diffusion) will be enabled by a single edit to the metadata map, without any code change to consumers.
+- **`alexi image` CLI command.** Planned at `src/cli/commands/image.ts` with flags `--model`, `--size`, `--output`, registered in `src/cli/program.ts`. Tracked as issue #1391.
+- **`image_generate` tool.** Planned at `src/tool/tools/image-generate.ts` using `defineTool` from `src/tool/index.ts`, with a Zod schema accepting `prompt` (required) and optional `model`, `size`, `style`, `quality`. Registered in `src/tool/registry.ts`. Tracked as issue #1390.
+- **TUI image rendering.** A component under `src/cli/tui/components/` will render a `NormalizedImageChunk` inline in terminals that support Kitty or iTerm2 graphics protocols, falling back to `[Image: <mime>, <size>]` placeholders elsewhere. The optional `terminal-image` module (already used for the input-side attachment flow in `src/cli/tui/utils/terminalImage.ts`) is the anticipated backend.
+
+When these pieces land, this section will be revised to document their user-facing surfaces alongside the infrastructure above.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -318,6 +318,86 @@ discriminated union `NormalizedImageChunk` (`{ kind: 'url' | 'base64',
 ... }`). The extractors return `undefined` / `[]` for non-image or
 malformed content, so consumers can invoke them unconditionally.
 
+#### Which models advertise `image-generation` today
+
+**None**, at the time of writing. Every entry in the current
+`ORCHESTRATION_MODEL_METADATA` map declares either `['tools']` or
+`[]`. The `image-generation` string is a valid `ModelCapability` and
+the transform layer already understands the two SDK payload shapes,
+but SAP AI Core does not yet expose a chat-completion model that emits
+image payloads through `ORCHESTRATION_MODELS`.
+
+The intended activation path is a single edit to the metadata map —
+for example, adding `capabilities: ['image-generation']` (or
+`['tools', 'image-generation']`) to whichever future model in the
+catalog gains the capability. No changes to `modelHasCapability`,
+`extractImageChunks`, or callers are required.
+
+Candidate future models discussed in the research artefacts (all
+subject to SAP AI Core exposing them via orchestration):
+
+- Anthropic Claude with image output.
+- Gemini Imagen.
+- Stable Diffusion deployments.
+
+Anticipated activation for one of these (hypothetical, do not copy
+verbatim until the model actually ships):
+
+```typescript
+// src/providers/sapOrchestration.ts (illustrative future edit)
+'anthropic--claude-image-experimental': {
+  capabilities: ['image-generation'],
+},
+```
+
+#### Example — capability-gated image chunk extraction
+
+```typescript
+import { modelHasCapability } from './providers/index.js';
+import { extractImageChunks } from './providers/transform.js';
+
+// Somewhere in a streaming consumer:
+for await (const delta of stream) {
+  if (modelHasCapability(modelId, 'image-generation')) {
+    for (const chunk of extractImageChunks(delta.content)) {
+      if (chunk.kind === 'url') {
+        // Fetch chunk.url. `chunk.mimeType` may be undefined —
+        // fall back to the Content-Type response header or sniff.
+      } else {
+        // Decode chunk.data (base64) using chunk.mimeType.
+      }
+    }
+  }
+}
+```
+
+If `modelHasCapability` returns `false`, the gate short-circuits and
+`extractImageChunks` is never called. Passing
+`{ assumeWhenUnspecified: true }` is **discouraged for image
+generation** — the whole point of the tag is to fail closed on a text
+model that happens to emit something image-shaped. `true` is only
+appropriate for legacy paths that predate the capability data and
+cannot yet be audited.
+
+#### `assumeWhenUnspecified` — full behaviour matrix
+
+| Model in `ORCHESTRATION_MODEL_METADATA`? | `capabilities` value                    | `assumeWhenUnspecified` | Result for the queried capability |
+| ---------------------------------------- | --------------------------------------- | ----------------------- | --------------------------------- |
+| Yes                                      | Includes the queried capability         | ignored                 | `true`                            |
+| Yes                                      | Does NOT include the queried capability | ignored                 | `false`                           |
+| Yes                                      | `[]` (explicit empty list)              | ignored                 | `false`                           |
+| No entry at all                          | —                                       | `false` (default)       | `false`                           |
+| No entry at all                          | —                                       | `true`                  | `true`                            |
+| id is empty string / non-string          | —                                       | any                     | `assumeWhenUnspecified ?? false`  |
+
+The subtle case is the third row: an entry with `capabilities: []`
+reports `false` for every capability regardless of the option. This is
+by design — an empty list is an explicit "does not support anything in
+this dimension" signal, distinct from "not authored yet" (missing
+entry). This lets contributors distinguish models the team has
+audited (present in the map) from those that have not been reviewed
+(absent from the map).
+
 ## Configuration
 
 ### Environment Variables


### PR DESCRIPTION
Closes #1393

## What

Adds an authoritative Image Generation section to `docs/ARCHITECTURE.md`, `README.md`, and `docs/PROVIDERS.md` that reflects the **actual state** of the feature in the codebase today.

## Why

Issue #1393 asks for docs covering the capability system, model support, CLI command, and tool usage. The catch is that only the capability layer + streaming-chunk normalisation are landed. The CLI command (`alexi image`, issue #1391), the `image_generate` tool (#1390), and any model tag declaring `image-generation` are all still pending. Documenting them as if they existed would ship documentation for code that isn't there — reviewers would (correctly) flag it. The docs here explain what ships, what does not, and the exact activation path once SAP AI Core exposes an image-gen-capable model.

## What changed

- **`docs/ARCHITECTURE.md`** — new `## Image Generation` section covering:
  - The `ModelCapability` union and `OrchestrationModelMetadata` map (with the name-collision warning vs the router's unrelated `ModelCapability` interface at `src/core/router.ts:15`).
  - `modelHasCapability` resolution rules, including the subtle `capabilities: []` vs missing-entry behaviour.
  - Streaming payload normalisation: the two SDK shapes and the `NormalizedImageChunk` discriminated union produced by `extractImageChunk` / `extractImageChunks` from `src/providers/transform.ts`.
  - The current router boundary (image-gen requests would land on a text model today; the intended failure mode is at the provider dispatch layer).
  - Roadmap block listing the four unimplemented pieces.
- **`README.md`** — user-facing `## Image Generation` section with what-ships / what-does-not, a planned CLI-command sketch (clearly marked `# PLANNED — not yet implemented`), a consumer-code example, and cross-links to the deeper docs. Also updated the Roadmap checklist.
- **`docs/PROVIDERS.md`** — expanded the existing "Provider-Layer Capability Validation" section with:
  - The current list of image-gen-capable models (empty) and why.
  - Anticipated activation path (single map edit).
  - Capability-gated extraction example.
  - Full `assumeWhenUnspecified` behaviour matrix.
  - Guidance not to use `assumeWhenUnspecified: true` for image-generation gates (fail closed).

## Verification

- `npm run typecheck` — clean.
- `npm run lint` — 0 errors (pre-existing warnings unchanged).
- `npm run format:check` — clean; also verified `npx prettier --check` on the three modified markdown files.
- `npm test` — 4002 passed, 62 skipped (no changes to test surface).
- `npm run build` — clean.
- No zero-width characters or non-ASCII glyphs introduced beyond the em dashes / arrows already used throughout the docs.

## Hard-constraint compliance

- No `.github/` files touched.
- `package.json` version untouched.
- No `eslint-disable` or `@ts-ignore` added.
- No production code paths touched — this is a docs-only PR.