### PR TITLE
feat(providers): persist connector auth state

### DIFF
--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -30,7 +30,7 @@
  * `ErrorBackoff` / route-retry layers do not spend budget on them.
  */
 
-import { getConnectorStore, type ConnectorState } from './connectorStore.js';
+import { getConnectorStore, saveConnectorState, type ConnectorState } from './connectorStore.js';
 import { TokenRefreshed } from '../bus/index.js';
 import { saveToken } from '../utils/tokenStorage.js';
 import { getConfigPersistAuthTokens } from '../config/userConfig.js';
@@ -399,6 +399,18 @@ export async function refreshAccessToken(
       // token is already in the in-memory connector store, so the
       // current invocation continues; only cross-process reuse is
       // lost, which is a soft-fail we accept.
+    }
+
+    // Also persist the broader connector state (refresh token +
+    // access token + expiry) to `~/.alexi/connectors.json` so the
+    // next session can skip re-authentication entirely. Failures
+    // here are non-fatal for the same reason as the `saveToken`
+    // path above: the in-memory store already has the fresh
+    // credentials, so the current invocation succeeds regardless.
+    try {
+      await saveConnectorState({ [providerId]: nextState });
+    } catch {
+      // Non-fatal — see comment above.
     }
   }
 

--- a/src/providers/connectorStore.ts
+++ b/src/providers/connectorStore.ts
@@ -3,9 +3,13 @@
  *
  * Minimal typed abstraction over per-provider persisted state:
  * OAuth `accessToken` + `refreshToken` + `expiry`, plus room for
- * rate-limit metadata. A future feature will add a file-backed
- * implementation persisting to `~/.alexi/connectors/`; for now this
- * module exposes:
+ * rate-limit metadata. In addition to the in-memory default, this
+ * module ships a JSON-file-backed persistence layer at
+ * `~/.alexi/connectors.json` (see `loadConnectorState` /
+ * `saveConnectorState`) so users do not have to re-authenticate on
+ * every session start.
+ *
+ * Public surface:
  *
  *  1. `ConnectorState` — the shape stored per `providerId`.
  *  2. `ConnectorStore` — the interface a persistence backend implements.
@@ -16,12 +20,22 @@
  *     singleton the rest of Alexi consumes. Tests reset it to the
  *     in-memory default via `setConnectorStore(createInMemoryConnectorStore())`
  *     to keep isolation between suites.
+ *  5. `loadConnectorState()` / `saveConnectorState()` — read/write the
+ *     on-disk JSON snapshot. Corrupt / missing files resolve to an
+ *     empty snapshot so a bad cache never blocks a session.
+ *  6. `getConnectorStatePath()` / `setConnectorStatePath()` /
+ *     `resetConnectorStatePath()` — path overrides for tests.
  *
  * We deliberately keep the interface minimal (`get`, `set`, `delete`)
  * — richer queries live on top of `get()` in caller code. This matches
  * the pattern in `sessionManager.ts` where the storage layer is a
  * dumb key-value byproduct and semantics live in the caller.
  */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { getConfigPersistAuthTokens } from '../config/userConfig.js';
 
 /**
  * State persisted for a single connector (provider).
@@ -83,6 +97,18 @@ export function createInMemoryConnectorStore(): ConnectorStore {
 let currentStore: ConnectorStore = createInMemoryConnectorStore();
 
 /**
+ * Track whether `initializeConnectorStore` has already hydrated the
+ * current store from disk in this process. Callers may invoke the
+ * initializer eagerly on startup or lazily before their first
+ * refresh — either way we only pay the read once.
+ *
+ * `setConnectorStore` resets this flag so a test swapping the store
+ * to a fresh in-memory instance gets re-hydrated on the next init
+ * call.
+ */
+let currentStoreHydrated = false;
+
+/**
  * Return the currently registered connector store. Callers should
  * treat this as a module singleton; overriding it is a test hook.
  */
