### PR TITLE
feat(tools): PowerShell fail-fast via ErrorActionPreference=Stop bootstrap

### DIFF
--- a/src/tool/tools/bash.ts
+++ b/src/tool/tools/bash.ts
@@ -228,7 +228,11 @@ const bashToolBase = defineTool<typeof BashParamsSchema, BashResult>({
     // executed the command (helpful for debugging shell-specific
     // syntax across platforms).
     const shellInfo = detectShell();
-    const { file: shellFile, prefixArgs: shellPrefix } = shellSpawnArgs(shellInfo);
+    const {
+      file: shellFile,
+      prefixArgs: shellPrefix,
+      suffixArgs: shellSuffix = [],
+    } = shellSpawnArgs(shellInfo);
 
     return new Promise((resolve) => {
       let stdout = '';
@@ -247,7 +251,7 @@ const bashToolBase = defineTool<typeof BashParamsSchema, BashResult>({
       // `%ComSpec%` — usually `cmd.exe` — on Windows). Passing the
       // command as a single argument after the shell's "-c" flag keeps
       // quoting semantics identical to the previous `shell: true` path.
-      const proc = spawn(shellFile, [...shellPrefix, params.command], {
+      const proc = spawn(shellFile, [...shellPrefix, params.command, ...shellSuffix], {
         cwd: workdir,
         env: { ...process.env, FORCE_COLOR: '0' },
         windowsHide: true,

--- a/src/tool/tools/shell.ts
+++ b/src/tool/tools/shell.ts
@@ -217,7 +217,11 @@ const shellToolBase = defineTool<typeof ShellParamsSchema, ShellResult>({
     // The detector caches its result for a short TTL, so calling this on
     // every invocation is cheap but still picks up profile changes.
     const shellInfo = detectShell();
-    const { file: shellFile, prefixArgs: shellPrefix } = shellSpawnArgs(shellInfo);
+    const {
+      file: shellFile,
+      prefixArgs: shellPrefix,
+      suffixArgs: shellSuffix = [],
+    } = shellSpawnArgs(shellInfo);
 
     return new Promise((resolve) => {
       let stdout = '';
@@ -235,7 +239,7 @@ const shellToolBase = defineTool<typeof ShellParamsSchema, ShellResult>({
       // `%ComSpec%` on Windows). The command string is passed as a
       // single argument after the shell's "-c"/"-Command"/"/c" flag,
       // preserving quoting semantics equivalent to the previous path.
-      const proc = spawn(shellFile, [...shellPrefix, params.command], {
+      const proc = spawn(shellFile, [...shellPrefix, params.command, ...shellSuffix], {
         cwd: workdir,
         env: { ...process.env, FORCE_COLOR: '0' },
         windowsHide: true,

--- a/src/tool/tools/shell/id.ts
+++ b/src/tool/tools/shell/id.ts
@@ -209,18 +209,74 @@ export function detectShell(): ShellInfo {
 }
 
 /**
- * Return `[executable, [flag]]` suitable for `spawn(cmd, args, { shell: false })`
+ * Return `{ file, prefixArgs, suffixArgs? }` suitable for
+ * `spawn(file, [...prefixArgs, userCommand, ...suffixArgs], { shell: false })`
  * to invoke a single command string in the detected shell. Callers pass
- * the user command as the LAST element of the args array.
+ * the user command AFTER the `prefixArgs` and BEFORE the `suffixArgs`,
+ * so the user's script text remains byte-identical (no in-place mutation
+ * of the command string).
  *
  * PowerShell requires `-Command` (or `-c` shorthand) rather than the
  * POSIX `-c`, and expects the command as a single argument.
  * cmd.exe uses `/d /s /c "<cmd>"`. Everything else uses `-c`.
+ *
+ * PowerShell fail-fast semantics (Cline PR #13358 pattern for
+ * https://github.com/cline/cline/issues/13285): the `-Command` bootstrap
+ * sets `$ErrorActionPreference='Stop'` BEFORE invoking the user script
+ * as a scriptblock via `& { <user command> }`. This gives the invoked
+ * scriptblock fail-fast semantics (first non-terminating error
+ * terminates with a non-zero exit and a single error record) while
+ * keeping the user command:
+ *   - byte-identical (not string-mutated by us; passed as its own arg
+ *     that PowerShell joins between the opening `& {` and closing `}`),
+ *   - `param(...)`-compatible (param stays first-statement inside the
+ *     scriptblock braces, so scripts starting with `param($x = 5)` still
+ *     work — a plain top-level prepend would displace `param` and fail
+ *     with CommandNotFoundException),
+ *   - opt-out-able per-cmdlet with `-ErrorAction Continue` /
+ *     `-ErrorAction SilentlyContinue`, or globally by reassigning
+ *     `$ErrorActionPreference` inside the user script.
+ *
+ * Precedent: GitHub Actions prepends `$ErrorActionPreference = 'stop'`
+ * to every `powershell` / `pwsh` step
+ * (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell),
+ * so model-authored PowerShell commands already run under these
+ * semantics in CI. Aligning the bash tool matches that contract.
+ *
+ * Deliberate tradeoffs (documented so the tradeoff is chosen, not
+ * accidental):
+ *   - `Stop` promotes every non-terminating error, not just per-item
+ *     pipeline floods. `Get-ChildItem -Recurse` crossing an
+ *     access-denied junction ("Application Data", "System Volume
+ *     Information") now aborts at the first denial with truncated
+ *     output and exit 1, where it previously completed with warnings.
+ *     Users who need partial results should add `-ErrorAction Continue`
+ *     to the specific cmdlet.
+ *   - On Windows PowerShell 5.1, in-script stderr redirection (`2>&1`,
+ *     `2>file`) of a succeeding native command wraps each stderr line
+ *     in a `NativeCommandError`; under `Stop` the first one terminates
+ *     the script. PowerShell 7.2+ exempts native stderr from the
+ *     preference (PowerShell/PowerShell#3996, #14273). This matches
+ *     GitHub Actions behaviour on 5.1 today.
  */
-export function shellSpawnArgs(info: ShellInfo): { file: string; prefixArgs: string[] } {
+export function shellSpawnArgs(info: ShellInfo): {
+  file: string;
+  prefixArgs: string[];
+  suffixArgs?: string[];
+} {
   switch (info.type) {
     case 'powershell':
-      return { file: info.path, prefixArgs: ['-NoProfile', '-Command'] };
+      // Bootstrap prelude: set fail-fast preference at the -Command
+      // scope, then open a scriptblock `& { ` that PowerShell will
+      // close with the trailing `}` suffix arg once it joins all
+      // -Command arguments. The user command sits verbatim between
+      // the opening brace and the closing brace, so `param(...)` still
+      // occupies first-statement position inside the scriptblock.
+      return {
+        file: info.path,
+        prefixArgs: ['-NoProfile', '-Command', "$ErrorActionPreference='Stop'; & {"],
+        suffixArgs: ['}'],
+      };
     case 'cmd':
       return { file: info.path, prefixArgs: ['/d', '/s', '/c'] };
     default:

--- a/tests/tool/tools/shell-detect.test.ts
+++ b/tests/tool/tools/shell-detect.test.ts
@@ -254,10 +254,18 @@ describe('shellSpawnArgs', () => {
     });
   });
 
-  it('emits -NoProfile -Command for PowerShell', () => {
+  it('emits -NoProfile -Command with fail-fast bootstrap and closing brace for PowerShell', () => {
+    // The PowerShell branch sets $ErrorActionPreference='Stop' at the
+    // -Command bootstrap scope and wraps the user command in a
+    // scriptblock `& { <user command> }` (Cline PR #13358 pattern).
+    // The user command itself is passed as a separate spawn arg
+    // between prefixArgs and suffixArgs so its text stays
+    // byte-identical (no in-place mutation, `param(...)` stays first
+    // statement inside the scriptblock).
     expect(shellSpawnArgs({ type: 'powershell', path: 'C:\\pwsh.exe' })).toEqual({
       file: 'C:\\pwsh.exe',
-      prefixArgs: ['-NoProfile', '-Command'],
+      prefixArgs: ['-NoProfile', '-Command', "$ErrorActionPreference='Stop'; & {"],
+      suffixArgs: ['}'],
     });
   });
 

--- a/tests/tool/tools/shell/powershell-fail-fast.test.ts
+++ b/tests/tool/tools/shell/powershell-fail-fast.test.ts
@@ -1,0 +1,180 @@
+/**
+ * PowerShell fail-fast regression tests (Cline PR #13358, alexi issue
+ * #1456). The `shellSpawnArgs` PowerShell branch prepends a bootstrap
+ * to `-Command` that sets `$ErrorActionPreference='Stop'` before
+ * invoking the user command as a scriptblock via `& { <user> }`.
+ *
+ * These tests focus on end-to-end semantics observed through a real
+ * `spawn` of `pwsh` (skipped when pwsh is not on PATH, which lets the
+ * suite still run on macOS / Linux dev boxes without PowerShell 7
+ * installed). The pure-shape assertions on the return value of
+ * `shellSpawnArgs` live in `../shell-detect.test.ts`.
+ *
+ * The behaviours we regression-guard here:
+ *   1. A malformed pipeline stops at the FIRST non-terminating error
+ *      with a non-zero exit code (fixes the "stderr flood + exit 0"
+ *      hang reported in cline/cline#13285 / alexi #1456).
+ *   2. The stderr flood is bounded: on a broken per-item pipeline over
+ *      a directory tree, we get a single error record — NOT one per
+ *      enumerated entry.
+ *   3. Successful commands still succeed (no false-positive Stop).
+ *   4. Per-cmdlet opt-out with `-ErrorAction Continue` restores the old
+ *      non-fail-fast behaviour for that specific cmdlet, so users can
+ *      still write partial-result commands when they explicitly want
+ *      to.
+ *   5. Scripts beginning with `param(...)` still work — the bootstrap
+ *      is at the -Command outer scope, and the user command is wrapped
+ *      in `& { ... }`, so `param` retains its mandatory first-statement
+ *      position INSIDE the scriptblock. A naive top-level prepend
+ *      would displace `param` and fail with CommandNotFoundException.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { shellSpawnArgs } from '../../../../src/tool/tools/shell/id.js';
+
+/**
+ * Locate a PowerShell executable to drive the end-to-end assertions.
+ * We accept either `pwsh` (PowerShell 7+, cross-platform) or
+ * `powershell.exe` (Windows PowerShell 5.1). Returns undefined when
+ * neither is on PATH — in that case the tests self-skip so this file
+ * stays green on POSIX runners without pwsh.
+ */
+function findPowerShell(): string | undefined {
+  const candidates = ['pwsh', 'powershell.exe', 'powershell'];
+  for (const cmd of candidates) {
+    const probe = spawnSync(cmd, ['-NoProfile', '-Command', 'Write-Output ok'], {
+      encoding: 'utf8',
+    });
+    if (probe.status === 0 && probe.stdout.trim() === 'ok') {
+      return cmd;
+    }
+  }
+  return undefined;
+}
+
+const pwshCmd = findPowerShell();
+const describePwsh = pwshCmd ? describe : describe.skip;
+
+/**
+ * Simulate the exact wiring bash.ts / shell.ts perform: destructure
+ * `shellSpawnArgs` and spawn `[...prefixArgs, userCommand, ...suffixArgs]`.
+ * Returns the child-process status, stdout, and stderr so tests can
+ * assert on all three.
+ */
+function runViaShellSpawnArgs(userCommand: string): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+} {
+  const { prefixArgs, suffixArgs = [] } = shellSpawnArgs({
+    type: 'powershell',
+    path: pwshCmd as string,
+  });
+  const result = spawnSync(pwshCmd as string, [...prefixArgs, userCommand, ...suffixArgs], {
+    encoding: 'utf8',
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+describePwsh('PowerShell fail-fast semantics (issue #1456)', () => {
+  it('stops at the first error in a malformed pipeline with non-zero exit', () => {
+    // Emit a line, hit a hard error, then emit another line. Under
+    // the old ErrorActionPreference='Continue' default, both lines
+    // would print and the exit code would be 0. Under Stop, the first
+    // error terminates the script before the second Write-Output.
+    const cmd = 'Write-Output "before"; Get-Item /definitely-not-a-real-path; Write-Output "after"';
+    const { status, stdout, stderr } = runViaShellSpawnArgs(cmd);
+
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('before');
+    // The post-error statement must NOT have executed.
+    expect(stdout).not.toContain('after');
+    // The error message is reported (single record, no flood).
+    expect(stderr.length).toBeGreaterThan(0);
+  });
+
+  it('emits a single error message rather than a flood on a broken per-item pipeline', () => {
+    // The exact reproduction from cline/cline#13285: an invalid
+    // scriptblock in Where-Object is invoked once per enumerated
+    // item. Under Continue, we would see one error record per file
+    // in the tree (tens of thousands on large trees). Under Stop,
+    // the first item's error terminates the whole pipeline.
+    //
+    // Set up a temp directory with a handful of files so we have a
+    // deterministic input regardless of the ambient filesystem.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'alexi-ps-flood-'));
+    try {
+      for (let i = 0; i < 5; i++) {
+        fs.writeFileSync(path.join(dir, `file-${i}.txt`), '');
+      }
+      // [int]::Parse on the filename (`file-0.txt`, ...) is malformed
+      // and throws for every enumerated item — the classic flood
+      // pattern.
+      const cmd =
+        `Get-ChildItem -File -LiteralPath '${dir}' ` +
+        `| Where-Object { [int]::Parse($_.Name) -gt 0 }`;
+      const { status, stderr } = runViaShellSpawnArgs(cmd);
+
+      expect(status).not.toBe(0);
+      // Bound the flood: with 5 files we would see 5 records under
+      // Continue. Under Stop we expect exactly 1 error record — but
+      // allow a modest ceiling to keep the test robust across pwsh
+      // versions that vary in how many follow-up lines a single
+      // ErrorRecord serialises to.
+      const errorLines = stderr.split('\n').filter((line) => line.trim().length > 0);
+      expect(errorLines.length).toBeLessThan(5);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('lets successful commands succeed with exit 0 and expected stdout', () => {
+    const { status, stdout } = runViaShellSpawnArgs('Write-Output "hello-alexi"');
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('hello-alexi');
+  });
+
+  it('honours per-cmdlet -ErrorAction Continue opt-out', () => {
+    // The user explicitly opts out of Stop for a specific cmdlet.
+    // Post-error statements should still run, and the overall exit
+    // code should be 0.
+    const cmd =
+      'Get-Item /definitely-not-a-real-path -ErrorAction Continue; Write-Output "still-ran"';
+    const { status, stdout } = runViaShellSpawnArgs(cmd);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('still-ran');
+  });
+
+  it('accepts scripts starting with param(...) (param stays first-statement inside the scriptblock)', () => {
+    // Regression guard: a naive `prepend to user script` strategy
+    // would displace `param(...)` from its mandatory first-statement
+    // position and fail with CommandNotFoundException. The bootstrap-
+    // scope strategy sets $ErrorActionPreference at the -Command
+    // outer scope and wraps the user command in `& { <user> }`, so
+    // `param` still occupies the first-statement slot INSIDE the
+    // scriptblock braces.
+    const cmd = 'param($name = "world") Write-Output "hello $name"';
+    const { status, stdout } = runViaShellSpawnArgs(cmd);
+
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('hello world');
+  });
+
+  it('preserves user exit codes through the wrapper', () => {
+    // A user `exit 42` should propagate as 42, not be swallowed by
+    // Stop's own exit code. This mirrors the exit-code preservation
+    // check in cline/cline#13358.
+    const { status } = runViaShellSpawnArgs('exit 42');
+    expect(status).toBe(42);
+  });
+});


### PR DESCRIPTION
## What

Adds fail-fast error semantics to the PowerShell wrapper by setting `$ErrorActionPreference='Stop'` in the `-Command` bootstrap scope.

## Why

Alexi's bash/shell tools dispatch to PowerShell via `src/tool/tools/shell/id.ts` `shellSpawnArgs` on Windows. Previously the branch was `['-NoProfile', '-Command']` with no `$ErrorActionPreference`, so PowerShell's default `Continue` applied — malformed per-item pipelines (e.g. `Get-ChildItem -Recurse | Where-Object { invalid }`) emitted one error record per enumerated file (tens of thousands of stderr lines on large trees) and could still resolve SUCCESS with exit 0. GitHub Actions already prepends `$ErrorActionPreference = 'stop'` to every `powershell`/`pwsh` step; this change aligns Alexi with that precedent.

## How

- `src/tool/tools/shell/id.ts`: PowerShell branch of `shellSpawnArgs` now returns `prefixArgs: ['-NoProfile', '-Command', "\$ErrorActionPreference='Stop'; & {"]` plus `suffixArgs: ['}']`. The user command is passed as its own spawn arg between them, staying byte-identical (no in-place string mutation).
- `& { <user command> }` scriptblock keeps `param(...)` in its mandatory first-statement position — a naive top-level prepend would displace `param` and fail with `CommandNotFoundException`.
- `src/tool/tools/bash.ts` and `src/tool/tools/shell.ts`: destructure `suffixArgs` and append it after `params.command`.
- Code comment documents the deliberate tradeoffs (partial-result commands, PS 5.1 stderr redirection, per-cmdlet opt-out via `-ErrorAction Continue`, GitHub Actions precedent link).

## Test coverage

- `tests/tool/tools/shell-detect.test.ts`: updated `shellSpawnArgs` assertion for the new PowerShell shape.
- `tests/tool/tools/shell/powershell-fail-fast.test.ts` (new): end-to-end regression tests against a real `pwsh` process (self-skips when pwsh isn't on PATH). Covers:
  - Malformed pipeline stops at first error with non-zero exit
  - Broken per-item pipeline emits a single error record (bounded, not one-per-item)
  - Successful commands still succeed
  - Per-cmdlet `-ErrorAction Continue` opt-out works
  - `param(...)`-leading scripts still work
  - User `exit 42` propagates as 42

## Done when

- [x] `shellSpawnArgs` PowerShell branch sets `$ErrorActionPreference='Stop'` in the `-Command` bootstrap
- [x] Code comment documents tradeoffs + opt-out pattern + GitHub Actions precedent
- [x] `tests/tool/tools/shell/powershell-fail-fast.test.ts` created with regression tests
- [x] `npm run typecheck && npm run lint && npm run format:check && npm test && npm run build` all green locally
- [x] PowerShell failures fail immediately with a single message (verified end-to-end via pwsh 7)

Closes #1456