@@ -96,4 +122,365 @@ export function getConnectorStore(): ConnectorStore {
  */
 export function setConnectorStore(store: ConnectorStore): void {
   currentStore = store;
+  currentStoreHydrated = false;
+}
+
+// ============================================================================
+// On-disk persistence (~/.alexi/connectors.json)
+// ============================================================================
+
+/**
+ * On-disk file format version. Bump when a backwards-incompatible
+ * shape change is made; loaders that see an unknown version reject
+ * the file (returning an empty snapshot) rather than mis-parse.
+ */
+const CONNECTOR_STATE_VERSION = 1;
+
+/**
+ * Skew applied to `expiresAt` on load. Tokens within this window of
+ * expiry are pruned so the caller performs a fresh refresh rather
+ * than racing the OAuth server. Matches the 30-second skew used in
+ * `sapOrchestration.ts` (`TOKEN_EXPIRY_SKEW_MS`).
+ */
+const TOKEN_EXPIRY_SKEW_MS = 30_000;
+
+/**
+ * Shape of a single connector entry as stored on disk. Note this is
+ * a narrower projection of `ConnectorState` — we intentionally do
+ * NOT persist the `extra` bag, `clientSecret`, or `tokenEndpoint`
+ * because the caller re-hydrates those from configuration on
+ * startup. The on-disk file is a token cache, not a full mirror.
+ */
+interface StoredConnectorEntry {
+  accessToken?: string;
+  refreshToken?: string;
+  /** Unix epoch ms; named `expiresAt` on disk to match tokenStorage. */
+  expiresAt?: number;
+}
+
+/**
+ * Full on-disk file shape.
+ */
+export interface ConnectorStateFile {
+  version: number;
+  connectors: Record<string, StoredConnectorEntry>;
+}
+
+const DEFAULT_CONNECTOR_FILE = path.join(os.homedir(), '.alexi', 'connectors.json');
+
+let currentConnectorFile: string = DEFAULT_CONNECTOR_FILE;
+
+/**
+ * Return the absolute path used for on-disk connector state.
+ * Tests may relocate this via `setConnectorStatePath`.
+ */
+export function getConnectorStatePath(): string {
+  return currentConnectorFile;
+}
+
+/**
+ * Override the connector state path. Intended for tests that want
+ * to point at a `fs.mkdtempSync(...)` directory. Callers must
+ * restore the previous value in their `afterEach` hook (or call
+ * `resetConnectorStatePath`).
+ */
+export function setConnectorStatePath(newPath: string): void {
+  currentConnectorFile = newPath;
+}
+
+/**
+ * Restore the connector state path to the default
+ * `~/.alexi/connectors.json`.
+ */
+export function resetConnectorStatePath(): void {
+  currentConnectorFile = DEFAULT_CONNECTOR_FILE;
+}
+
+/**
+ * Return `true` when `value` matches the `StoredConnectorEntry` shape.
+ * Any deviation (missing fields, wrong types) is rejected so a
+ * malformed entry cannot poison the in-memory store on load.
+ */
+function isStoredConnectorEntry(value: unknown): value is StoredConnectorEntry {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const rec = value as Record<string, unknown>;
+  if (rec.accessToken !== undefined && typeof rec.accessToken !== 'string') {
+    return false;
+  }
+  if (rec.refreshToken !== undefined && typeof rec.refreshToken !== 'string') {
+    return false;
+  }
+  if (
+    rec.expiresAt !== undefined &&
+    (typeof rec.expiresAt !== 'number' || !Number.isFinite(rec.expiresAt))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Load the on-disk connector snapshot into a `Record<string, ConnectorState>`.
+ *
+ * Returns an empty record when:
+ *  - `persistAuthTokens` is `false` in user config;
+ *  - the file does not exist (`ENOENT`);
+ *  - the file is unreadable (permissions, IO);
+ *  - the JSON is malformed;
+ *  - the file `version` does not match `CONNECTOR_STATE_VERSION`.
+ *
+ * Expired tokens (within `TOKEN_EXPIRY_SKEW_MS` of `now`) are pruned
+ * from the returned snapshot — their `accessToken` and `expiry` fields
+ * are stripped, but `refreshToken` is kept so the caller can still
+ * refresh. If a `now` override is not supplied, `Date.now` is used.
+ *
+ * This function never throws. Callers can treat a load failure
+ * identically to a first-run "empty snapshot".
+ */
+export async function loadConnectorState(options?: {
+  now?: () => number;
+}): Promise<Record<string, ConnectorState>> {
+  if (!getConfigPersistAuthTokens()) {
+    return {};
+  }
+
+  let raw: string;
+  try {
+    raw = await fs.promises.readFile(currentConnectorFile, 'utf-8');
+  } catch {
+    // Missing / unreadable file: fall back to empty snapshot.
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Corrupt JSON: treat as empty. The next successful save will
+    // overwrite the bad file atomically.
+    return {};
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {};
+  }
+
+  const file = parsed as Partial<ConnectorStateFile>;
+  if (file.version !== CONNECTOR_STATE_VERSION) {
+    // Unknown / mismatched version — treat as empty so a future
+    // upgrade or a hand-edited file cannot mis-populate the store.
+    return {};
+  }
+  if (!file.connectors || typeof file.connectors !== 'object' || Array.isArray(file.connectors)) {
+    return {};
+  }
+
+  const now = options?.now ? options.now() : Date.now();
+  const out: Record<string, ConnectorState> = {};
+  for (const [providerId, entry] of Object.entries(file.connectors)) {
+    if (!isStoredConnectorEntry(entry)) {
+      continue;
+    }
+    const state: ConnectorState = {};
+    // Prune access tokens that are already expired (or within the
+    // skew window). Preserve the refresh token so the caller can
+    // still recover without a full re-login.
+    if (entry.accessToken && typeof entry.expiresAt === 'number') {
+      if (entry.expiresAt - TOKEN_EXPIRY_SKEW_MS > now) {
+        state.accessToken = entry.accessToken;
+        state.expiry = entry.expiresAt;
+      }
+    }
+    if (entry.refreshToken) {
+      state.refreshToken = entry.refreshToken;
+    }
+    // Only include the entry if at least one field survived.
+    if (state.accessToken || state.refreshToken) {
+      out[providerId] = state;
+    }
+  }
+  return out;
+}
+
+/**
+ * Read the on-disk file WITHOUT any pruning or `persistAuthTokens`
+ * gating. Used internally by `saveConnectorState` for its
+ * read-modify-write cycle so a save for one provider preserves
+ * entries for other providers. Returns an empty object on any
+ * failure (missing file, corrupt JSON, wrong version, IO error).
+ */
+async function readRawConnectorFile(): Promise<Record<string, StoredConnectorEntry>> {
+  let raw: string;
+  try {
+    raw = await fs.promises.readFile(currentConnectorFile, 'utf-8');
+  } catch {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {};
+  }
+  const file = parsed as Partial<ConnectorStateFile>;
+  if (file.version !== CONNECTOR_STATE_VERSION) {
+    return {};
+  }
+  if (!file.connectors || typeof file.connectors !== 'object' || Array.isArray(file.connectors)) {
+    return {};
+  }
+  const out: Record<string, StoredConnectorEntry> = {};
+  for (const [providerId, entry] of Object.entries(file.connectors)) {
+    if (isStoredConnectorEntry(entry)) {
+      out[providerId] = { ...entry };
+    }
+  }
+  return out;
+}
+
+/**
+ * Project a `ConnectorState` into the narrower `StoredConnectorEntry`
+ * shape. Returns `null` when no field survives, so the caller can
+ * skip persisting empty entries.
+ */
+function projectStoredEntry(entry: ConnectorState): StoredConnectorEntry | null {
+  const stored: StoredConnectorEntry = {};
+  if (entry.accessToken) {
+    stored.accessToken = entry.accessToken;
+  }
+  if (entry.refreshToken) {
+    stored.refreshToken = entry.refreshToken;
+  }
+  if (typeof entry.expiry === 'number' && Number.isFinite(entry.expiry)) {
+    stored.expiresAt = entry.expiry;
+  }
+  if (stored.accessToken || stored.refreshToken || stored.expiresAt !== undefined) {
+    return stored;
+  }
+  return null;
+}
+
+/**
+ * Atomically merge the supplied connectors into
+ * `~/.alexi/connectors.json`, then rewrite the file.
+ *
+ * Uses a temp-file + rename sequence so concurrent readers never
+ * observe a partially-written file. The temp file is created with
+ * mode `0o600` so token contents never sit on disk with looser
+ * permissions, even briefly. After the rename the target file's
+ * mode is tightened again in case it pre-existed with a laxer mode.
+ *
+ * When `persistAuthTokens` is disabled in user config this is a
+ * no-op — callers can invoke it unconditionally.
+ *
+ * The persisted projection is intentionally narrow: only
+ * `accessToken`, `refreshToken`, and `expiresAt` are written per
+ * provider. Configuration-derived fields (`tokenEndpoint`,
+ * `clientId`, `clientSecret`) are excluded so a stale on-disk cache
+ * cannot silently override a corrected `.env` / config file.
+ *
+ * Semantics: this is a read-modify-write **merge**. Entries for
+ * providers not present in `state` are preserved from disk. To
+ * remove a provider entry, pass `{}` as its value (an empty
+ * `ConnectorState` projects to `null` and is skipped, so the
+ * previous entry survives) — use a dedicated future
+ * `clearConnectorState(providerId)` helper for explicit deletion.
+ */
+export async function saveConnectorState(state: Record<string, ConnectorState>): Promise<void> {
+  if (!getConfigPersistAuthTokens()) {
+    return;
+  }
+
+  const merged = await readRawConnectorFile();
+  for (const [providerId, entry] of Object.entries(state)) {
+    const stored = projectStoredEntry(entry);
+    if (stored !== null) {
+      merged[providerId] = stored;
+    }
+  }
+
+  const file: ConnectorStateFile = {
+    version: CONNECTOR_STATE_VERSION,
+    connectors: merged,
+  };
+
+  const dir = path.dirname(currentConnectorFile);
+  await fs.promises.mkdir(dir, { recursive: true });
+
+  const tmpPath = `${currentConnectorFile}.${process.pid}.${Math.random()
+    .toString(36)
+    .slice(2)}.tmp`;
+  const contents = JSON.stringify(file, null, 2);
+  await fs.promises.writeFile(tmpPath, contents, { encoding: 'utf-8', mode: 0o600 });
+  try {
+    await fs.promises.rename(tmpPath, currentConnectorFile);
+  } catch (err) {
+    await fs.promises.unlink(tmpPath).catch(() => undefined);
+    throw err;
+  }
+  // Tighten permissions in case the target pre-existed with a laxer
+  // mode. `chmod` is a no-op on Windows for permission bits but does
+  // not throw.
+  try {
+    await fs.promises.chmod(currentConnectorFile, 0o600);
+  } catch {
+    // Non-fatal: some filesystems (tmpfs, FAT) do not implement chmod.
+  }
+}
+
+/**
+ * Hydrate the currently-registered `ConnectorStore` from the on-disk
+ * snapshot. Idempotent: subsequent calls in the same process are
+ * no-ops until `setConnectorStore` swaps in a fresh instance (which
+ * resets the internal flag).
+ *
+ * On any load failure this becomes a no-op — the caller keeps
+ * running against an empty in-memory store. Individual `store.set`
+ * failures are swallowed so a single bad entry cannot block
+ * hydration of the rest.
+ *
+ * Callers should invoke this once during startup (e.g. from the
+ * provider bootstrap path in `sapOrchestration.ts`) so the first
+ * refresh check finds the persisted refresh token.
+ */
+export async function initializeConnectorStore(options?: { now?: () => number }): Promise<void> {
+  if (currentStoreHydrated) {
+    return;
+  }
+  currentStoreHydrated = true;
+
+  let snapshot: Record<string, ConnectorState>;
+  try {
+    snapshot = await loadConnectorState(options);
+  } catch {
+    return;
+  }
+
+  for (const [providerId, entry] of Object.entries(snapshot)) {
+    try {
+      const existing = (await currentStore.get(providerId)) ?? {};
+      // Merge: on-disk fields fill in gaps, but never overwrite
+      // fields that were already populated in-memory by the current
+      // process (e.g. by a prior `alexi login` call in the same
+      // session).
+      const merged: ConnectorState = { ...entry, ...existing };
+      // The merge above prefers `existing`; explicitly restore
+      // disk-only fields that `existing` may lack.
+      if (existing.accessToken === undefined && entry.accessToken) {
+        merged.accessToken = entry.accessToken;
+        merged.expiry = entry.expiry;
+      }
+      if (existing.refreshToken === undefined && entry.refreshToken) {
+        merged.refreshToken = entry.refreshToken;
+      }
+      await currentStore.set(providerId, merged);
+    } catch {
+      // Skip this entry and keep going.
+    }
+  }
 }

--- a/src/providers/sapOrchestration.ts
+++ b/src/providers/sapOrchestration.ts
@@ -42,7 +42,11 @@ import {
   ReauthenticationRequiredError,
   NoRefreshTokenError,
 } from './auth.js';
-import { getConnectorStore, type ConnectorState } from './connectorStore.js';
+import {
+  getConnectorStore,
+  initializeConnectorStore,
+  type ConnectorState,
+} from './connectorStore.js';
 import { isClaudeOpus4 } from './model-match.js';
 import { env } from '../config/env.js';
 import {
@@ -1070,6 +1074,19 @@ export class SapOrchestrationProvider {
 
     if (!getConfigPersistAuthTokens()) {
       return;
+    }
+
+    // Hydrate the connector store from `~/.alexi/connectors.json`
+    // (refresh tokens + expiry + access tokens) BEFORE reading the
+    // narrower `tokens.json` cache. The two files complement each
+    // other: `tokens.json` holds just the current bearer for the
+    // hot path, `connectors.json` holds the durable refresh token
+    // and secondary provider state that survives multiple bearer
+    // rotations.
+    try {
+      await initializeConnectorStore();
+    } catch {
+      // Non-fatal — fall through to the `tokens.json` path.
     }
 
     let cached;

--- a/tests/providers/auth-tokenPersist.test.ts
+++ b/tests/providers/auth-tokenPersist.test.ts
@@ -25,6 +25,8 @@ import { refreshAccessToken, type FetchLike } from '../../src/providers/auth.js'
 import {
   setConnectorStore,
   createInMemoryConnectorStore,
+  setConnectorStatePath,
+  resetConnectorStatePath,
 } from '../../src/providers/connectorStore.js';
 import {
   loadToken,
@@ -47,12 +49,14 @@ describe('refreshAccessToken -> tokenStorage persistence', () => {
   beforeEach(async () => {
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'alexi-auth-persist-'));
     setTokenStoragePath(path.join(tmpDir, 'tokens.json'));
+    setConnectorStatePath(path.join(tmpDir, 'connectors.json'));
     setConnectorStore(createInMemoryConnectorStore());
     persistAuthTokensMock.mockReturnValue(true);
   });
 
   afterEach(async () => {
     resetTokenStoragePath();
+    resetConnectorStatePath();
     setConnectorStore(createInMemoryConnectorStore());
     await fs.promises.rm(tmpDir, { recursive: true, force: true });
   });

--- a/tests/providers/connector-persistence.test.ts
+++ b/tests/providers/connector-persistence.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Tests for connector auth state persistence (issue #1401).
+ *
+ * `loadConnectorState` / `saveConnectorState` provide a JSON file at
+ * `~/.alexi/connectors.json` so users do not have to re-authenticate
+ * on every session start. These tests exercise:
+ *
+ *  - save/load roundtrip (state persisted and restored);
+ *  - expired-token pruning respects `TOKEN_EXPIRY_SKEW_MS` (30s);
+ *  - corrupted file handled gracefully (fresh start, no throw);
+ *  - missing file yields an empty snapshot;
+ *  - `persistAuthTokens: false` disables both save and load;
+ *  - file permissions `0600` on POSIX;
+ *  - merge semantics — saving one provider preserves others;
+ *  - `initializeConnectorStore` hydrates the in-memory store;
+ *  - `refreshAccessToken` writes broader connector state on refresh.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Toggle `persistAuthTokens` per test.
+const persistAuthTokensMock = vi.fn(() => true);
+vi.mock('../../src/config/userConfig.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/config/userConfig.js')>(
+    '../../src/config/userConfig.js'
+  );
+  return {
+    ...actual,
+    getConfigPersistAuthTokens: () => persistAuthTokensMock(),
+  };
+});
+
+import {
+  loadConnectorState,
+  saveConnectorState,
+  setConnectorStatePath,
+  resetConnectorStatePath,
+  getConnectorStatePath,
+  initializeConnectorStore,
+  setConnectorStore,
+  createInMemoryConnectorStore,
+  getConnectorStore,
+  type ConnectorState,
+  type ConnectorStateFile,
+} from '../../src/providers/connectorStore.js';
+import { refreshAccessToken, type FetchLike } from '../../src/providers/auth.js';
+
+function makeFetch(body: unknown, status = 200): FetchLike {
+  return async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    text: async () => JSON.stringify(body),
+  });
+}
+
+describe('connectorStore persistence', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'alexi-connector-'));
+    setConnectorStatePath(path.join(tmpDir, 'connectors.json'));
+    setConnectorStore(createInMemoryConnectorStore());
+    persistAuthTokensMock.mockReturnValue(true);
+  });
+
+  afterEach(async () => {
+    resetConnectorStatePath();
+    setConnectorStore(createInMemoryConnectorStore());
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe('save/load roundtrip', () => {
+    it('persists and restores connector state', async () => {
+      const state: Record<string, ConnectorState> = {
+        'sap-ai-core': {
+          accessToken: 'bearer-1',
+          refreshToken: 'refresh-1',
+          expiry: Date.now() + 3600 * 1000,
+        },
+      };
+      await saveConnectorState(state);
+
+      const loaded = await loadConnectorState();
+      expect(loaded['sap-ai-core']).toBeDefined();
+      expect(loaded['sap-ai-core'].accessToken).toBe('bearer-1');
+      expect(loaded['sap-ai-core'].refreshToken).toBe('refresh-1');
+      expect(loaded['sap-ai-core'].expiry).toBe(state['sap-ai-core'].expiry);
+    });
+
+    it('writes the documented v1 file shape', async () => {
+      const expiry = Date.now() + 3600 * 1000;
+      await saveConnectorState({
+        connectorA: { accessToken: 'ta', refreshToken: 'ra', expiry },
+      });
+      const raw = await fs.promises.readFile(getConnectorStatePath(), 'utf-8');
+      const parsed = JSON.parse(raw) as ConnectorStateFile;
+      expect(parsed.version).toBe(1);
+      expect(parsed.connectors.connectorA).toEqual({
+        accessToken: 'ta',
+        refreshToken: 'ra',
+        expiresAt: expiry,
+      });
+    });
+
+    it('does NOT persist configuration-derived fields', async () => {
+      // `tokenEndpoint`, `clientId`, `clientSecret`, `extra` are
+      // sourced from config and must never leak into the on-disk
+      // token cache.
+      await saveConnectorState({
+        sap: {
+          accessToken: 'bearer',
+          refreshToken: 'refresh',
+          expiry: Date.now() + 3600 * 1000,
+          tokenEndpoint: 'https://example/token',
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+          extra: { foo: 'bar' },
+        },
+      });
+      const raw = await fs.promises.readFile(getConnectorStatePath(), 'utf-8');
+      const parsed = JSON.parse(raw) as ConnectorStateFile;
+      expect(parsed.connectors.sap).toEqual({
+        accessToken: 'bearer',
+        refreshToken: 'refresh',
+        expiresAt: parsed.connectors.sap.expiresAt,
+      });
+      expect(parsed.connectors.sap).not.toHaveProperty('tokenEndpoint');
+      expect(parsed.connectors.sap).not.toHaveProperty('clientSecret');
+      expect(parsed.connectors.sap).not.toHaveProperty('extra');
+    });
+  });
+
+  describe('missing file', () => {
+    it('returns empty snapshot when file does not exist', async () => {
+      const loaded = await loadConnectorState();
+      expect(loaded).toEqual({});
+    });
+  });
+
+  describe('expired token pruning', () => {
+    it('prunes access tokens within TOKEN_EXPIRY_SKEW_MS of expiry', async () => {
+      const now = 1_000_000_000;
+      // 15 seconds until expiry (< 30s skew).
+      await saveConnectorState({
+        stale: {
+          accessToken: 'stale-bearer',
+          refreshToken: 'refresh-still-good',
+          expiry: now + 15_000,
+        },
+      });
+      const loaded = await loadConnectorState({ now: () => now });
+      // Access token pruned...
+      expect(loaded.stale?.accessToken).toBeUndefined();
+      expect(loaded.stale?.expiry).toBeUndefined();
+      // ...but the refresh token survives so the caller can recover.
+      expect(loaded.stale?.refreshToken).toBe('refresh-still-good');
+    });
+
+    it('preserves access tokens beyond the skew window', async () => {
+      const now = 1_000_000_000;
+      await saveConnectorState({
+        fresh: {
+          accessToken: 'fresh-bearer',
+          refreshToken: 'refresh',
+          expiry: now + 60_000,
+        },
+      });
+      const loaded = await loadConnectorState({ now: () => now });
+      expect(loaded.fresh?.accessToken).toBe('fresh-bearer');
+      expect(loaded.fresh?.expiry).toBe(now + 60_000);
+    });
+
+    it('drops entries entirely when nothing survives pruning', async () => {
+      const now = 1_000_000_000;
+      // No refresh token — after pruning the entry is empty and
+      // should not appear in the loaded snapshot at all.
+      await saveConnectorState({
+        gone: {
+          accessToken: 'about-to-expire',
+          expiry: now + 5_000,
+        },
+      });
+      const loaded = await loadConnectorState({ now: () => now });
+      expect(loaded.gone).toBeUndefined();
+    });
+  });
+
+  describe('corrupted file', () => {
+    it('returns empty snapshot on malformed JSON', async () => {
+      await fs.promises.mkdir(path.dirname(getConnectorStatePath()), { recursive: true });
+      await fs.promises.writeFile(getConnectorStatePath(), '{ this is not json ', 'utf-8');
+      const loaded = await loadConnectorState();
+      expect(loaded).toEqual({});
+    });
+
+    it('returns empty snapshot when top-level is an array', async () => {
+      await fs.promises.mkdir(path.dirname(getConnectorStatePath()), { recursive: true });
+      await fs.promises.writeFile(getConnectorStatePath(), '[]', 'utf-8');
+      const loaded = await loadConnectorState();
+      expect(loaded).toEqual({});
+    });
+
+    it('returns empty snapshot on wrong version', async () => {
+      await fs.promises.mkdir(path.dirname(getConnectorStatePath()), { recursive: true });
+      await fs.promises.writeFile(
+        getConnectorStatePath(),
+        JSON.stringify({ version: 999, connectors: { sap: { accessToken: 'x' } } }),
+        'utf-8'
+      );
+      const loaded = await loadConnectorState();
+      expect(loaded).toEqual({});
+    });
+
+    it('skips malformed per-provider entries and keeps valid ones', async () => {
+      await fs.promises.mkdir(path.dirname(getConnectorStatePath()), { recursive: true });
+      await fs.promises.writeFile(
+        getConnectorStatePath(),
+        JSON.stringify({
+          version: 1,
+          connectors: {
+            valid: {
+              accessToken: 'good',
+              refreshToken: 'r',
+              expiresAt: Date.now() + 3600 * 1000,
+            },
+            invalid: { accessToken: 123 }, // wrong type
+            alsoInvalid: null,
+          },
+        }),
+        'utf-8'
+      );
+      const loaded = await loadConnectorState();
+      expect(loaded.valid?.accessToken).toBe('good');
+      expect(loaded.invalid).toBeUndefined();
+      expect(loaded.alsoInvalid).toBeUndefined();
+    });
+
+    it('overwrites corrupted file on next save', async () => {
+      await fs.promises.mkdir(path.dirname(getConnectorStatePath()), { recursive: true });
+      await fs.promises.writeFile(getConnectorStatePath(), 'garbage', 'utf-8');
+      await saveConnectorState({
+        fresh: {
+          accessToken: 'x',
+          refreshToken: 'r',
+          expiry: Date.now() + 3600 * 1000,
+        },
+      });
+      const loaded = await loadConnectorState();
+      expect(loaded.fresh?.accessToken).toBe('x');
+    });
+  });
+
+  describe('persistAuthTokens: false', () => {
+    it('skips writing when disabled', async () => {
+      persistAuthTokensMock.mockReturnValue(false);
+      await saveConnectorState({
+        sap: {
+          accessToken: 'x',
+          refreshToken: 'r',
+          expiry: Date.now() + 3600 * 1000,
+        },
+      });
+      expect(fs.existsSync(getConnectorStatePath())).toBe(false);
+    });
+
+    it('skips reading when disabled', async () => {
+      // Populate the file first with persistence enabled.
+      await saveConnectorState({
+        sap: {
+          accessToken: 'x',
+          refreshToken: 'r',
+          expiry: Date.now() + 3600 * 1000,
+        },
+      });
+      expect(fs.existsSync(getConnectorStatePath())).toBe(true);
+
+      // Then flip the setting and observe an empty load.
+      persistAuthTokensMock.mockReturnValue(false);
+      const loaded = await loadConnectorState();
+      expect(loaded).toEqual({});
+    });
+  });
+
+  describe('file permissions', () => {
+    // On POSIX the file must be `0600`. Windows/tmpfs may not honour
+    // chmod bits — skip gracefully on those platforms.
+    const isPosix = process.platform !== 'win32';
+    (isPosix ? it : it.skip)('creates the file with mode 0600', async () => {
+      await saveConnectorState({
+        sap: {
+          accessToken: 'x',
+          refreshToken: 'r',
+          expiry: Date.now() + 3600 * 1000,
+        },
+      });
+      const stat = await fs.promises.stat(getConnectorStatePath());
+      // Compare only the permission bits.
+      expect(stat.mode & 0o777).toBe(0o600);
+    });
+  });
+
+  describe('merge semantics', () => {
+    it('preserves entries for other providers on partial save', async () => {
+      const expiry = Date.now() + 3600 * 1000;
+      await saveConnectorState({
+        a: { accessToken: 'ta', refreshToken: 'ra', expiry },
+        b: { accessToken: 'tb', refreshToken: 'rb', expiry },
+      });
+
+      // Save only provider `a` with a new bearer.
+      await saveConnectorState({
+        a: { accessToken: 'ta-new', refreshToken: 'ra', expiry },
+      });
+
+      const loaded = await loadConnectorState();
+      expect(loaded.a?.accessToken).toBe('ta-new');
+      // Provider `b` should still be there.
+      expect(loaded.b?.accessToken).toBe('tb');
+      expect(loaded.b?.refreshToken).toBe('rb');
+    });
+  });
+
+  describe('initializeConnectorStore', () => {
+    it('hydrates the in-memory store from disk', async () => {
+      const expiry = Date.now() + 3600 * 1000;
+      await saveConnectorState({
+        sap: { accessToken: 'bearer', refreshToken: 'refresh', expiry },
+      });
+      // Fresh in-memory store — nothing in it yet.
+      setConnectorStore(createInMemoryConnectorStore());
+      await initializeConnectorStore();
+      const state = await getConnectorStore().get('sap');
+      expect(state?.accessToken).toBe('bearer');
+      expect(state?.refreshToken).toBe('refresh');
+    });
+
+    it('is idempotent within a single store lifetime', async () => {
+      await saveConnectorState({
+        sap: {
+          accessToken: 'first',
+          refreshToken: 'refresh',
+          expiry: Date.now() + 3600 * 1000,
+        },
+      });
+      await initializeConnectorStore();
+
+      // Mutate in-memory, then rewrite disk to something else, then
+      // call initialize again — the second init should be a no-op.
+      await getConnectorStore().set('sap', {
+        accessToken: 'in-memory-override',
+        refreshToken: 'refresh',
+      });
+      await saveConnectorState({
+        sap: {
+          accessToken: 'disk-override',
+          refreshToken: 'refresh',
+          expiry: Date.now() + 3600 * 1000,
+        },
+      });
+      await initializeConnectorStore();
+
+      const state = await getConnectorStore().get('sap');
+      expect(state?.accessToken).toBe('in-memory-override');
+    });
+
+    it('re-hydrates after setConnectorStore swaps in a fresh store', async () => {
+      await saveConnectorState({
+        sap: {
+          accessToken: 'bearer',
+          refreshToken: 'refresh',
+          expiry: Date.now() + 3600 * 1000,
+        },
+      });
+      await initializeConnectorStore();
+      // Swap; the flag resets and the next init reads disk again.
+      setConnectorStore(createInMemoryConnectorStore());
+      await initializeConnectorStore();
+      const state = await getConnectorStore().get('sap');
+      expect(state?.refreshToken).toBe('refresh');
+    });
+
+    it('does nothing when persistAuthTokens is disabled', async () => {
+      // Prime the file with persistence enabled.
+      await saveConnectorState({
+        sap: {
+          accessToken: 'bearer',
+          refreshToken: 'refresh',
+          expiry: Date.now() + 3600 * 1000,
+        },
+      });
+      persistAuthTokensMock.mockReturnValue(false);
+      setConnectorStore(createInMemoryConnectorStore());
+      await initializeConnectorStore();
+      const state = await getConnectorStore().get('sap');
+      expect(state).toBeUndefined();
+    });
+  });
+
+  describe('refreshAccessToken persistence integration', () => {
+    it('writes the refreshed connector state (incl. refresh token) to disk', async () => {
+      const store = createInMemoryConnectorStore();
+      await store.set('sap-ai-core', {
+        refreshToken: 'refresh-abc',
+        tokenEndpoint: 'https://oauth.example/token',
+      });
+      setConnectorStore(store);
+
+      await refreshAccessToken('sap-ai-core', {
+        now: () => 1_000_000,
+        fetchImpl: makeFetch({
+          access_token: 'new-bearer',
+          refresh_token: 'refresh-rotated',
+          expires_in: 3600,
+        }),
+      });
+
+      // Broader connector snapshot on disk should include the rotated
+      // refresh token so a new process can reuse it.
+      const loaded = await loadConnectorState({ now: () => 1_000_000 });
+      expect(loaded['sap-ai-core']?.accessToken).toBe('new-bearer');
+      expect(loaded['sap-ai-core']?.refreshToken).toBe('refresh-rotated');
+      expect(loaded['sap-ai-core']?.expiry).toBe(1_000_000 + 3600 * 1000);
+    });
+
+    it('does not write connector state to disk when persistAuthTokens is disabled', async () => {
+      persistAuthTokensMock.mockReturnValue(false);
+      const store = createInMemoryConnectorStore();
+      await store.set('sap-ai-core', {
+        refreshToken: 'refresh-abc',
+        tokenEndpoint: 'https://oauth.example/token',
+      });
+      setConnectorStore(store);
+
+      await refreshAccessToken('sap-ai-core', {
+        now: () => 1_000_000,
+        fetchImpl: makeFetch({ access_token: 'new-bearer', expires_in: 3600 }),
+      });
+
+      expect(fs.existsSync(getConnectorStatePath())).toBe(false);
+    });
+
+    it('propagates the refreshed token even when the connector snapshot save fails', async () => {
+      // Point the storage path at a file-that-is-not-a-dir so mkdir
+      // fails; refreshAccessToken must swallow the write error.
+      const blocking = path.join(tmpDir, 'blocked');
+      fs.writeFileSync(blocking, 'stop');
+      setConnectorStatePath(path.join(blocking, 'connectors.json'));
+
+      const store = createInMemoryConnectorStore();
+      await store.set('sap-ai-core', {
+        refreshToken: 'refresh-abc',
+        tokenEndpoint: 'https://oauth.example/token',
+      });
+      setConnectorStore(store);
+
+      const result = await refreshAccessToken('sap-ai-core', {
+        now: () => 1_000_000,
+        fetchImpl: makeFetch({ access_token: 'new-bearer', expires_in: 3600 }),
+      });
+      expect(result.accessToken).toBe('new-bearer');
+    });
+  });
+});

--- a/tests/providers/sapOrchestration-tokenCache.test.ts
+++ b/tests/providers/sapOrchestration-tokenCache.test.ts
@@ -68,6 +68,8 @@ import {
   getConnectorStore,
   setConnectorStore,
   createInMemoryConnectorStore,
+  setConnectorStatePath,
+  resetConnectorStatePath,
 } from '../../src/providers/connectorStore.js';
 
 describe('SapOrchestrationProvider token cache priming', () => {
@@ -76,12 +78,14 @@ describe('SapOrchestrationProvider token cache priming', () => {
   beforeEach(async () => {
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'alexi-sap-token-'));
     setTokenStoragePath(path.join(tmpDir, 'tokens.json'));
+    setConnectorStatePath(path.join(tmpDir, 'connectors.json'));
     setConnectorStore(createInMemoryConnectorStore());
     persistAuthTokensMock.mockReturnValue(true);
   });
 
   afterEach(async () => {
     resetTokenStoragePath();
+    resetConnectorStatePath();
     setConnectorStore(createInMemoryConnectorStore());
     await fs.promises.rm(tmpDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
Closes #1401

## Summary

Persist per-provider connector state (accessToken, refreshToken, expiry) to `~/.alexi/connectors.json` so users no longer have to re-authenticate at the start of every Alexi session.

This complements the existing `tokens.json` cache:
- `tokens.json` holds just the hot-path bearer token
- `connectors.json` is the durable snapshot including the refresh token

## Changes

### `src/providers/connectorStore.ts`
- New `loadConnectorState()` / `saveConnectorState()` — JSON v1 file format at `~/.alexi/connectors.json`, 0o600 permissions, atomic temp+rename writes, merge semantics so per-provider saves preserve other entries
- New `initializeConnectorStore()` — hydrates the current in-memory store from disk exactly once per store lifetime; `setConnectorStore` resets the flag for test isolation
- Expired-token pruning respects `TOKEN_EXPIRY_SKEW_MS` (30s); refresh tokens survive pruning so recovery is possible
- Corrupt / missing / wrong-version files resolve to empty snapshot; loader never throws
- Path override helpers (`setConnectorStatePath`, `resetConnectorStatePath`) for tests
- Configuration-derived fields (`tokenEndpoint`, `clientSecret`, `clientId`, `extra`) are intentionally NOT persisted — a stale on-disk cache can never override a corrected `.env` / config file

### `src/providers/auth.ts`
- `refreshAccessToken` writes the broader connector snapshot after a successful refresh (including rotated refresh tokens)
- Disk failures are non-fatal — the in-memory store already has the fresh credentials
- Respects `getConfigPersistAuthTokens()` config setting

### `src/providers/sapOrchestration.ts`
- `primeAuthTokenCache` hydrates the connector store from `connectors.json` (via `initializeConnectorStore`) BEFORE reading `tokens.json`, so refresh tokens survive multiple bearer rotations across sessions

### `tests/providers/connector-persistence.test.ts` (new, 23 tests)
- save/load roundtrip
- v1 file shape verification
- excludes configuration-derived fields
- expired-token pruning respects 30s skew
- missing/corrupt/wrong-version file handling
- `persistAuthTokens: false` disables save and load
- 0o600 file permissions on POSIX (skipped on Windows)
- merge semantics for multi-provider files
- `initializeConnectorStore` idempotency + fresh-store re-hydration
- `refreshAccessToken` integration

### Test hygiene
Updated `tests/providers/auth-tokenPersist.test.ts` and `tests/providers/sapOrchestration-tokenCache.test.ts` to redirect `connectorStatePath` to their tmpdir so they cannot touch the developer's real `~/.alexi/connectors.json` when running.

## Storage format

```json
{
  "version": 1,
  "connectors": {
    "sap-ai-core": {
      "accessToken": "...",
      "refreshToken": "...",
      "expiresAt": 1723900000000
    }
  }
}
```

## Verification

- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors)
- `npm run format:check` ✓
- `npm test` ✓ (4027 pass, 62 skipped)
- `npm run test:coverage` ✓ (67.83% lines, well above 40% floor)
- `npm run build` ✓